### PR TITLE
Update prometheus service-discovery 

### DIFF
--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -101,7 +101,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/mlab-service-discovery
+      - image: measurementlab/gcp-service-discovery
         name: service-discovery
         env:
         - name: GCLOUD_PROJECT
@@ -109,8 +109,16 @@ spec:
             configMapKeyRef:
               name: prometheus-federation-config
               key: gcloud-project
-        args: [ "-output=/targets/aeflex-targets/aeflex.json",
-                "-project=$(GCLOUD_PROJECT)"]
+        args: [ "-aef-target=/targets/aeflex-targets/aeflex.json",
+                "-gke-target=/targets/federation-targets/prometheus-clusters.json",
+                "-http-target=/targets/legacy-targets/sidestream.json",
+                "-http-target=/targets/blackbox-targets/ssh806.json",
+                "-http-target=/targets/blackbox-targets/rsyncd.json",
+                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
+                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
+                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
+                "-project=$(GCLOUD_PROJECT)" ]
+        - mountPath: /federation-targets
         resources:
           requests:
             memory: "10Mi"


### PR DESCRIPTION
This change depends on https://github.com/m-lab/operator/pull/105

This change updates the service discovery image to use gcp-service-discovery. Because gcp-service-discovery supports downloading arbitrary target files, this change also references the three target files generated automatically by https://github.com/m-lab/operator/pull/105

With the combination of https://github.com/m-lab/operator/pull/105 and this change, changes to the operator repo (addition or removal of sites) will automatically be propagated to prometheus services running the gcp-service-discovery image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/28)
<!-- Reviewable:end -->
