### PR TITLE
Add disk usage monitoring of /prometheus mount point.

### DIFF
--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -21,6 +21,11 @@ spec:
         # Note: run=prometheus-server should match a service config with a
         # public IP and port so that it is publically accessible.
         run: prometheus-server
+      annotations:
+        # Tell prometheus service discovery to scrape the node-exporter running
+        # within the prometheus-server pod.
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9100'
     spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
@@ -30,6 +35,12 @@ spec:
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: prometheus-server
+        # Note: Set retention time to 120 days. (default retention is 30d).
+        args: ["-config.file=/etc/prometheus/prometheus.yml",
+               "-storage.local.path=/prometheus",
+               "-storage.local.retention=2880h",
+               "-web.console.libraries=/usr/share/prometheus/console_libraries",
+               "-web.console.templates=/usr/share/prometheus/consoles"]
         ports:
           - containerPort: 9090
         resources:
@@ -48,6 +59,21 @@ spec:
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
+
+      # Run a node-exporter as part of the prometheus-server pod so that it has
+      # access to the same namespace and volumes as the prometheus-server. This
+      # allows simple disk usage monitoring of the "/prometheus" mount point.
+      - image: prom/node-exporter:v0.13.0
+        name: fs-exporter
+        # Note: only enable the filesystem collector, and ignore system paths.
+        args: [ "--collectors.enabled=filesystem",
+                "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)"]
+        ports:
+          - containerPort: 9100
+        volumeMounts:
+        - mountPath: /prometheus
+          name: prometheus-storage
+
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.
       volumes:


### PR DESCRIPTION
By default, (afaict) there is no monitoring of disk utilization for mount points of persistent volumes that uses the natural name familiar to operators, e.g. "/prometheus".

So, instead of a label like:
```
{mountpoint="/prometheus"}
```

Default behavior provides inscrutable labels like:
```
{mountpoint="/rootfs/var/lib/kubelet/pods/6950c80b-0b72-11e7-b1f8-42010af0004b/volumes/kubernetes.io~gce-pd/pvc-3e682a5b-f95d-11e6-a30a-42010af0004b"}
```

While the generated name does not change over time, it is a tedious manual process for an operator to translate that label to a human readable one.

This change provides human readable filesystem usage metrics by running a node-exporter within the same pod as the prometheus server. As a result, it has access to the same namespace and mount points as the prometheus-server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/10)
<!-- Reviewable:end -->
