### PR TITLE
Add configmap for prometheus.yml config (and use upstream prometheus docker image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ the file.
 
 We can now refer to this ConfigMap in the deployment configs below. For
 example, k8s/prometheus.yml maps the prometheus configuration as a volume so
-that the file `prometheus.yml` appears under `/etc/config`.
+that the file `prometheus.yml` appears under `/etc/prometheus`.
 
     - containers:
       ...
         volumeMounts:
-          # /etc/config/prometheus.yml should contain the M-Lab Prometheus config.
-          - mountPath: /etc/config
+          # /etc/prometheus/prometheus.yml should contain the M-Lab Prometheus config.
+          - mountPath: /etc/prometheus
             name: prometheus-config
       volumes:
       - name: prometheus-config

--- a/README.md
+++ b/README.md
@@ -112,14 +112,15 @@ ConfigMap with keys equal to the filenames and values equal to the content of
 the file.
 
     kubectl describe configmap prometheus-config
-    Name:       prometheus-config
-    Namespace:  default
-    Labels:     <none>
-    Annotations:    <none>
 
-    Data
-    ====
-    prometheus.yml: 9754 bytes
+      Name:       prometheus-config
+      Namespace:  default
+      Labels:     <none>
+      Annotations:    <none>
+
+      Data
+      ====
+      prometheus.yml: 9754 bytes
 
 We can now refer to this ConfigMap in the deployment configs below. For
 example, k8s/prometheus.yml maps the prometheus configuration as a volume so
@@ -135,6 +136,18 @@ that the file `prometheus.yml` appears under `/etc/config`.
       - name: prometheus-config
         configMap:
           name: prometheus-config
+
+Note: Configmaps only support text data. Secrets may be an alternative for
+binary data. https://github.com/kubernetes/kubernetes/issues/32432
+
+### Update a ConfigMap
+
+When the content of a configmap value needs to change, you can either delete and
+create the configmap object (not ideal), or replace the new configuration all at
+once.
+
+    kubectl create configmap prometheus-config --from-file=prometheus \
+        --dry-run -o json | kubectl apply -f -
 
 ## Start
 

--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ new static IP allocation.
 
 ## ConfigMaps
 
-Many services like prometheus provide canonical docker images publised to
-dockerhub (or other registry). We can customize the deployment by changing the
-configuration at run time using ConfigMaps. For detailed background see the
-[official docs][configmaps].
+Many services like prometheus provide canonical docker images published to
+[Dockerhub][dockerhub] (or other registry). We can customize the deployment by
+changing the configuration at run time using ConfigMaps. For detailed background
+see the [official docs][configmaps].
 
 Create a ConfigMap for prometheus:
 
     kubectl create configmap prometheus-config --from-file=prometheus
 
 Although the flag is named `--from-file`, it accepts a directory. With this
-flag, the kubernetes creates a ConfigMap with keys equal to the filenames, and
+flag, kubernetes creates a ConfigMap with keys equal to the filenames, and
 values equal to the content of the file.
 
     kubectl describe configmap prometheus-config
@@ -75,6 +75,7 @@ For example this will look something like (with abbreviated configuration):
 Note: Configmaps only support text data. Secrets may be an alternative for
 binary data. https://github.com/kubernetes/kubernetes/issues/32432
 
+[dockerhub]: https://hub.docker.com/r/prom/prometheus/
 [configmaps]: https://kubernetes.io/docs/user-guide/configmap/
 
 ### Verify that a ConfigMap is Mounted

--- a/README.md
+++ b/README.md
@@ -2,18 +2,6 @@
 
 Prometheus configuration for M-Lab.
 
-# Building an M-Lab Prometheus image
-
-To build the demo prometheus docker image:
-
-Log into your personal docker account, to publish the newly built image.
-
-    DOCKERUSER=$USER   # Use your actual dockerhub username.
-    sudo docker login
-    sudo docker build -t prometheus-server .
-    sudo docker tag prometheus-server $DOCKERUSER/prometheus-server:latest
-    sudo docker push $DOCKERUSER/prometheus-server:latest
-
 # Deploying Prometheus to Kubernetes
 
 The following instructions presume there is already a kubernetes cluster

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Kubernetes config files preserve a deployment configuration and provide a
 convenient mechanism for review and automated deployments.
 
 Some steps cannot be automated. For example, while a LoadBalancer can
-automatically assign a public IP address to a service, it will not ([yet](dns)
+automatically assign a public IP address to a service, it will not ([yet][dns])
 update corresponding DNS records for that IP address. So, we must reserve a
 static IP through the Cloud Console interface first.
 
@@ -39,9 +39,9 @@ Create a ConfigMap for prometheus:
 
     kubectl create configmap prometheus-config --from-file=prometheus
 
-While the flag is `--from-file` it accepts a directory, and creates a
-ConfigMap with keys equal to the filenames and values equal to the content of
-the file.
+Although the flag is named `--from-file`, it accepts a directory. With this
+flag, the kubernetes creates a ConfigMap with keys equal to the filenames, and
+values equal to the content of the file.
 
     kubectl describe configmap prometheus-config
 
@@ -54,7 +54,7 @@ the file.
       ====
       prometheus.yml: 9754 bytes
 
-We can now refer to this ConfigMap in the "deployment" coniguration later. For
+We can now refer to this ConfigMap in the "deployment" configuration later. For
 example, k8s/prometheus.yml declares the prometheus configuration as a volume so
 that the file `prometheus.yml` appears under `/etc/prometheus`.
 
@@ -124,7 +124,7 @@ https://github.com/kubernetes/kubernetes/issues/13488
 Before beginning, verify that you are [operating on the correct kubernetes
 cluster][cluster].
 
-Then, update k8s/prometheus.yml to reference the latest stable prometheus
+Then, update k8s/prometheus.yml to reference the current stable prometheus
 container tag. Now, deploy the service.
 
 Create a storage class for GCE persistent disks:

--- a/README.md
+++ b/README.md
@@ -95,11 +95,46 @@ update corresponding DNS records for that IP address. So, we must reserve a
 static IP through the Cloud Console interface first.
 
 *Also, note*: Only one GKE cluster at a time can use the static IPs allocated in
-the `k8s/*/services.yml` files. If you are using an additional GKE cluster (e.g.
+the `k8s/.../services.yml` files. If you are using an additional GKE cluster (e.g.
 in mlab-sandbox project), create a new services.yml file that uses the new
 static IP allocation.
 
 [dns]: https://github.com/kubernetes-incubator/external-dns
+
+## ConfigMaps
+
+Create the ConfigMap for prometheus:
+
+    kubectl create configmap prometheus-config --from-file=prometheus
+
+While the flag is `--from-file` it accepts a directory, and creates a
+ConfigMap with keys equal to the filenames and values equal to the content of
+the file.
+
+    kubectl describe configmap prometheus-config
+    Name:       prometheus-config
+    Namespace:  default
+    Labels:     <none>
+    Annotations:    <none>
+
+    Data
+    ====
+    prometheus.yml: 9754 bytes
+
+We can now refer to this ConfigMap in the deployment configs below. For
+example, k8s/prometheus.yml maps the prometheus configuration as a volume so
+that the file `prometheus.yml` appears under `/etc/config`.
+
+    - containers:
+      ...
+        volumeMounts:
+          # /etc/config/prometheus.yml should contain the M-Lab Prometheus config.
+          - mountPath: /etc/config
+            name: prometheus-config
+      volumes:
+      - name: prometheus-config
+        configMap:
+          name: prometheus-config
 
 ## Start
 

--- a/README.md
+++ b/README.md
@@ -5,42 +5,162 @@ Prometheus configuration for M-Lab.
 # Deploying Prometheus to Kubernetes
 
 The following instructions presume there is already a kubernetes cluster
-configured and accessible with `kubectl`.
+created in a GCP project and the cluster is accessible with `kubectl`.
 
 See the [container engine quickstart guide][quickstart] for a simple howto.
 
 [quickstart]: https://cloud.google.com/container-engine/docs/quickstart
 
-## Testing: Using explicit kubectl commands
+# Using Kubernetes config files
 
-This option is helpful for testing. There is no persistent storage.
+Kubernetes config files preserve a deployment configuration and provide a
+convenient mechanism for review and automated deployments.
 
-### Start
+Some steps cannot be automated. For example, while a LoadBalancer can
+automatically assign a public IP address to a service, it will not ([yet](dns)
+update corresponding DNS records for that IP address. So, we must reserve a
+static IP through the Cloud Console interface first.
 
-The `kubectl run` and `kubectl expose` commands automatically create the
-services, deployments, and pods.
+*Also, note*: Only one GKE cluster at a time can use the static IPs allocated
+in the `k8s/.../services.yml` files. If you are using an additional GKE cluster
+(e.g.  in mlab-sandbox project), create a new services.yml file that uses the
+new static IP allocation.
 
-    kubectl run prometheus-server --image=$DOCKERUSER/prometheus-server --port=9090
-    kubectl expose deployment prometheus-server --type="LoadBalancer"
-    kubectl annotate services prometheus-server prometheus.io/scrape=true
-    sleep 60 && kubectl get service prometheus-server
+[dns]: https://github.com/kubernetes-incubator/external-dns
 
-After a minute or two, `kubectl get service prometheus-server` should report the
-public IP address assigned to the prometheus service.
+## ConfigMaps
 
-For example: [http://127.0.0.1:9090](http://127.0.0.1:9090) (but you should use
-the actual public IP address).
+Many services like prometheus provide canonical docker images publised to
+dockerhub (or other registry). We can customize the deployment by changing the
+configuration at run time using ConfigMaps. For detailed background see the
+[official docs][configmaps].
 
-### Shutdown
+Create a ConfigMap for prometheus:
 
-To shutdown the service in the cluster:
+    kubectl create configmap prometheus-config --from-file=prometheus
 
-    kubectl delete deployment prometheus-server
-    kubectl delete service prometheus-server
+While the flag is `--from-file` it accepts a directory, and creates a
+ConfigMap with keys equal to the filenames and values equal to the content of
+the file.
 
-Since there is no persistent storage, all data collected will be lost.
+    kubectl describe configmap prometheus-config
 
-### Add configuration for legacy targets
+      Name:       prometheus-config
+      Namespace:  default
+      Labels:     <none>
+      Annotations:    <none>
+
+      Data
+      ====
+      prometheus.yml: 9754 bytes
+
+We can now refer to this ConfigMap in the "deployment" coniguration later. For
+example, k8s/prometheus.yml declares the prometheus configuration as a volume so
+that the file `prometheus.yml` appears under `/etc/prometheus`.
+
+For example this will look something like (with abbreviated configuration):
+
+    - containers:
+      ...
+        volumeMounts:
+          # /etc/prometheus/prometheus.yml should contain the M-Lab Prometheus
+          # config.
+          - mountPath: /etc/prometheus
+            name: prometheus-config
+      volumes:
+      - name: prometheus-config
+        configMap:
+          name: prometheus-config
+
+Note: Configmaps only support text data. Secrets may be an alternative for
+binary data. https://github.com/kubernetes/kubernetes/issues/32432
+
+[configmaps]: https://kubernetes.io/docs/user-guide/configmap/
+
+### Verify that a ConfigMap is Mounted
+
+When a pod has mounted a configmap (or other resource), it is visible in the
+"Volume Mounts" status reported by `kubectl describe`.
+
+For example (with abbreviated output):
+
+    podname=$( kubectl get pods -o name --selector='run=prometheus-server' )
+    kubectl describe ${podname}
+      ...
+      Containers:
+        prometheus-server:
+          ...
+          Image:              prom/prometheus:v1.5.2
+          ...
+          Port:               9090/TCP
+          ...
+          Volume Mounts:
+            /etc/prometheus from prometheus-config (rw)
+            /legacy-targets from prometheus-storage (rw)
+            /prometheus from prometheus-storage (rw)
+          ...
+
+### Update a ConfigMap
+
+When the content of a configmap value needs to change, you can either delete and
+create the configmap object (not ideal), or replace the new configuration all at
+once.
+
+    kubectl create configmap prometheus-config --from-file=prometheus \
+        --dry-run -o json | kubectl apply -f -
+
+After updating a configmap, any pods that use this configmap will need to be
+restarted for the change to take effect.
+
+    podname=$( kubectl get pods -o name --selector='run=prometheus-server' )
+    kubectl delete ${podname}
+
+The deployment replica set will automatically recreate the pod and the new
+prometheus server will use the updated configmap. This is a known issue:
+https://github.com/kubernetes/kubernetes/issues/13488
+
+## Create deployment
+
+Before beginning, verify that you are [operating on the correct kubernetes
+cluster][cluster].
+
+Then, update k8s/prometheus.yml to reference the latest stable prometheus
+container tag. Now, deploy the service.
+
+Create a storage class for GCE persistent disks:
+
+    kubectl create -f k8s/storage-class.yml
+
+Create a persistent volume claim that Prometheus will bind to:
+
+    kubectl create -f k8s/persistent-volumes.yml
+
+Note: Persistent volume claims are intended to exist longer than pods. This
+allows persistent disks to be dynamically allocated and preserved across pod
+creations and deletions.
+
+Create a service using the public IP address that will send traffic to pods
+with the label "run=prometheus-server":
+
+    kubectl create -f k8s/mlab-sandbox/services.yml
+
+Create the prometheus deployment. This is the last step and includes the actual
+prometheus server. The deployment will receive traffic from the service defined
+above and binds to the persistent volume claim. If a persistent volume does not
+already exist, this will create a new one. It will be automatically formatted.
+
+    kubectl create -f k8s/prometheus.yml
+
+After completing the above steps, you can view the status of all objects using
+something like:
+
+    kubectl get services,deployments,pods,configmaps,pvc,pv,events
+
+`kubectl get` is your friend. See also `kubectl describe` for even more details.
+
+[cluster]: https://cloud.google.com/container-engine/docs/clusters/operations
+
+## Add Legacy Targets
 
 Using the file service discovery configuration, we can add new targets at
 runtime. Create a JSON or YAML input file in the [correct form][file_sd_config].
@@ -60,122 +180,31 @@ For example:
 ]
 ```
 
-Then copy the file into the prometheus container under the
-`/legacy-targets` directory.
+Then copy the file into the prometheus container under the `/legacy-targets`
+directory.
 
     podname=$( kubectl get pods -o name --selector='run=prometheus-server' )
     kubectl cp <filename.json> ${podname##*/}:/legacy-targets/
 
-Within five minutes, the new targets should be reported in: Status -> Targets
--> "legacy-targets"
+To look at the available files in the `legacy-targets` directory:
+
+    kubectl exec -t ${podname##*/} -- /bin/ls -l /legacy-targets
+
+Within five minutes, any file ending with `*.json` or `*.yaml` will be scanned
+and the new targets should be reported by the prometheus server, listed under:
+Status -> Targets -> "legacy-targets"
 
 [file_sd_config]: https://prometheus.io/docs/operating/configuration/#file_sd_config
 
-
-## Automation: Using predefined Kubernetes config files
-
-Kubernetes config files preserve a deployment configuration and provide a
-convenient mechanism for review and automated deployments.
-
-Some steps cannot be automated. For example, while a LoadBalancer can
-automatically assign a public IP address to a service, it will not ([yet](dns)
-update corresponding DNS records for that IP address. So, we must reserve a
-static IP through the Cloud Console interface first.
-
-*Also, note*: Only one GKE cluster at a time can use the static IPs allocated in
-the `k8s/.../services.yml` files. If you are using an additional GKE cluster (e.g.
-in mlab-sandbox project), create a new services.yml file that uses the new
-static IP allocation.
-
-[dns]: https://github.com/kubernetes-incubator/external-dns
-
-## ConfigMaps
-
-Create the ConfigMap for prometheus:
-
-    kubectl create configmap prometheus-config --from-file=prometheus
-
-While the flag is `--from-file` it accepts a directory, and creates a
-ConfigMap with keys equal to the filenames and values equal to the content of
-the file.
-
-    kubectl describe configmap prometheus-config
-
-      Name:       prometheus-config
-      Namespace:  default
-      Labels:     <none>
-      Annotations:    <none>
-
-      Data
-      ====
-      prometheus.yml: 9754 bytes
-
-We can now refer to this ConfigMap in the deployment configs below. For
-example, k8s/prometheus.yml maps the prometheus configuration as a volume so
-that the file `prometheus.yml` appears under `/etc/prometheus`.
-
-    - containers:
-      ...
-        volumeMounts:
-          # /etc/prometheus/prometheus.yml should contain the M-Lab Prometheus config.
-          - mountPath: /etc/prometheus
-            name: prometheus-config
-      volumes:
-      - name: prometheus-config
-        configMap:
-          name: prometheus-config
-
-Note: Configmaps only support text data. Secrets may be an alternative for
-binary data. https://github.com/kubernetes/kubernetes/issues/32432
-
-### Update a ConfigMap
-
-When the content of a configmap value needs to change, you can either delete and
-create the configmap object (not ideal), or replace the new configuration all at
-once.
-
-    kubectl create configmap prometheus-config --from-file=prometheus \
-        --dry-run -o json | kubectl apply -f -
-
-## Start
-
-Before beginning, verify that you are [operating on the correct kubernetes
-cluster][cluster].
-
-Then, update k8s/prometheus.yml to reference the latest container version.
-
-Then, deploy the service:
-
-Creates a storage class for GCE persistent disks.
-
-    kubectl create -f k8s/storage-class.yml
-
-Creates a persistent volume claim that Prometheus will bind to.
-
-    kubectl create -f k8s/persistent-volumes.yml
-
-Creates a service using the public IP address that will send traffic to pods
-with the label "run=prometheus-server".
-
-    kubectl create -f k8s/mlab-sandbox/services.yml
-
-Creates the prometheus deployment. This receives traffic from the service above
-and binds to the persistent volume claim. If a persistent volume does not
-already exist, this will create a new one. It will be automatically formatted.
-
-    kubectl create -f k8s/prometheus.yml
-
-[cluster]: https://cloud.google.com/container-engine/docs/clusters/operations
-
-## Shutdown
+## Delete deployment
 
 Delete the prometheus deployment.
 
     kubectl delete -f k8s/prometheus.yml
 
 Since the prometheus pod is no longer running, clients connecting to the public
-IP address will try to load and timeout. If we also delete the service, then
-traffic will stop being forwarded form the public IP.
+IP address will try to load but fail. If we also delete the service, then
+traffic will stop being forwarded from the public IP altogether.
 
     kubectl delete -f k8s/mlab-sandbox/services.yml
 
@@ -190,6 +219,13 @@ Delete the storage class.
 
     kubectl delete -f k8s/storage-class.yml
 
+ConfigMaps are managed explicitly for now:
+
+    kubectl delete configmap prometheus-config
+
+Now, `kubectl get` should not include any of the above objects.
+
+    kubectl get services,deployments,pods,configmaps,pvc,pv
 
 # Debugging the steps above
 

--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -23,7 +23,7 @@ spec:
         run: prometheus-server
     spec:
       containers:
-      - image: measurementlab/prometheus-server:v1.5.2-3
+      - image: prom/prometheus:v1.5.2
         # Note: this value appears to be ignored and the actual pod name is
         # derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
@@ -43,9 +43,15 @@ spec:
         - mountPath: /legacy-targets
           name: prometheus-storage
           subPath: legacy-targets
+        # /etc/config/prometheus.yml should contain the M-Lab Prometheus config.
+        - mountPath: /etc/config
+          name: prometheus-config
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.
       volumes:
       - name: prometheus-storage
         persistentVolumeClaim:
           claimName: auto-prometheus-disk0
+      - name: prometheus-config
+        configMap:
+          name: prometheus-config

--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -43,8 +43,8 @@ spec:
         - mountPath: /legacy-targets
           name: prometheus-storage
           subPath: legacy-targets
-        # /etc/config/prometheus.yml should contain the M-Lab Prometheus config.
-        - mountPath: /etc/config
+        # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
+        - mountPath: /etc/prometheus
           name: prometheus-config
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.

--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -24,8 +24,8 @@ spec:
     spec:
       containers:
       - image: prom/prometheus:v1.5.2
-        # Note: this value appears to be ignored and the actual pod name is
-        # derived from the Deployment.metadata.name. However, removing this
+        # Note: the container name appears to be ignored and the actual pod name
+        # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: prometheus-server
         ports:

--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -23,6 +23,8 @@ spec:
         run: prometheus-server
     spec:
       containers:
+      # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
+      # stable version.
       - image: prom/prometheus:v1.5.2
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,3 +1,0 @@
-FROM prom/prometheus:v1.5.2
-MAINTAINER support@measurementlab.net
-ADD prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
This PR removes the need to create a custom prometheus docker image by adding a ConfigMap configuration for the prometheus configuration.

Using the ConfigMap, operators can update a configuration file and restart the pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/7)
<!-- Reviewable:end -->
