### PR TITLE
Add a DaemonSet for the node-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ with the label "run=prometheus-server":
 
     kubectl create -f k8s/mlab-sandbox/<cluser-name>/services.yml
 
+Create the node-exporter daemonset. A [DaemonSet][daemonset] ensures that all
+nodes in the cluster run a copy of a pod. Our daemonset will run one instance of
+the node-exporter on every node.
+
+    kubectl create -f k8s/node-exporter-daemonset.yml
+
 Create the prometheus deployment. This step starts the actual prometheus
 server. The deployment will receive traffic from the service defined above and
 binds to the persistent volume claim. If a persistent volume does not already
@@ -198,6 +204,7 @@ something like:
 
 [cluster]: https://cloud.google.com/container-engine/docs/clusters/operations
 [setup]: #grafana-setup
+[daemonset]: https://kubernetes.io/docs/admin/daemons/
 
 ## Add Legacy Targets
 
@@ -257,6 +264,10 @@ deleted. At that point all data will be lost.
 Delete the storage class.
 
     kubectl delete -f k8s/storage-class.yml
+
+Delete the node exporter daemonset.
+
+    kubectl delete -f k8s/node-exporter-daemonset.yml
 
 ConfigMaps are managed explicitly for now:
 

--- a/k8s/node-exporter-daemonset.yml
+++ b/k8s/node-exporter-daemonset.yml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        name: node-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      containers:
+      - image: prom/node-exporter:v0.13.0
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+        resources:
+          requests:
+            cpu: 0.15
+        securityContext:
+          privileged: true
+        # Specify the host-specific paths to monitor, and ignore pod-local paths.
+        args: ["-collector.procfs=/host/proc",
+               "-collector.sysfs=/host/sys",
+               "-collector.filesystem.ignored-mount-points=^/(sys|proc|dev|etc)($|/)"]
+        # Mount the node volumes into a separate directory to not conflict with
+        # the pod's version.
+        volumeMounts:
+        - name: dev
+          mountPath: /host/dev
+        - name: proc
+          mountPath: /host/proc
+        - name: sys
+          mountPath: /host/sys
+        - name: rootfs
+          mountPath: /rootfs
+      # Define volumes taken from the host context, i.e. the node itself.
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: rootfs
+        hostPath:
+          path: /


### PR DESCRIPTION
This change adds a DaemonSet configuration for the node-exporter to run on every node in a cluster.

The node-exporter collects [a variety of system metrics][exporter] that we can use to assess whole-cluster health.

[exporter]: https://github.com/prometheus/node_exporter#enabled-by-default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/11)
<!-- Reviewable:end -->
