### PR TITLE
Add support for recording rules

### DIFF
--- a/k8s/mlab-sandbox/salarcon-kub-prom-walkthru/services.yml
+++ b/k8s/mlab-sandbox/salarcon-kub-prom-walkthru/services.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+  name: prometheus-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: prometheus-server
+  sessionAffinity: None
+  # Allocate a static IP manually in GCP console: Networking -> Load Balancing.
+  externalIPs:
+    - 130.211.72.70
+  type: ClusterIP

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -15,9 +15,7 @@ global:
 # Load rules once and periodically evaluate them according to the global
 # 'evaluation_interval'.
 rule_files:
-  # - "first.rules"
-  # - "second.rules"
-
+  - /etc/prometheus/rules.yml
 
 # Scrape configurations.
 #

--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -1,0 +1,35 @@
+# M-Lab prometheus recording rules.
+#
+# Before adding a new recording rule, review the general documentation and best
+# practices.
+#
+#  * https://prometheus.io/docs/querying/rules/
+#  * https://prometheus.io/docs/practices/rules/
+#
+# NOTE: As of 2017-03, all rules are evalutated in parallel. Their evaluation
+# order is not guaranteed, and dependencies between rules are not respected.
+# Using recording rules on the right hand side of an expression can have
+# undefined behavior and may result in recording old data or other errors.
+#
+#    https://github.com/prometheus/prometheus/blob/master/rules/manager.go#L240
+#
+# DO:
+#  * Do use raw prometheus expressions on the right hand side of a new rule.
+#
+# DO NOT:
+#  * Do not use recording rules on the right hand side of a new rule.
+#  * Do not overwrite a metric name with itself.
+#  * Do not use 'label_replace' to overwrite a metric name.
+
+
+# Precalculate the increase of ipv4 and ipv6 sidestream connections.
+ipv4_and_ipv6:sidestream_connection_count:increase2m =
+    increase(sidestream_connection_count{type=~"ipv4|ipv6"}[2m])
+
+# Precalculate the sum of sidestream connections per machine.
+instance:sidestream_connection_count:increase2m =
+    sum by(instance) (increase(sidestream_connection_count{type=~"ipv4|ipv6"}[2m]))
+
+# Precalculate the sum of sidestream connections per experiment "last six bits".
+lsb:sidestream_connection_count:increase2m =
+    sum by(lsb) (increase(sidestream_connection_count{type=~"ipv4|ipv6"}[2m]))


### PR DESCRIPTION
This change adds recording rules to Prometheus.

Recording rules are a form of pre-calculation for expressions that are more expensive to execute at run-time. When active, recording rules can be queried like any other prometheus metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/8)
<!-- Reviewable:end -->
