### PR TITLE
Add App Engine Flex service discovery to Prometheus deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ see the [official docs][configmaps].
 Create the ConfigMap for prometheus (only create a ConfigMap for one of cluster
 or federation, not both):
 
+TODO(soltesz): move environment variables (like gcloud-project) to a separate
+directory.
+
     kubectl create configmap prometheus-federation-config \
+        --from-literal=gcloud-project=mlab-sandbox
         --from-file=config/federation/prometheus
+
     kubectl create configmap prometheus-cluster-config \
         --from-file=config/cluster/prometheus
 
@@ -459,6 +464,29 @@ Delete the configmaps.
 
     kubectl delete configmap blackbox-config
 
+# Pushgateway
+
+A prometheus push gateway are useful for short-lived processes, or processes
+that are not network accessible by the prometheus server.
+
+Note that push gateways have limitations. So, consider this an option of last
+resort and understand the limits before proceeding.
+
+For more information, see:
+https://github.com/prometheus/pushgateway#prometheus-pushgateway
+
+## Create
+
+The pushgateway has no configuration file or persistent state. Create the
+deployment.
+
+    kubectl create -f k8s/federation/pushgateway.yml
+
+## Delete
+
+Delete the deployment.
+
+    kubectl delete -f k8s/federation/pushgateway.yml
 
 # Debugging the steps above
 

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -340,3 +340,25 @@ scrape_configs:
     static_configs:
       - targets:
         - pushgateway-public-service.default.svc.cluster.local:9091
+
+  # Scrape config for App Engine Flex VMs.
+  #
+  # In order to scrape Prometheus metrics directly from Flex VMs, the app.yaml
+  # configuration must include a rule to forward the container port to the host
+  # VM. The measurementlab/mlab-service-discovery detects these VMs and
+  # generates a targets file.
+  #
+  # Learn more at:
+  #   TODO(soltesz): add canonical link to the service discovery repo when it
+  #   exists.
+  - job_name: 'aeflex-targets'
+    file_sd_configs:
+      - files:
+          - /aeflex-targets/*.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    relabel_configs:
+      # Copy all labels from the aeflex service discovery.
+      - action: labelmap
+        regex: __aef_(.+)

--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -97,6 +97,29 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
+      - image: measurementlab/mlab-service-discovery
+        name: service-discovery
+        env:
+        - name: GCLOUD_PROJECT
+          valueFrom:
+            configMapKeyRef:
+              name: prometheus-federation-config
+              key: gcloud-project
+        args: [ "-output=/targets/aeflex-targets/aeflex.json",
+                "-project=$(GCLOUD_PROJECT)"]
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "50m"
+          limits:
+            memory: "10Mi"
+            cpu: "50m"
+        volumeMounts:
+        # Mount the the prometheus-storage for write access to the target
+        # directories.
+        - mountPath: /targets
+          name: prometheus-storage
+
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.
       volumes:


### PR DESCRIPTION
This change includes two updates.

 1. The README now includes notes on the pushgateway, since they were not added previously.
 2. Add the mlab-service-discovery container to the federation prometheus deployment so that App Engine Flex VMs can be automatically detected continuously and scraped by prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/21)
<!-- Reviewable:end -->
