### PR TITLE
Run mlab_service_discovery continuously.

### DIFF
--- a/cmd/mlab_service_discovery/Dockerfile
+++ b/cmd/mlab_service_discovery/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.8
+COPY . /go/src/mlab_service_discovery
+RUN go get -v mlab_service_discovery
+ENTRYPOINT ["/go/bin/mlab_service_discovery"]


### PR DESCRIPTION
This change adds a Dockerfile for `mlab_service_discovery` and allows the process to run continuously.

The intended deployment is within the prometheus pod, so that `mlab_service_discovery` can update the targets file continuously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/20)
<!-- Reviewable:end -->
