### PR TITLE
Add framework to implement tests on queries for prometheus alerts

### DIFF
--- a/cmd/query_tester/README.md
+++ b/cmd/query_tester/README.md
@@ -13,7 +13,6 @@ The `promql.Test` uses a special purpose syntax for setting up data available
 for a test query, and specifying expected results.
 
 The basic form is:
-
 ```
 clear
 load <step>
@@ -34,16 +33,18 @@ eval instant at 0m absent(up{service="ssh806"})
 ```
 
 * `clear` resets the current data set.
+
 * `load` reads in a set of metrics and sets values for those metrics. The load
    parameter is a step size, in the same form as supported by
    `time.ParseDuration`, e.g. 1m for 1 minute.
+
 * `eval instant at 0m` evaluates an instantaneous query expression evaluated at
-  time 0. Timestamps begin at 0.
+  time 0. Timestamps begin at 0. NOTE: While some queryies may be very long, for
+  now, the entire expression must be on a single line.
 
 ## Advanced test format
 
 When loading metric values, you may specify repeated values. For example:
-
 ```
 clear
 load 1m
@@ -64,7 +65,6 @@ The form is: `<initial value> [+-] <delta> x <number of steps>`
 
 So, using the example, the initial value is 0, and for 20 steps, we'll add 10
 each step. This will save values:
-
 ```
  0m, 0
  1m, 10

--- a/cmd/query_tester/README.md
+++ b/cmd/query_tester/README.md
@@ -1,0 +1,75 @@
+# Query Tester
+
+Query tester uses an undocumented and unofficially supported language used
+within the prometheus source for testing queryies.
+
+There is some desire to generalize this language and make it officially
+supported, but until then, we are borrowing what is currently available to get
+as close as we can.
+
+## Test format
+
+The `promql.Test` uses a special purpose syntax for setting up data available
+for a test query, and specifying expected results.
+
+The basic form is:
+
+```
+clear
+load <step>
+    <metric_name>{<label>=<value>, ...} <values>
+
+eval instant at <eval-time> <promql query under test>
+    <expected result metrics>
+```
+
+For example:
+```
+clear
+load 1m
+    metric_name{service="unrelated-service"} 1
+
+eval instant at 0m absent(up{service="ssh806"})
+    {service="ssh806"} 1
+```
+
+* `clear` resets the current data set.
+* `load` reads in a set of metrics and sets values for those metrics. The load
+   parameter is a step size, in the same form as supported by
+   `time.ParseDuration`, e.g. 1m for 1 minute.
+* `eval instant at 0m` evaluates an instantaneous query expression evaluated at
+  time 0. Timestamps begin at 0.
+
+## Advanced test format
+
+When loading metric values, you may specify repeated values. For example:
+
+```
+clear
+load 1m
+    metric_name{service="unrelated-service"} 1 0 0 1 1 1
+```
+
+This saves values at corresponding times: 0m, 1m, 2m, 3m, 4m, 5m.
+
+
+There is also an abreviated form that applies a delta to every step:
+```
+clear
+load 1m
+    metric_name{service="unrelated-service"} 0+10x20
+```
+
+The form is: `<initial value> [+-] <delta> x <number of steps>`
+
+So, using the example, the initial value is 0, and for 20 steps, we'll add 10
+each step. This will save values:
+
+```
+ 0m, 0
+ 1m, 10
+ 2m, 20
+ 3m, 30
+ 4m, 40
+ 5m, 50
+```

--- a/cmd/query_tester/main.go
+++ b/cmd/query_tester/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("To run query tests:")
+	fmt.Println("go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn")
+}

--- a/cmd/query_tester/main_test.go
+++ b/cmd/query_tester/main_test.go
@@ -1,0 +1,37 @@
+// query_tester evaluates all query tests found in testdata/*.txt files.
+//
+// We implement query_tester as a Go test because promql.NewTest requires a
+// testing.T instance.
+package main_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql"
+)
+
+func TestEvaluations(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		t.Logf("Running %s", file)
+		content, err := ioutil.ReadFile(file)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		test, err := promql.NewTest(t, string(content))
+		if err != nil {
+			t.Errorf("Failed to create test for %s: %s", file, err)
+		}
+		err = test.Run()
+		if err != nil {
+			t.Errorf("Failed to run test %s: %s", file, err)
+		}
+		test.Close()
+	}
+}

--- a/cmd/query_tester/testdata/inventory.txt
+++ b/cmd/query_tester/testdata/inventory.txt
@@ -1,0 +1,59 @@
+# Machine and rsync inventory.
+
+# At collection time, prometheus defines the up{} metric. So, up{} is a view
+# of the target inventory. This metric for the ssh806 service should always be
+# present.
+
+# The ssh806 service is a proxy for machine inventory. Prometheus should always
+# be monitoring some machines.
+
+# Service ssh806 is absent.
+clear
+load 1m
+    up{service="unrelated-service"} 1
+
+eval instant at 0m absent(up{service="ssh806"})
+    {service="ssh806"} 1
+
+
+# The number of machines in the ssh806 inventory should equal the number of
+# machines in the rsyncd inventory.
+
+# Counts are equal.
+clear
+load 1m
+    up{service="rsyncd", machine="a", experiment="foo"} 1
+    up{service="ssh806", machine="b"} 1
+
+eval instant at 0m count(up{service="ssh806"}) - scalar( count( count BY(machine) (up{service="rsyncd"}))) != 0
+# EMPTY RESULT
+
+# Counts are not equal.
+clear
+load 1m
+    up{service="rsyncd", machine="a", experiment="foo"} 1
+    up{service="rsyncd", machine="b", experiment="foo"} 1
+    up{service="ssh806", machine="c"} 1
+
+eval instant at 0m count(up{service="ssh806"}) - scalar( count( count BY(machine) (up{service="rsyncd"}))) != 0
+    {} -1
+
+
+# For a complete check, the set of machines that do not have rsyncd services,
+# and the set of rsyncd servers that are not on inventory machines, should both
+# be empty.
+
+clear
+load 1m
+    up{service="rsyncd", machine="a", experiment="foo"} 1
+    up{service="rsyncd", machine="b", experiment="foo"} 1
+    up{service="ssh806", machine="b"} 1
+    up{service="ssh806", machine="c"} 1
+
+# Identify ssh806 that do not have a corresponding rsyncd.
+eval instant at 0m up{service="ssh806"} UNLESS ON(machine) up{service="rsyncd"}
+    up{service="ssh806", machine="c"} 1
+
+# Identify rsyncd that do not have a corresponding ssh806.
+eval instant at 0m up{service="rsyncd"} UNLESS ON(machine) up{service="ssh806"}
+    up{service="rsyncd", machine="a", experiment="foo"} 1


### PR DESCRIPTION
This change adds a command that runs as a golang test and evaluates prometheus queries. The intention is to provide a way of verifying that our alert queries behave correctly with synthetic data.

Currently, Prometheus does not support unit tests on alert rules (though it is desired https://github.com/prometheus/prometheus/issues/1695).

For now, the `query_tester` uses the test framework that prometheus uses to test itself. Note that this syntax is not an officially supported language. But, having the ability to test queries used in our alerts, in some form, is much better than untested (or ad-hoc manual "integration" testing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/30)
<!-- Reviewable:end -->
