### PR TITLE
Add service definitions for mlab-oti & deploy scripts

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# apply-cluster.sh applies the k8s cluster configuration to the currently
+# configured cluster. This script may be safely run multiple times to load the
+# most recent configurations.
+#
+# Example:
+#
+#   ./apply-cluster.sh
+
+set -x
+set -e
+set -u
+
+# Deployent dependencies.
+kubectl apply -f k8s/storage-class.yml
+kubectl apply -f k8s/persistent-volumes.yml
+
+# Prometheus config map.
+kubectl create configmap prometheus-cluster-config \
+    --from-file=config/cluster/prometheus \
+    --dry-run -o json | kubectl apply -f -
+
+# Deployments.
+kubectl apply -f k8s/cluster/prometheus.yml
+kubectl apply -f k8s/node-exporter-daemonset.yml

--- a/apply-federation.sh
+++ b/apply-federation.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# apply-federation.sh applies the k8s federation configuration to the currently
+# configured cluster. This script may be safely run multiple times to load the
+# most recent configurations.
+#
+# If a config file (config/*) changes, the pod does not automatically restart
+# when the configmap for that config file is updated. You must manually delete
+# the pod, and kubernetes will recreate it with the new config.
+#
+# Example:
+#
+# GRAFANA_DOMAIN=status-mlab-staging.measurementlab.net \
+#   GRAFANA_PASSWORD=<password> \
+#   ALERTMANAGER_URL=http://status-mlab-staging.measurementlab.net:9093 \
+#   ./apply-federation.sh mlab-staging
+
+set -x
+set -e
+set -u
+
+USAGE="$0 <projectid> [<grafana passwd>]"
+PROJECT=${1:?Please provide project id: $USAGE}
+
+# Deployent dependencies.
+kubectl apply -f k8s/storage-class.yml
+kubectl apply -f k8s/persistent-volumes.yml
+
+# Services.
+kubectl apply -f k8s/${PROJECT}/prometheus-federation
+
+# Config maps and Secrets
+
+## Blackbox exporter.
+kubectl create configmap blackbox-config \
+    --from-file=config/federation/blackbox \
+    --dry-run -o json | kubectl apply -f -
+
+## Prometheus
+kubectl create configmap prometheus-federation-config \
+    --from-literal=gcloud-project=${PROJECT} \
+    --from-file=config/federation/prometheus \
+    --dry-run -o json | kubectl apply -f -
+
+## Grafana
+kubectl create configmap grafana-config \
+    --from-file=config/federation/grafana \
+    --dry-run -o json | kubectl apply -f -
+
+if [[ -n "$GRAFANA_PASSWORD" ]] ; then
+  kubectl create secret generic grafana-secrets \
+      "--from-literal=admin-password=${GRAFANA_PASSWORD}" \
+      --dry-run -o json | kubectl apply -f -
+fi
+if [[ -n "${GRAFANA_DOMAIN}" ]] ; then
+  kubectl create configmap grafana-env \
+      "--from-literal=domain=${GRAFANA_DOMAIN}" \
+      --dry-run -o json | kubectl apply -f -
+fi
+
+## Alertmanager
+kubectl create configmap alertmanager-config \
+    --from-file=config/federation/alertmanager \
+    --dry-run -o json | kubectl apply -f -
+
+if [[ -n "${ALERTMANAGER_URL}" ]] ; then
+    kubectl create configmap alertmanager-env \
+        "--from-literal=external-url=${ALERTMANAGER_URL}" \
+        --dry-run -o json | kubectl apply -f -
+fi
+
+# Deployments
+kubectl apply -f k8s/node-exporter-daemonset.yml
+kubectl apply -f k8s/federation/blackbox.yml
+kubectl apply -f k8s/federation/grafana.yml
+kubectl apply -f k8s/federation/prometheus.yml
+kubectl apply -f k8s/federation/alertmanager.yml

--- a/k8s/mlab-oti/prometheus-federation/alertmanager-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/alertmanager-public-service.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9093'
+  name: alertmanager-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9093
+    protocol: TCP
+    targetPort: 9093
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: alertmanager-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.81.106
+  type: ClusterIP

--- a/k8s/mlab-oti/prometheus-federation/blackbox-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/blackbox-public-service.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # The grafana web server does not export any prometheus metrics.
+    prometheus.io/scrape: 'false'
+  name: blackbox-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9115
+    protocol: TCP
+    targetPort: 9115
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: blackbox-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.81.106
+  type: ClusterIP

--- a/k8s/mlab-oti/prometheus-federation/grafana-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/grafana-public-service.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # The grafana web server does not export any prometheus metrics.
+    prometheus.io/scrape: 'false'
+  name: grafana-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: grafana-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.81.106
+  type: ClusterIP

--- a/k8s/mlab-oti/prometheus-federation/prometheus-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/prometheus-public-service.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+  name: prometheus-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: prometheus-server
+  sessionAffinity: None
+  # Allocate a static IP manually in GCP console: Networking -> Load Balancing.
+  externalIPs:
+    - 35.184.81.106
+  type: ClusterIP

--- a/k8s/mlab-oti/prometheus-federation/pushgateway-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/pushgateway-public-service.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9091
+    protocol: TCP
+    targetPort: 9091
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: pushgateway-server
+  sessionAffinity: None
+  # Use the same static IP as used for Prometheus.
+  externalIPs:
+    # Use the same IP as above, since we're on a different port.
+    - 35.184.81.106
+  type: ClusterIP


### PR DESCRIPTION
This change adds k8s service definitions for the mlab-oti deployment of the prometheus-federation cluster.

As well, we add two `apply-*` scripts that will make it easier to deploy changes in the future.