### PR TITLE
Add new services.yml file with external IP pointing to the GCP addres…

### DIFF
--- a/k8s/mlab-staging/status-mlab-staging/services.yml
+++ b/k8s/mlab-staging/status-mlab-staging/services.yml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+  name: prometheus-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: prometheus-server
+  sessionAffinity: None
+  # Allocate a static IP manually in GCP console: Networking -> Load Balancing.
+  externalIPs:
+    - 35.185.76.159
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # The grafana web server does not export any prometheus metrics.
+    prometheus.io/scrape: 'false'
+  name: grafana-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: grafana-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.185.76.159
+  type: ClusterIP


### PR DESCRIPTION
…s assigned to status-mlab-staging.measurementlab.net

The assigned external IP can be verified here:
https://console.cloud.google.com/networking/addresses/list?project=mlab-staging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/13)
<!-- Reviewable:end -->
