### PR TITLE
Increase resources for federated prometheus

### DIFF
--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -50,11 +50,11 @@ spec:
           - containerPort: 9090
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "1000m"
+            memory: "8Gi"
+            cpu: "3000m"
           limits:
-            memory: "4Gi"
-            cpu: "1000m"
+            memory: "8Gi"
+            cpu: "3000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus
@@ -72,6 +72,10 @@ spec:
         - mountPath: /blackbox-targets
           name: prometheus-storage
           subPath: blackbox-targets
+        # /aeflex-targets should contain AppEngine target config files.
+        - mountPath: /aeflex-targets
+          name: prometheus-storage
+          subPath: aeflex-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config


### PR DESCRIPTION
This change increases the resources assigned to Prometheus based on load requirements from work on the ETL pipeline.

As well, this provides a mount point for saving the aeflex service discovery file (accidentally omitted from a previous PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/22)
<!-- Reviewable:end -->
