### PR TITLE
Add blackbox exporter monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,56 @@ Delete the configmaps.
     kubectl delete configmap alertmanager-config
     kubectl delete configmap alertmanage-env
 
+# Blackbox exporter
+
+The blackbox exporter allows probes of endpoints over HTTP, HTTPS, DNS, TCP and
+ICMP.
+
+Targets are declared in an input file like legacy targets, however
+blackbox targets require specifying a "module". The module name must match a
+module defined in `config/federation/blackbox/config.yml`. Different modules
+have different format requirements on the targets (e.g. some with ports, some
+without).
+
+```
+[
+    {
+        "labels": {
+            "module": "ssh_v4_online",
+            "service": "sshalt"
+        },
+        "targets": [
+            "mlab1.den02.measurement-lab.org:806",
+            "mlab4.den02.measurement-lab.org:806"
+        ]
+    }
+]
+```
+
+A single input file can define a list of configurations, each with a different
+"module" and independent list of targets.
+
+## Create
+
+Create the configmaps for the blackbox exporter:
+
+    kubectl create configmap blackbox-config \
+        --from-file=config/federation/blackbox
+
+Create the blackbox exporter deployment.
+
+    kubectl create -f k8s/federation/blackbox.yml
+
+## Delete
+
+Delete the deployment.
+
+    kubectl delete -f k8s/federation/blackbox.yml
+
+Delete the configmaps.
+
+    kubectl delete configmap blackbox-config
+
 
 # Debugging the steps above
 

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -1,68 +1,58 @@
+# M-Lab blackbox exporter configuration.
+#
+# The blackbox exporter allows probes of endpoints over HTTP, HTTPS, DNS, TCP
+# and ICMP.
+#
+# Every probe takes a "target" and "module" as parameters. The probe runs
+# synchronously with the request. Typically, Prometheus will issue the request
+# to the blackbox exporter.
+#
+# We can run a sample check. For example:
+#    target=mlab1.lga02.measurement-lab.org:806
+#    module=ssh_v4_online
+#    wget "http://<blackbox-ip>:9115/probe?target=${target}&module=${module}"
+#
+# Returns:
+#
+#    probe_ip_protocol 4
+#    probe_duration_seconds 0.179516
+#    probe_success 1
+#
+# See https://github.com/prometheus/blackbox_exporter for additional examples.
+
 modules:
-  host_online:
+  # target=<hostname:port>
+  tcp_v4_online:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      protocol: "tcp4"
+
+  # target=<hostname:port>
+  ssh_v4_online:
     prober: tcp
     timeout: 10s
     tcp:
       protocol: "tcp4"
       query_response:
         - expect: "SSH-2.0-OpenSSH_.+"
-    
-  http_post_2xx:
-    prober: http
-    timeout: 5s
-    http:
-      method: POST
-      headers:
-        Content-Type: application/json
-      body: '{}'
 
-  tcp_connect_v4_example:
-    prober: tcp
-    timeout: 5s
-    tcp:
-      protocol: "tcp4"
-
-  irc_banner_example:
-    prober: tcp
-    timeout: 5s
-    tcp:
-      query_response:
-        - send: "NICK prober"
-        - send: "USER prober prober prober :prober"
-        - expect: "PING :([^ ]+)"
-          send: "PONG ${1}"
-        - expect: "^:[^ ]+ 001"
-
-  icmp_example:
+  # target=<hostname>
+  icmp:
     prober: icmp
     timeout: 5s
     icmp:
       protocol: "icmp"
       preferred_ip_protocol: "ip4"
 
-  dns_udp_example:
-    prober: dns
+  # target=<http[s]://host:port>
+  #
+  # Works with http or https targets.
+  #
+  # NOTE: M-Lab DRACs are network filtered.
+  # NOTE: NDT ports do not return valid HTTP responses and appear to fail.
+  http_2xx:
+    prober: http
     timeout: 5s
-    dns:
-      query_name: "www.prometheus.io"
-      query_type: "A"
-      valid_rcodes:
-      - NOERROR
-      validate_answer_rrs:
-        fail_if_matches_regexp:
-        - ".*127.0.0.1"
-        fail_if_not_matches_regexp:
-        - "www.prometheus.io.\t300\tIN\tA\t127.0.0.1"
-      validate_authority_rrs:
-        fail_if_matches_regexp:
-        - ".*127.0.0.1"
-      validate_additional_rrs:
-        fail_if_matches_regexp:
-        - ".*127.0.0.1"
-
-  dns_tcp_example:
-    prober: dns
-    dns:
-      protocol: "tcp" # accepts "tcp/tcp4/tcp6/udp/udp4/udp6", defaults to "udp"
-      preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
-      query_name: "www.prometheus.io"
+    http:
+      method: GET

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -1,0 +1,68 @@
+modules:
+  host_online:
+    prober: tcp
+    timeout: 10s
+    tcp:
+      protocol: "tcp4"
+      query_response:
+        - expect: "SSH-2.0-OpenSSH_.+"
+    
+  http_post_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      headers:
+        Content-Type: application/json
+      body: '{}'
+
+  tcp_connect_v4_example:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      protocol: "tcp4"
+
+  irc_banner_example:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+        - send: "NICK prober"
+        - send: "USER prober prober prober :prober"
+        - expect: "PING :([^ ]+)"
+          send: "PONG ${1}"
+        - expect: "^:[^ ]+ 001"
+
+  icmp_example:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      protocol: "icmp"
+      preferred_ip_protocol: "ip4"
+
+  dns_udp_example:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: "www.prometheus.io"
+      query_type: "A"
+      valid_rcodes:
+      - NOERROR
+      validate_answer_rrs:
+        fail_if_matches_regexp:
+        - ".*127.0.0.1"
+        fail_if_not_matches_regexp:
+        - "www.prometheus.io.\t300\tIN\tA\t127.0.0.1"
+      validate_authority_rrs:
+        fail_if_matches_regexp:
+        - ".*127.0.0.1"
+      validate_additional_rrs:
+        fail_if_matches_regexp:
+        - ".*127.0.0.1"
+
+  dns_tcp_example:
+    prober: dns
+    dns:
+      protocol: "tcp" # accepts "tcp/tcp4/tcp6/udp/udp4/udp6", defaults to "udp"
+      preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
+      query_name: "www.prometheus.io"

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -272,14 +272,12 @@ scrape_configs:
   # Blackbox configurations.
   #
   # Each blackbox configuration uses a different probe (tcp, icmp, http, etc).
-  - job_name: 'blackbox-ssh-targets'
+  - job_name: 'blackbox-targets'
     metrics_path: /probe
-    params:
-      module: [ssh_v4_online]
 
     file_sd_configs:
       - files:
-          - /blackbox-targets/ssh_v4_online.json
+          - /blackbox-targets/*.json
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
@@ -299,6 +297,13 @@ scrape_configs:
         target_label: __param_target
         replacement: ${1}
 
+      # Use the "module" label defined in the input file as the module name for
+      # the blackbox exporter request.
+      - source_labels: [module]
+        regex: .*
+        target_label: __param_module
+        replacement: ${1}
+
       # Use the target parameter defined above and use it to define the
       # "instance" label.
       - source_labels: [__param_target]
@@ -309,81 +314,6 @@ scrape_configs:
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the blackbox exporter
       # address.
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: blackbox-public-service.default.svc.cluster.local:9115
-
-  - job_name: 'blackbox-tcp-targets'
-    metrics_path: /probe
-    params:
-      module: [tcp_v4_online]
-
-    file_sd_configs:
-      - files:
-          - /blackbox-targets/tcp_v4_online.json
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    relabel_configs:
-      - source_labels: [__address__]
-        regex: (.*)(:80)?
-        target_label: __param_target
-        replacement: ${1}
-      - source_labels: [__param_target]
-        regex: (.*)
-        target_label: instance
-        replacement: ${1}
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: blackbox-public-service.default.svc.cluster.local:9115
-
-  - job_name: 'blackbox-icmp-targets'
-    metrics_path: /probe
-    params:
-      module: [icmp]
-
-    file_sd_configs:
-      - files:
-          - /blackbox-targets/icmp.json
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    relabel_configs:
-      - source_labels: [__address__]
-        regex: (.*)(:80)?
-        target_label: __param_target
-        replacement: ${1}
-      - source_labels: [__param_target]
-        regex: (.*)
-        target_label: instance
-        replacement: ${1}
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: blackbox-public-service.default.svc.cluster.local:9115
-
-  - job_name: 'blackbox-http-targets'
-    metrics_path: /probe
-    params:
-      module: [http_2xx]  # Look for a HTTP 200 response.
-
-    file_sd_configs:
-      - files:
-          - /blackbox-targets/http_2xx.json
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    relabel_configs:
-      - source_labels: [__address__]
-        regex: (.*)(:80)?
-        target_label: __param_target
-        replacement: ${1}
-      - source_labels: [__param_target]
-        regex: (.*)
-        target_label: instance
-        replacement: ${1}
       - source_labels: []
         regex: .*
         target_label: __address__

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -269,14 +269,98 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-  - job_name: 'blackbox-file'
+  - job_name: 'blackbox-ssh-targets'
     metrics_path: /probe
     params:
-      module: [host_online]  # Look for a HTTP 200 response.
+      module: [ssh_v4_online]
 
     file_sd_configs:
       - files:
-          - /blackbox-targets/*.json
+          - /blackbox-targets/ssh_v4_online.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    # This is really very bad. The relabel config juggles the parameters as
+    # well as the address being probed. This is also how they tell you to do
+    # it: https://github.com/prometheus/blackbox_exporter
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (.*)(:80)?
+        target_label: __param_target
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: (.*)
+        target_label: instance
+        replacement: ${1}
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: 104.197.220.28:9115
+
+  - job_name: 'blackbox-tcp-targets'
+    metrics_path: /probe
+    params:
+      module: [tcp_v4_online]
+
+    file_sd_configs:
+      - files:
+          - /blackbox-targets/tcp_v4_online.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    # This is really very bad. The relabel config juggles the parameters as
+    # well as the address being probed. This is also how they tell you to do
+    # it: https://github.com/prometheus/blackbox_exporter
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (.*)(:80)?
+        target_label: __param_target
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: (.*)
+        target_label: instance
+        replacement: ${1}
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: 104.197.220.28:9115
+
+  - job_name: 'blackbox-icmp-targets'
+    metrics_path: /probe
+    params:
+      module: [icmp]
+
+    file_sd_configs:
+      - files:
+          - /blackbox-targets/icmp.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    # This is really very bad. The relabel config juggles the parameters as
+    # well as the address being probed. This is also how they tell you to do
+    # it: https://github.com/prometheus/blackbox_exporter
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (.*)(:80)?
+        target_label: __param_target
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: (.*)
+        target_label: instance
+        replacement: ${1}
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: 104.197.220.28:9115
+
+  - job_name: 'blackbox-http-targets'
+    metrics_path: /probe
+    params:
+      module: [http_2xx]  # Look for a HTTP 200 response.
+
+    file_sd_configs:
+      - files:
+          - /blackbox-targets/http_2xx.json
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -269,6 +269,9 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
+  # Blackbox configurations.
+  #
+  # Each blackbox configuration uses a different probe (tcp, icmp, http, etc).
   - job_name: 'blackbox-ssh-targets'
     metrics_path: /probe
     params:
@@ -280,22 +283,36 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-    # This is really very bad. The relabel config juggles the parameters as
-    # well as the address being probed. This is also how they tell you to do
-    # it: https://github.com/prometheus/blackbox_exporter
+    # This relabel config is necessary. The relabel config redefines the address
+    # to scrape and sets the correct parameters to pass to the scrape target.
+    #
+    # While not as direct as other configs, this approach allows us to specify a
+    # dynamic list of targets for a static blackbox exporter. This is also the
+    # supported configuration: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
+
+      # The default __address__ value is a target host from the config file.
+      # Here, we set (i.e. "replace") a request parameter "target" equal to the
+      # host value.
       - source_labels: [__address__]
         regex: (.*)(:80)?
         target_label: __param_target
         replacement: ${1}
+
+      # Use the target parameter defined above and use it to define the
+      # "instance" label.
       - source_labels: [__param_target]
         regex: (.*)
         target_label: instance
         replacement: ${1}
+
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the blackbox exporter
+      # address.
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: 104.197.220.28:9115
+        replacement: blackbox-public-service.default.svc.cluster.local:9115
 
   - job_name: 'blackbox-tcp-targets'
     metrics_path: /probe
@@ -308,9 +325,6 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-    # This is really very bad. The relabel config juggles the parameters as
-    # well as the address being probed. This is also how they tell you to do
-    # it: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
       - source_labels: [__address__]
         regex: (.*)(:80)?
@@ -323,7 +337,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: 104.197.220.28:9115
+        replacement: blackbox-public-service.default.svc.cluster.local:9115
 
   - job_name: 'blackbox-icmp-targets'
     metrics_path: /probe
@@ -336,9 +350,6 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-    # This is really very bad. The relabel config juggles the parameters as
-    # well as the address being probed. This is also how they tell you to do
-    # it: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
       - source_labels: [__address__]
         regex: (.*)(:80)?
@@ -351,7 +362,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: 104.197.220.28:9115
+        replacement: blackbox-public-service.default.svc.cluster.local:9115
 
   - job_name: 'blackbox-http-targets'
     metrics_path: /probe
@@ -364,9 +375,6 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-    # This is really very bad. The relabel config juggles the parameters as
-    # well as the address being probed. This is also how they tell you to do
-    # it: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
       - source_labels: [__address__]
         regex: (.*)(:80)?
@@ -379,4 +387,4 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: 104.197.220.28:9115
+        replacement: blackbox-public-service.default.svc.cluster.local:9115

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -269,3 +269,30 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
+  - job_name: 'blackbox-file'
+    metrics_path: /probe
+    params:
+      module: [host_online]  # Look for a HTTP 200 response.
+
+    file_sd_configs:
+      - files:
+          - /blackbox-targets/*.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    # This is really very bad. The relabel config juggles the parameters as
+    # well as the address being probed. This is also how they tell you to do
+    # it: https://github.com/prometheus/blackbox_exporter
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: (.*)(:80)?
+        target_label: __param_target
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: (.*)
+        target_label: instance
+        replacement: ${1}
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: 104.197.220.28:9115

--- a/k8s/federation/blackbox.yml
+++ b/k8s/federation/blackbox.yml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: blackbox-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      # Used to match pre-existing pods that may be affected during updates.
+      run: blackbox-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  # Pod template.
+  template:
+    metadata:
+      labels:
+        # Note: run=blackbox-server should match a service config with a
+        # public IP and port so that it is publically accessible.
+        run: blackbox-server
+    spec:
+      # Place the pod into the Guaranteed QoS by setting equal resource
+      # requests and limits for *all* containers in the pod.
+      # For more background, see:
+      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
+      containers:
+      # Check https://hub.docker.com/r/prom/blackbox-exporter/tags/ for the current
+      # stable version.
+      - image: prom/blackbox-exporter:v0.4.0
+        # Note: the container name appears to be ignored and the actual pod name
+        # is derived from the Deployment.metadata.name. However, removing this
+        # value results in a configuration error.
+        name: blackbox-server
+        args: ["-config.file=/etc/blackbox/config.yml"]
+        ports:
+          - containerPort: 9115
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "100m"
+          limits:
+            memory: "100Mi"
+            cpu: "100m"
+        volumeMounts:
+        # /etc/blackbox/config.yml contains the M-Lab Prometheus config.
+        - mountPath: /etc/blackbox
+          name: blackbox-config
+
+      # Disks created manually, can be named here explicitly using
+      # gcePersistentDisk instead of the persistentVolumeClaim.
+      volumes:
+      - name: blackbox-config
+        configMap:
+          name: blackbox-config

--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -68,6 +68,10 @@ spec:
         - mountPath: /federation-targets
           name: prometheus-storage
           subPath: federation-targets
+        # /blackbox-targets should contain blackbox target config files.
+        - mountPath: /blackbox-targets
+          name: prometheus-storage
+          subPath: blackbox-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config

--- a/k8s/mlab-sandbox/soltesz-test-3/services.yml
+++ b/k8s/mlab-sandbox/soltesz-test-3/services.yml
@@ -68,3 +68,27 @@ spec:
     # Use the same IP as above, since we're on a different port.
     - 35.184.247.140
   type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # The grafana web server does not export any prometheus metrics.
+    prometheus.io/scrape: 'false'
+  name: blackbox-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9115
+    protocol: TCP
+    targetPort: 9115
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: blackbox-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.247.140
+  type: ClusterIP


### PR DESCRIPTION
This change adds basic configuration for the blackbox exporter as well as changes to the prometheus configuration to take advantage of the blackbox exporter.

With this configuration it will be possible to emulate the nagios `check_tcp`, `check_http`, `check_ssh`, and `check_icmp` plugins (with some caveats).

The changes to the prometheus config can be deployed independently of the blackbox configs.

A working configuration is available temporarily at http://104.197.220.28:9090/targets and:

    wget -q -O - 'http://104.197.220.28:9115/probe?target=mlab1.lga02.measurement-lab.org:806&module=ssh_v4_online'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/15)
<!-- Reviewable:end -->
