### PR TITLE
Fix typos with flags and stray value.

### DIFF
--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -109,16 +109,15 @@ spec:
             configMapKeyRef:
               name: prometheus-federation-config
               key: gcloud-project
-        args: [ "-aef-target=/targets/aeflex-targets/aeflex.json",
-                "-gke-target=/targets/federation-targets/prometheus-clusters.json",
-                "-http-target=/targets/legacy-targets/sidestream.json",
-                "-http-target=/targets/blackbox-targets/ssh806.json",
-                "-http-target=/targets/blackbox-targets/rsyncd.json",
-                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
-                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
-                "-http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
-                "-project=$(GCLOUD_PROJECT)" ]
-        - mountPath: /federation-targets
+        args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
+                "--gke-target=/targets/federation-targets/prometheus-clusters.json",
+                "--http-target=/targets/legacy-targets/sidestream.json",
+                "--http-target=/targets/blackbox-targets/ssh806.json",
+                "--http-target=/targets/blackbox-targets/rsyncd.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
+                "--project=$(GCLOUD_PROJECT)"]
         resources:
           requests:
             memory: "10Mi"

--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -120,10 +120,10 @@ spec:
                 "--project=$(GCLOUD_PROJECT)"]
         resources:
           requests:
-            memory: "10Mi"
+            memory: "150Mi"
             cpu: "50m"
           limits:
-            memory: "10Mi"
+            memory: "150Mi"
             cpu: "50m"
         volumeMounts:
         # Mount the the prometheus-storage for write access to the target


### PR DESCRIPTION
This change removes a stray value `- mountPath` that was added accidentally and uses double `--` prefixes for flags, required by the POSIX compatible flag package "github.com/spf13/pflag".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/29)
<!-- Reviewable:end -->
