### PR TITLE
Add blackbox exporter module for rsyncd.

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -37,6 +37,17 @@ modules:
       query_response:
         - expect: "SSH-2.0-OpenSSH_.+"
 
+  # target=<hostname:port>
+  rsync_online:
+    prober: tcp
+    timeout: 10s
+    tcp:
+      protocol: "tcp4"
+      query_response:
+        # @RSYNCD: is followed by a version number, e.g. 30.0. For more
+        # flexibility we do not require a specific version here.
+        - expect: "@RSYNCD: .+"
+
   # target=<hostname>
   icmp:
     prober: icmp


### PR DESCRIPTION
This change adds a new module to the blackbox exporter configuration for checking the status of rsyncd servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/25)
<!-- Reviewable:end -->
