### PR TITLE
Allow longer timeouts for collection from federated clusters.

### DIFF
--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -253,6 +253,8 @@ scrape_configs:
     # them as-is.
     honor_labels: true
     metrics_path: '/federate'
+    # Allow more time, since the number of metrics may be large.
+    scrape_timeout: 50s
 
     params:
       'match[]':


### PR DESCRIPTION
The scrape interval is every 60seconds and the default timeout is 10seconds.

This change increases the scrape timeout to 50s only for federation collection. This is not because collection *should* take that long or even that we want to allow it to take that long, but so that we have more headroom to monitor deployments with longer collection times than the default (10s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/34)
<!-- Reviewable:end -->
