### PR TITLE
Add k8s/mlab-staging/services.yml with IP of mlab-staging instance

### DIFF
--- a/k8s/mlab-staging/services.yml
+++ b/k8s/mlab-staging/services.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+  name: prometheus-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: prometheus-server
+  sessionAffinity: None
+  # Allocate a static IP manually in GCP console: Networking -> Load Balancing.
+  externalIPs:
+    - 104.197.33.56
+  type: ClusterIP


### PR DESCRIPTION
This made a copy of mlab-sandbox, was renamed to mlab-staging, and the services.yml file inside was updated to reflect the IP of the instance running in the mlab-staging GCloud project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/6)
<!-- Reviewable:end -->
