### PR TITLE
Configuration for Prometheus in Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus
+MAINTAINER soltesz@google.com
+RUN mkdir /etc/prometheus/legacy
+ADD prometheus.yml /etc/prometheus/prometheus.yml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # prometheus-support
-Prometheus configuration tweaks
+
+Prometheus configuration for M-Lab.
+
+# Deploying Prometheus with Kubernetes
+
+The following instructions presume there is already a kubernetes cluster
+configured and accessible with `kubectl`.
+
+See the [container engine quickstart guide][quickstart] for a simple howto.
+
+[quickstart]: https://cloud.google.com/container-engine/docs/quickstart
+
+## Build
+
+To build the demo prometheus docker image:
+
+    sudo docker login
+    sudo docker build -t demo-prometheus .
+    sudo docker tag demo-prometheus <username>/demo-prometheus:latest
+    sudo docker push <username>/demo-prometheus:latest
+
+## Run
+
+To deploy the published docker image:
+
+    kubectl run demo-prometheus --image=<username>/demo-prometheus --port=9090
+    kubectl expose deployment demo-prometheus --type="LoadBalancer"
+    kubectl annotate services demo-prometheus prometheus.io/scrape=true
+    sleep 60 && kubectl get service demo-prometheus
+
+After a minute or two, `kubectl get service demo-prometheus` shold report the
+public IP address assigned to the prometheus service.
+
+http://[public-IP]:9090
+
+## Shutdown
+
+To shutdown the service in the cluster:
+
+    kubectl delete deployment demo-prometheus
+    kubectl delete service demo-prometheus
+
+## Add a legacy configuration
+
+Using the file service discovery configuration, we can add new targets at
+runtime. Create a JSON or YAML input file in the [correct form][file_sd_config].
+
+Then copy the file into the prometheus container under the
+`/etc/prometheus/legacy` directory.
+
+    podname=$( kubectl get pods -o name --selector='run=demo-prometheus' )
+    kubectl cp <filename.json> ${podname}:/etc/prometheus/legacy/
+
+Within five minutes, the new targets should be reported in: Status -> Targets
+-> "legacy-targets"
+
+[file_sd_config]: https://prometheus.io/docs/operating/configuration/#file_sd_config

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To deploy the published docker image:
     kubectl annotate services demo-prometheus prometheus.io/scrape=true
     sleep 60 && kubectl get service demo-prometheus
 
-After a minute or two, `kubectl get service demo-prometheus` shold report the
+After a minute or two, `kubectl get service demo-prometheus` should report the
 public IP address assigned to the prometheus service.
 
 http://[public-IP]:9090

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ See the [container engine quickstart guide][quickstart] for a simple howto.
 
 To build the demo prometheus docker image:
 
+Log into your personal docker account, to publish the newly built image.
+
     sudo docker login
     sudo docker build -t demo-prometheus .
-    sudo docker tag demo-prometheus <username>/demo-prometheus:latest
-    sudo docker push <username>/demo-prometheus:latest
+    sudo docker tag demo-prometheus <dockerhub-username>/demo-prometheus:latest
+    sudo docker push <dockerhub-username>/demo-prometheus:latest
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,37 @@ Within five minutes, the new targets should be reported in: Status -> Targets
 -> "legacy-targets"
 
 [file_sd_config]: https://prometheus.io/docs/operating/configuration/#file_sd_config
+
+# Debugging the steps above
+
+## Public IP appears to hang
+
+After `kubectl get service demo-prometheus` assigns a public IP, you can visit
+the service at that IP, e.g. http://[public-ip]:9090. If the service appears to
+hang, the docker instance may have failed to start.
+
+Check using:
+
+```
+$ kubectl get pods
+NAME                               READY     STATUS             RESTARTS   AGE
+demo-prometheus-2562116152-9mdrq   0/1       CrashLoopBackOff   9          25m
+```
+
+In this case, the `READY` status is "0", meaning not yet ready. And, the
+`STATUS` gives a clue that the docker instance is crashing immediately after
+start.
+
+## Viewing logs
+
+If a docker instance is misbehaving, we can view the logs reported by that
+instance using `kubectl logs`. For example, in the case above, we can ask for
+the logs with the pod name.
+
+```
+$ kubectl logs demo-prometheus-2562116152-9mdrq
+time="2017-02-01T21:02:36Z" level=info msg="Starting prometheus (version=1.5.0, branch=master, revision=d840f2c400629a846b210cf58d65b9fbae0f1d5c)" source="main.go:75"
+time="2017-02-01T21:02:36Z" level=info msg="Build context (go=go1.7.4, user=root@a04ed5b536e3, date=20170123-13:56:24)" source="main.go:76"
+time="2017-02-01T21:02:36Z" level=info msg="Loading configuration file /etc/prometheus/prometheus.yml" source="main.go:248"
+time="2017-02-01T21:02:36Z" level=error msg="Error loading config: couldn't load configuration (-config.file=/etc/prometheus/prometheus.yml): yaml: line 2: mapping values are not allowed in this context" source="main.go:150"
+```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ To shutdown the service in the cluster:
 Using the file service discovery configuration, we can add new targets at
 runtime. Create a JSON or YAML input file in the [correct form][file_sd_config].
 
+For example:
+
+```
+[
+    {
+        "labels": {
+            "service": "sidestream"
+        },
+        "targets": [
+            "npad.iupui.mlab4.mia03.measurement-lab.org:9090"
+        ]
+    }
+]
+```
+
 Then copy the file into the prometheus container under the
 `/etc/prometheus/legacy` directory.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then copy the file into the prometheus container under the
 `/etc/prometheus/legacy` directory.
 
     podname=$( kubectl get pods -o name --selector='run=demo-prometheus' )
-    kubectl cp <filename.json> ${podname}:/etc/prometheus/legacy/
+    kubectl cp <filename.json> ${podname##*/}:/etc/prometheus/legacy/
 
 Within five minutes, the new targets should be reported in: Status -> Targets
 -> "legacy-targets"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -55,13 +55,13 @@ scrape_configs:
   #  * service endpoints
   #
   # The separation allows each component to use different authentication
-  # configs, or apply different relabling rules.
+  # configs, or apply different relabeling rules.
 
   # Scrape config for kubernetes master API server.
   #
   # The kubernetes API is exposed as an "endpoint". Since kubernetes may have
   # many endpoints, this configuration restricts the targets monitored to the
-  # default/kubernetes service. The relabelling rules ignore other endpoints.
+  # default/kubernetes service. The relabeling rules ignore other endpoints.
   - job_name: 'kubernetes-apiservers'
     kubernetes_sd_configs:
       - role: endpoints

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,214 @@
+# M-Lab Prometheus configuration.
+
+global:
+  scrape_interval:     60s  # Set the scrape interval to every 60 seconds.
+  evaluation_interval: 60s  # Evaluate rules every 60 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+  # These labels are attached to any time series or alert sent to external
+  # systems (federation, remote storage, Alertmanager).
+  # TODO(soltesz): use this when M-Lab adds federation or alertmanager.
+  # external_labels:
+  #   monitor: 'mlab1'
+
+
+# Load rules once and periodically evaluate them according to the global
+# 'evaluation_interval'.
+rule_files:
+  # - "first.rules"
+  # - "second.rules"
+
+
+# Scrape configurations.
+#
+# Each job name defines monitoring targets (or a method for discovering
+# targets).
+#
+# The M-Lab Prometheus configuration uses three config types:
+#  * automatically discovered services via kubernetes (kubernetes_sd_config)
+#  * automatically discovered services via file (file_sd_config)
+#  * static targets (static_config)
+#
+# Kubernetes targets are discovered automatically by querying the kubernetes
+# master API. The configuration for this is simplest when Prometheus runs in
+# the same cluster as the kubernetes master being monitored. In particular,
+# the master CA certificates and an authentication token are mounted
+# automatically in every container's filesystem for easy access.
+#
+# Discovery of legacy targets occurs by reading a configuration file. This
+# configuration file can be updated out of band after start and Prometheus will
+# periodically re-read the contents, adding new targets or removing old ones.
+#
+# Static targets cannot change after Prometheus starts. They are the least
+# flexible. Because of this, only well known, or long lived targets, or
+# singleton targets that need special relabeling rules should be static.
+scrape_configs:
+
+  # Kubernetes configurations were inspired by:
+  # https://github.com/prometheus/prometheus/blob/master/documentation/examples
+  #
+  # The four kubernetes scrape configs correspond to specific cluster
+  # components.
+  #  * master API
+  #  * cluster nodes
+  #  * pods
+  #  * service endpoints
+  #
+  # The separation allows each component to use different authentication
+  # configs, or apply different relabling rules.
+
+  # Scrape config for kubernetes master API server.
+  #
+  # The kubernetes API is exposed as an "endpoint". Since kubernetes may have
+  # many endpoints, this configuration restricts the targets monitored to the
+  # default/kubernetes service. The relabelling rules ignore other endpoints.
+  - job_name: 'kubernetes-apiservers'
+    kubernetes_sd_configs:
+      - role: endpoints
+
+    # The kubernetes API requires authentication and uses a privately signed
+    # certificate. The tls_config specifies the private CA cert and an
+    # auth token. Kubernetes automatically mounts these files in the container
+    # filesystem.
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    # The source_labels are concatenated with ';'. The regex matches a single
+    # value for the default kubernetes service endpoint. If there are
+    # multiple API servers, all will match this pattern.
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace,
+                        __meta_kubernetes_service_name,
+                        __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: default;kubernetes;https
+
+
+  # Scrape config for kubernetes nodes.
+  #
+  # A kubernetes cluster consists of one or more nodes. Each reports metrics
+  # related to the whole machine.
+  - job_name: 'kubernetes-nodes'
+    kubernetes_sd_configs:
+      - role: node
+
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+      # Nodes are discovered and scrapped using the kubernetes internal network
+      # IP. Unfortunately, the certificates do not validate on requests:
+      #
+      #   "x509: cannot validate certificate for 10.0.4.126 because it doesn't
+      #    contain any IP SANs"
+      #
+      # This is a known issue without a likely solution for private APIs:
+      #    https://github.com/prometheus/prometheus/issues/1822
+      #
+      # Since these IPs are internal to the kubernetes virtual network, it
+      # should be safe to skip certificate verification.
+      insecure_skip_verify: true
+    # TODO(soltesz): if we skip_verify, do we still need the bearer token?
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    # Copy node labels from kubernetes to labels on the Prometheus metrics.
+    # TODO(soltesz): There are many labels. Some look unnecessary. Restrict
+    # pattern to match helpful labels.
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+
+
+  # Scrape config for kubernetes pods.
+  #
+  # Kubernetes pods are scraped when they have an annotation:
+  #   `prometheus.io/scrape=true`.
+  #
+  # Configuration expects the default HTTP protocol scheme.
+  # Configuration expects the default path of /metrics on targets.
+  #
+  # NB: Pods report every declared container port. So, it's possible that not
+  # all ports will be instrumented. So, in the future, we may add some filters.
+  - job_name: 'kubernetes-pods'
+    kubernetes_sd_configs:
+      - role: pod
+
+    relabel_configs:
+      # Check for the prometheus.io/scrape=true annotation.
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      # Copy all pod labels from kubernetes to the Prometheus metrics.
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      # Add the kubernetes namespace as a Prometheus label.
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      # Add the kubernetes pod name as a Prometheus label.
+      # TODO(soltesz): pod names include a randomly generated portion. This
+      # could make historical queries more complex. Do we need this?
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+
+
+  # Scrape config for kubernetes service endpoints.
+  #
+  # Service endpoints are scraped when they have an annotation:
+  #   `prometheus.io/scrape=true`.
+  #
+  # Configuration expects the default HTTP protocol scheme.
+  # Configuration expects the default path of /metrics on targets.
+  - job_name: 'kubernetes-service-endpoints'
+    kubernetes_sd_configs:
+      - role: endpoints
+
+    relabel_configs:
+      # Check for the prometheus.io/scrape=true annotation.
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      # Copy all service labels from kubernetes to the Prometheus metrics.
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      # Add the kubernetes namespace as a Prometheus label.
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      # Add the kubernetes service name as a Prometheus label.
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
+
+
+  # Scrape config for legacy targets.
+  #
+  # Using an out-of-band process, generated configs can be copied into the
+  # Prometheus container. Prometheus will periodically re-read these files to
+  # load any new targets or remove missing ones.
+  #
+  # The file format is described here:
+  #   https://prometheus.io/docs/operating/configuration/#file_sd_config
+  - job_name: 'legacy-targets'
+    file_sd_configs:
+      - files:
+          # NOTE: the path /etc/prometheus/legacy does not exist in the default
+          # image. It must be created in images derived for M-Lab.
+          - /etc/prometheus/legacy/*.json
+          - /etc/prometheus/legacy/*.yaml
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+
+  # Scrape config for the nagios exporter.
+  #
+  # The nagios exporter generates its own labels.
+  #
+  # TODO(soltesz): the "job=nagios.measurementlab.net:5000" label may be
+  # unnecessary; consider removing or replacing the job label.
+  - job_name: 'nagios-exporter'
+    static_configs:
+      - targets: ['nagios.measurementlab.net:5000']


### PR DESCRIPTION
This PR adds a Dockerfile and Prometheus configuration for M-Lab monitoring.

This configuration should be deployed within a kubernetes cluster. The kubernetes API server, nodes in the kubernetes cluster, as well as other pods and services running in the cluster are automatically discovered and added as targets for monitoring by Prometheus.

This configuration also supports file based service discovery. This will allow us to update the list of monitored legacy targets at run-time by copying a configuration file into the container.

This PR also adds instructions in the README.md for building and deploying the demo prometheus image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1)
<!-- Reviewable:end -->
