### PR TITLE
Fix blackbox timeout and prometheus relabel regex for blackbox module label

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -7,6 +7,11 @@
 # synchronously with the request. Typically, Prometheus will issue the request
 # to the blackbox exporter.
 #
+# The prober timeout setting must be less than the prometheus scrape timeout
+# or the prometheus server will give up and conclude that the blackbox service
+# is down and never receive the probe failure metrics from the blackbox
+# exporter.
+#
 # We can run a sample check. For example:
 #    target=mlab1.lga02.measurement-lab.org:806
 #    module=ssh_v4_online
@@ -31,7 +36,7 @@ modules:
   # target=<hostname:port>
   ssh_v4_online:
     prober: tcp
-    timeout: 10s
+    timeout: 5s
     tcp:
       protocol: "tcp4"
       query_response:
@@ -40,7 +45,7 @@ modules:
   # target=<hostname:port>
   rsync_online:
     prober: tcp
-    timeout: 10s
+    timeout: 5s
     tcp:
       protocol: "tcp4"
       query_response:

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -43,7 +43,7 @@ modules:
         - expect: "SSH-2.0-OpenSSH_.+"
 
   # target=<hostname:port>
-  rsync_online:
+  rsyncd_online:
     prober: tcp
     timeout: 5s
     tcp:

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -300,7 +300,7 @@ scrape_configs:
       # Use the "module" label defined in the input file as the module name for
       # the blackbox exporter request.
       - source_labels: [module]
-        regex: .*
+        regex: (.*)
         target_label: __param_module
         replacement: ${1}
 


### PR DESCRIPTION
This change includes two fixes to the blackbox configuration.

First, we change all blackbox module timeouts to 5 seconds to guarantee that this timeout is less than the prometheus scrape timeout of 10 seconds. This is necessary to ensure that prometheus receives metrics about the failed probe rather than concluding that the blackbox exporter is down.

Second, we change a regex in the blackbox exporter relabel config to use parentheses so that the group numbers (`${1}`) work as intended. Their original omission was a typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/27)
<!-- Reviewable:end -->
