### PR TITLE
Use ephemeral IP for prometheus cluster service configuration

### DIFF
--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -68,11 +68,11 @@ spec:
           - containerPort: 9090
         resources:
           requests:
-            memory: "3Gi"
-            cpu: "500m"
+            memory: "8Gi"
+            cpu: "3000m"
           limits:
-            memory: "3Gi"
-            cpu: "500m"
+            memory: "8Gi"
+            cpu: "3000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -1,3 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-public-service
+  namespace: default
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+    gke-prometheus-federation/scrape: 'true'
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    run: prometheus-server
+  sessionAffinity: None
+  type: LoadBalancer
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This change updates the k8s/cluster configuration for prometheus so that the service definition uses an ephemeral IP that can be discovered later by searching for services annotated with the value: "gke-prometheus-federation/scrape: true".

This simplifies cluster deployments by not requiring a static ip allocation before hand and provides a means of discovering the target for "federation" scraping at a later time (likely from another cluster).