### PR TITLE
Fix kubernetes host:port relabel regex.

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -149,6 +149,8 @@ scrape_configs:
         action: replace
         target_label: __address__
         # A google/re2 regex, matching addresses with or without default ports.
+        # NB: this will not work with IPv6 addresses. But, atm, kubernetes uses
+        # IPv4 addresses for internal network and GCE doesn not support IPv6.
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
       # Copy all pod labels from kubernetes to the Prometheus metrics.
@@ -191,6 +193,8 @@ scrape_configs:
         action: replace
         target_label: __address__
         # A google/re2 regex, matching addresses with or without default ports.
+        # NB: this will not work with IPv6 addresses. But, atm, kubernetes uses
+        # IPv4 addresses for internal network and GCE doesn not support IPv6.
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
       # Copy all service labels from kubernetes to the Prometheus metrics.

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -149,7 +149,7 @@ scrape_configs:
         action: replace
         target_label: __address__
         # A google/re2 regex, matching addresses with or without default ports.
-        regex: (.+)(?::\d+)?;(\d+)
+        regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
       # Copy all pod labels from kubernetes to the Prometheus metrics.
       - action: labelmap
@@ -191,7 +191,7 @@ scrape_configs:
         action: replace
         target_label: __address__
         # A google/re2 regex, matching addresses with or without default ports.
-        regex: (.+)(?::\d+)?;(\d+)
+        regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
       # Copy all service labels from kubernetes to the Prometheus metrics.
       - action: labelmap


### PR DESCRIPTION
This change corrects a bug introduced by PR: https://github.com/m-lab/prometheus-support/pull/3

The regex uses three groups: the hostname, an optional port, and the
preferred port from a kubernetes annotation.

Previously, the second group should have been ignored if a :port was not
present in the input. However, making the port group optional with the
"?" had the unintended side-effect of allowing the hostname regex "(.+)"
to match greedily, which included the ":port" patterns up to the ";"
separating the hostname from the kubernetes port annotation.

This change updates the regex for the hostname to match any non-":"
characters. This forces the regex to stop if a ":port" is present and
allow the second group to match the optional port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/4)
<!-- Reviewable:end -->
