### PR TITLE
Add basic pushgateway support.

### DIFF
--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -318,3 +318,25 @@ scrape_configs:
         regex: .*
         target_label: __address__
         replacement: blackbox-public-service.default.svc.cluster.local:9115
+
+
+  # Scrape config for pushgateway.
+  #
+  # Push gateways allow services to publish metrics for later collection by
+  # prometheus. Push gateways are helpful for processes that cannot run an
+  # exporter, whose exporter is not publically accessible, or processes that
+  # are short-lived.
+  #
+  # Like federation, labels set on the pushgatway should be honored by
+  # prometheus.
+  #
+  # Learn more at:
+  #   https://github.com/prometheus/pushgateway#prometheus-pushgateway
+  - job_name: 'pushgateway-targets'
+    # Normally, the prometheus server updates target labels at collection time,
+    # but here we want to take them as-is.
+    honor_labels: true
+
+    static_configs:
+      - targets:
+        - pushgateway-public-service.default.svc.cluster.local:9091

--- a/k8s/federation/pushgateway.yml
+++ b/k8s/federation/pushgateway.yml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pushgateway-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      # Used to match pre-existing pods that may be affected during updates.
+      run: pushgateway-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  # Pod template.
+  template:
+    metadata:
+      labels:
+        # Note: run=pushgateway-server should match a service config with a
+        # public IP and port so that it is publically accessible.
+        run: pushgateway-server
+    spec:
+      # Place the pod into the Guaranteed QoS by setting equal resource
+      # requests and limits for *all* containers in the pod.
+      # For more background, see:
+      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
+      containers:
+      # Check https://hub.docker.com/r/prom/pushgateway/tags/ for the current
+      # stable version.
+      - image: prom/pushgateway:v0.3.1
+        name: pushgateway-server
+
+        # NOTE: push gateway metrics do not expire. Once pushed to the gateway
+        # they remain indefinitely until the gateway restarts or they are
+        # overwritten. For a fixed label set this is okay. However, if the set
+        # of instance names grows over time without reuse, then the gateway
+        # will persist that information indefinitely, but it won't be helpful.
+        # So, do not use file persistence until we're sure it's what we need.
+        # args: ["-persistence.file=/pushgateway/metrics.dat",
+        #        "-persistence.interval=1m"]
+        ports:
+          - containerPort: 9091
+        resources:
+          requests:
+            memory: "400Mi"
+            cpu: "200m"
+          limits:
+            memory: "400Mi"
+            cpu: "200m"

--- a/k8s/mlab-sandbox/soltesz-test-3/services.yml
+++ b/k8s/mlab-sandbox/soltesz-test-3/services.yml
@@ -92,3 +92,24 @@ spec:
     # Use the same IP as above, since we're on a different port.
     - 35.184.247.140
   type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9091
+    protocol: TCP
+    targetPort: 9091
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: pushgateway-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.247.140
+  type: ClusterIP


### PR DESCRIPTION
This change adds a new service definition for the push gateway, a k8s
config for the pushgateway deployment, and an update to the prometheus server
scrape configuration to collect metrics from the push gateway.

The pushgateway does not need persistent storage with the minimal configuration and it's not clear that we want that ultimately for our use cases anyway.

The configuration changes to the prometheus.yml scrape configuration can be deployed safely without the pushgatway deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/17)
<!-- Reviewable:end -->
