### PR TITLE
Add basic travis support to prometheus-support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+ - 1.8.1
+
 # Unconditionally place the repo at GOPATH/src/${go_import_path} to support
 # forks.
 go_import_path: github.com/m-lab/prometheus-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+# Unconditionally place the repo at GOPATH/src/${go_import_path} to support
+# forks.
+go_import_path: github.com/m-lab/prometheus-support
+
+install:
+- go install github.com/prometheus/prometheus/cmd/promtool
+
+script:
+# Run query "unit tests".
+- go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn
+
+# Use promtool to check current alerts and rules. This is only a syntax check.
+- promtool check-rules config/federation/prometheus/alerts.yml
+- promtool check-rules config/federation/prometheus/rules.yml
+
+# TODO(soltesz): support check-config.
+# promtool check-config config/federation/prometheus/prometheus.yml
+# promtool check-config config/cluster/prometheus/prometheus.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 go_import_path: github.com/m-lab/prometheus-support
 
 install:
-- go install github.com/prometheus/prometheus/cmd/promtool
+- go get github.com/prometheus/prometheus/cmd/promtool
 
 script:
 # Run query "unit tests".

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status][svg]][travis]
+[svg]: https://travis-ci.org/m-lab/prometheus-support.svg?branch=master
+[travis]: https://travis-ci.org/m-lab/prometheus-support
+
 # prometheus-support
 
 Prometheus configuration for M-Lab.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status][svg]][travis]
+
 [svg]: https://travis-ci.org/m-lab/prometheus-support.svg?branch=master
 [travis]: https://travis-ci.org/m-lab/prometheus-support
 


### PR DESCRIPTION
This change adds basic travis support for running the query unit tests and applying a rules check with `promtool`.

https://travis-ci.org/stephen-soltesz/prometheus-support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/35)
<!-- Reviewable:end -->
