### PR TITLE
Add Scraper alert tests & actual alert definitions

### DIFF
--- a/cmd/query_tester/testdata/machine-slo.txt
+++ b/cmd/query_tester/testdata/machine-slo.txt
@@ -1,0 +1,36 @@
+# Machine SLO.
+#
+# Ensure that sidestream is running on every online machine, so that we can
+# read machine up time.
+#
+# When both the machine and sidestream are online or offline, return nothing.
+
+
+# Machine and sidestream are online.
+clear
+load 1m
+    probe_success{service="ssh806", machine="mlab1-sidestream-online"} 1+0x20
+    up{service="sidestream", machine="mlab1-sidestream-online"} 1+0x20
+
+eval instant at 20m sum_over_time(up{service="sidestream"}[10m]) == 0 AND ON(machine) sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+# EMPTY RESULT.
+
+
+# Machine is online, but sidestream is offline.
+clear
+load 1m
+    probe_success{service="ssh806", machine="mlab1-sidestream-offline"} 1+0x20
+    up{service="sidestream", machine="mlab1-sidestream-offline"} 0+0x20
+
+eval instant at 20m sum_over_time(up{service="sidestream"}[10m]) == 0 AND ON(machine) sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+    {service="sidestream", machine="mlab1-sidestream-offline"} 0
+
+
+# Machine and sidestream are offline.
+clear
+load 1m
+    probe_success{service="ssh806", machine="mlab1"} 0+0x20
+    up{service="sidestream", machine="mlab1"} 0+0x20
+
+eval instant at 20m sum_over_time(up{service="sidestream"}[10m]) == 0 AND ON(machine) sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+# EMPTY RESULT.

--- a/cmd/query_tester/testdata/scraper-slo.txt
+++ b/cmd/query_tester/testdata/scraper-slo.txt
@@ -1,0 +1,77 @@
+# Scraper SLO
+#
+# Stale collection from healthy machines.
+#
+# The set of all scrapers that have a max file time greater than 36 hours AND
+# whose machines have been online for more than two hours (according to the
+# sidestream exporter).
+#
+# Constant: 36h == 36 * 60 * 60 sec == 129600 ; 130000 > (36 * 60 * 60)
+# Constant: 36h == 60 * 36 min == 2160
+# Constant:  2h ==  2 * 60 * 60 sec == 7200 ; 7500 > 7200
+
+# NOTE:
+#
+# time() begins at 0.
+#
+# Use initial values here that are negative, so that at evaluation time (36h),
+# the difference between time and the metric value at 36h is greater than the
+# 36h and 2h thresholds.
+
+clear
+load 1m
+    scraper_maxrawfiletimearchived{service="scraper-sync", machine="a"} -130000+60x2160
+    process_start_time_seconds{service="sidestream", machine="a"} -7500+60x2160
+
+# Sanity checks.
+eval instant at 36h time()
+    129600
+
+eval instant at 36h (time() - scraper_maxrawfiletimearchived{service="scraper-sync"})
+    {service="scraper-sync", machine="a"} 130000
+
+eval instant at 36h (time() - process_start_time_seconds{service="sidestream"})
+    {machine="a", service="sidestream"} 7500
+
+# SLO query.
+#
+# (time() - scraper_maxrawfiletimearchived{service="scraper-sync"}) > (36 * 60 * 60)
+#    AND ON(machine)
+#       (time() - process_start_time_seconds{service=”sidestream”}) > (2 * 60 * 60)
+eval instant at 36h (time() - scraper_maxrawfiletimearchived{service="scraper-sync"}) > (36 * 60 * 60) AND ON(machine) (time() - process_start_time_seconds{service="sidestream"}) > (2 * 60 * 60)
+    {service="scraper-sync", machine="a"} 130000
+
+
+# Scraper and Scraper-sync correspondence.
+
+# Correct configuration.
+#
+# The set of scrapers and metrics in scraper-sycn are completely matched.
+clear
+load 1m
+    scraper_maxrawfiletimearchived{service="scraper-sync", machine="mlab1.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+    up{service="scraper", machine="mlab1.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+
+eval instant at 1m (scraper_maxrawfiletimearchived{service="scraper-sync"} UNLESS ON(machine, experiment, rsync_module) up{service="scraper"})
+# EMPTY RESULT.
+
+eval instant at 1m (up{service="scraper"} UNLESS ON(machine, experiment, rsync_module) scraper_maxrawfiletimearchived{service="scraper-sync"})
+# EMPTY RESULT.
+
+
+# Incorrect configuration.
+#
+# There is an extra scraper-sync on mlab2.
+# There is an extra scraper on mlab3.
+clear
+load 1m
+    scraper_maxrawfiletimearchived{service="scraper-sync", machine="mlab1.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+    scraper_maxrawfiletimearchived{service="scraper-sync", machine="mlab2.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+    up{service="scraper", machine="mlab1.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+    up{service="scraper", machine="mlab3.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+
+eval instant at 1m (scraper_maxrawfiletimearchived{service="scraper-sync"} UNLESS ON(machine, experiment, rsync_module) up{service="scraper"})
+    scraper_maxrawfiletimearchived{service="scraper-sync", machine="mlab2.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1
+
+eval instant at 1m (up{service="scraper"} UNLESS ON(machine, experiment, rsync_module) scraper_maxrawfiletimearchived{service="scraper-sync"})
+    up{service="scraper", machine="mlab3.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1

--- a/cmd/query_tester/testdata/scraper-slo.txt
+++ b/cmd/query_tester/testdata/scraper-slo.txt
@@ -46,7 +46,7 @@ eval instant at 36h (time() - scraper_maxrawfiletimearchived{service="scraper-sy
 
 # Correct configuration.
 #
-# The set of scrapers and metrics in scraper-sycn are completely matched.
+# The set of scrapers and metrics in scraper-sync are completely matched.
 clear
 load 1m
     scraper_maxrawfiletimearchived{service="scraper-sync", machine="mlab1.lga0t", experiment="ndt.iupui", rsync_module="ndt"} 1

--- a/cmd/query_tester/testdata/scraper.txt
+++ b/cmd/query_tester/testdata/scraper.txt
@@ -1,0 +1,55 @@
+# Scraper and rsyncd.
+
+# Correct Configuration.
+clear
+load 1m
+    up{service="scraper", machine="a", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="a", experiment="npad", rsync_module="npad"} 1
+    up{service="scraper", machine="b", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="b", experiment="npad", rsync_module="npad"} 1
+    up{service="rsyncd", machine="a", experiment="npad"} 1
+    up{service="rsyncd", machine="b", experiment="npad"} 1
+
+# The number of targets per machine matches the number of rsync_modules globally.
+eval instant at 0m count BY(machine) (up{service="scraper"}) - scalar( count( count BY(rsync_module) (up{service="scraper"}))) != 0
+# EMPTY RESULT.
+
+# The set of monitored scraper targets that are on inventory machines.
+eval instant at 0m up{service="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
+# EMPTY RESULT.
+
+# The set of rsync inventory that do not have scraper services.
+eval instant at 0m up{service="rsyncd"} UNLESS ON(machine, experiment) up{service="scraper"}
+# EMPTY RESULT.
+
+# Incorrect Configuration.
+clear
+load 1m
+    up{service="scraper", machine="a", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="a", experiment="npad", rsync_module="npad"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="npad"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="paris-traceroute"} 1
+
+# Machine "a" does not have three rsync_module targets.
+eval instant at 0m count BY(machine) (up{service="scraper"}) - scalar( count( count BY(rsync_module) (up{service="scraper"}))) != 0
+    {machine="a"} -1
+
+
+clear
+load 1m
+    up{service="scraper", machine="a", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="a", experiment="npad", rsync_module="npad"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="npad"} 1
+    up{service="rsyncd", machine="a", experiment="npad"} 1
+    up{service="rsyncd", machine="b", experiment="npad"} 1
+
+# Scrapers are configured on machine "c", but machine "c" is not in the rsyncd inventory.
+eval instant at 0m up{service="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
+    up{service="scraper", machine="c", experiment="npad", rsync_module="sidestream"} 1
+    up{service="scraper", machine="c", experiment="npad", rsync_module="npad"} 1
+
+# Rsync inventory includes machine "b", but machine "b" does not have a configured scraper.
+eval instant at 0m up{service="rsyncd"} UNLESS ON(machine, experiment) up{service="scraper"}
+    up{service="rsyncd", machine="b", experiment="npad"} 1

--- a/cmd/query_tester/testdata/sidestream.txt
+++ b/cmd/query_tester/testdata/sidestream.txt
@@ -1,0 +1,54 @@
+# Sidestream exporter.
+#
+# Sidestream is a core service on M-Lab servers. And, it provides a proxy for
+# machine uptime. The sidestream service and machine inventory should match.
+
+# Correct configuration.
+clear
+load 1m
+    up{service="sidestream", machine="a"} 1
+    up{service="sidestream", machine="b"} 1
+    up{service="ssh806", machine="a"} 1
+    up{service="ssh806", machine="b"} 1
+
+# Since it's a core service, it should be monitored.
+eval instant at 0m absent(up{service="sidestream"})
+# EMPTY RESULT.
+
+# Guarantee that there are as many machines as configured sidestream targets.
+eval instant at 0m count(up{service="sidestream"}) - scalar(count(up{service="ssh806"})) != 0
+# EMPTY RESULT.
+
+# Identify sidestream exporters that do not have a corresponding ssh806.
+eval instant at 0m up{service="sidestream"} UNLESS ON(machine) up{service="ssh806"}
+# EMPTY RESULT.
+
+# Identify ssh806 servers that do not have a corresponding sidestream exporter.
+eval instant at 0m up{service="ssh806"} UNLESS ON(machine) up{service="sidestream"}
+# EMPTY RESULT.
+
+
+# Incorrect configuration.
+#
+# The configuration has a sidestrea service without a corresponding machine.
+# And, two machines without sidestream services.
+clear
+load 1m
+    up{service="sidestream", machine="a"} 1
+    up{service="sidestream", machine="b"} 1
+    up{service="ssh806", machine="a"} 1
+    up{service="ssh806", machine="c"} 1
+    up{service="ssh806", machine="d"} 1
+
+# Guarantee that there are as many machines as configured sidestream targets.
+eval instant at 0m count(up{service="sidestream"}) - scalar(count(up{service="ssh806"})) != 0
+    {} -1
+
+# Identify sidestream exporters that do not have a corresponding ssh806.
+eval instant at 0m up{service="sidestream"} UNLESS ON(machine) up{service="ssh806"}
+    up{service="sidestream", machine="b"} 1
+
+# Identify ssh806 servers that do not have a corresponding sidestream exporter.
+eval instant at 0m up{service="ssh806"} UNLESS ON(machine) up{service="sidestream"}
+    up{service="ssh806", machine="c"} 1
+    up{service="ssh806", machine="d"} 1

--- a/cmd/query_tester/testdata/sidestream.txt
+++ b/cmd/query_tester/testdata/sidestream.txt
@@ -30,7 +30,7 @@ eval instant at 0m up{service="ssh806"} UNLESS ON(machine) up{service="sidestrea
 
 # Incorrect configuration.
 #
-# The configuration has a sidestrea service without a corresponding machine.
+# The configuration has a sidestream service without a corresponding machine.
 # And, two machines without sidestream services.
 clear
 load 1m

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -24,6 +24,8 @@
 
 # ClusterDown: when any of the federated prometheus k8s clusters is down for
 # three sample periods, then raise an alert.
+#
+# All scraper metrics come from federated targets, so this is critical.
 ALERT ClusterDown
   IF up{job="federation-targets"} == 0
   FOR 3m
@@ -35,6 +37,77 @@ ALERT ClusterDown
     description = "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 2 minutes.",
   }
 
+##
+## SLOs
+##
+
+# MachineSLO
+#
+# SidestreamIsNotRunning: an M-Lab server is online, but the sidestream exporter
+# is not. Since sidestream is a core service, this must be fixed.
+ALERT SidestreamIsNotRunning
+  IF sum_over_time(up{service="sidestream"}[10m]) == 0
+        AND ON(machine)
+           sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+  FOR 10m
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "",
+    description = "",
+  }
+
+
+# ScraperSLO
+#
+# ScraperMostRecentArchivedFileTimeIsTooOld: scraper uploads archives for a
+# machine once a day. If the machine is online (for at least 2 hours), but
+# scraper has not uploaded an archive for that machine for more than 36 hours,
+# there is a problem.
+ALERT ScraperMostRecentArchivedFileTimeIsTooOld
+  IF (time() - scraper_maxrawfiletimearchived{service="scraper-sync"}) > (36 * 60 * 60)
+        AND ON(machine)
+           (time() - process_start_time_seconds{service="sidestream"}) > (2 * 60 * 60)
+  FOR 10m
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
+    description = "Max file mtime for {{ $labels.rsync_url }} is older than 40 hours.",
+  }
+
+# Scraper internal consistency.
+#
+# ScraperSyncPresentWithoutScaperCollector,
+#   ScraperCollectorMissingFromScaperSync:
+#
+ALERT ScraperSyncPresentWithoutScaperCollector
+  IF (scraper_maxrawfiletimearchived{service="scraper-sync"}
+        UNLESS ON(machine, experiment, rsync_module)
+           up{service="scraper"})
+  FOR 3h
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "",
+    description = "",
+  }
+
+ALERT ScraperCollectorMissingFromScaperSync
+  IF (up{service="scraper"}
+        UNLESS ON(machine, experiment, rsync_module)
+           scraper_maxrawfiletimearchived{service="scraper-sync"})
+  FOR 3h
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "",
+    description = "",
+  }
 
 ##
 ## Inventory.
@@ -49,8 +122,7 @@ ALERT InventoryConfigurationIsMissing
   ANNOTATIONS {
     summary = "Inventory configuration {{ $labels.service }} is missing.",
     description = "Machine or rsyncd service configuration has been missing for too long.",
-    hints = "Check the behavior of the m-lab/operator/.travis.yml deployment,
-             the GCS buckets, and the gcp-service-discovery component of prometheus-support.",
+    hints = "Check the behavior of the m-lab/operator/.travis.yml deployment, the GCS buckets, and the gcp-service-discovery component of prometheus-support.",
   }
 
 ALERT InventoryMachinesWithoutRsyncd
@@ -113,49 +185,29 @@ ALERT MachineWithoutSidestreamRunning
     hints = "",
   }
 
-
-##
-##
-##
 # Scrapers are configured on machine "c", but machine "c" is not in the rsyncd inventory.
-# ALERT ScraperRunningWithoutRsyncd
-# up{service="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
-
-# Rsync inventory includes machine "b", but machine "b" does not have a configured scraper.
-# ALERT RsyncRunningWithoutScraper
-# up{service="rsyncd"} UNLESS ON(machine, experiment) up{service="scraper"}
-
-
-
-##
-## SLOs
-##
-
-# MachineSLO
-ALERT SidestreamIsNotRunning
-  IF sum_over_time(up{service="sidestream"}[10m]) == 0
-        AND ON(machine)
-           sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
-  FOR 10m
+ALERT ScraperRunningWithoutRsyncd
+  IF up{service="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
+  FOR 30m
   LABELS {
-    severity = "page"
+    severity = "ticket"
   }
   ANNOTATIONS {
     summary = "",
-    description = "",
+    hints = "",
   }
 
-
-# ScraperSLO
-ALERT ScraperMostRecentArchivedFileTimeIsTooOld
-  IF (time() - scraper_maxrawfiletimearchived{service="scraper-sync"}) > (36 * 60 * 60)
-        AND ON(machine)
-           (time() - process_start_time_seconds{service=”sidestream”}) > (2 * 60 * 60)
-  FOR 10m
+# Rsync inventory includes machine "b", but machine "b" does not have a configured scraper.
+ALERT RsyncRunningWithoutScraper
+  IF up{service="rsyncd"} UNLESS ON(machine, experiment) up{service="scraper"}
+  FOR 30m
   LABELS {
-    severity = "page"
+    severity = "ticket"
   }
   ANNOTATIONS {
-    summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
-    description = "Max file mtime for {{ $labels.rsync_url }} is older than 40 hours.",
+    summary = "",
+    hints = "",
   }
+
+
+

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -34,3 +34,128 @@ ALERT ClusterDown
     summary = "Instance {{ $labels.instance }} down",
     description = "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 2 minutes.",
   }
+
+
+##
+## Inventory.
+##
+
+ALERT InventoryConfigurationIsMissing
+  IF absent(up{service="ssh806"}) OR absent(up{service="rsyncd"})
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "Inventory configuration {{ $labels.service }} is missing.",
+    description = "Machine or rsyncd service configuration has been missing for too long.",
+    hints = "Check the behavior of the m-lab/operator/.travis.yml deployment,
+             the GCS buckets, and the gcp-service-discovery component of prometheus-support.",
+  }
+
+ALERT InventoryMachinesWithoutRsyncd
+  IF up{service="ssh806"} UNLESS ON(machine) up{service="rsyncd"}
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "Rsyncd configuration is missing from some machines.",
+    hints = "",
+  }
+
+ALERT InventoryRsyncdWithoutMachines
+  IF up{service="rsyncd"} UNLESS ON(machine) up{service="ssh806"}
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "Machine configuration is missing for some rsyncd services.",
+    hints = "",
+  }
+
+
+##
+## Services.
+##
+
+ALERT SidestreamServicesAreMissing
+  IF absent(up{service="sidestream"})
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "",
+    hints = "",
+  }
+
+ALERT SidestreamRunningWithoutMachine
+  IF up{service="sidestream"} UNLESS ON(machine) up{service="ssh806"}
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "",
+    hints = "",
+  }
+
+ALERT MachineWithoutSidestreamRunning
+  IF up{service="ssh806"} UNLESS ON(machine) up{service="sidestream"}
+  FOR 30m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "",
+    hints = "",
+  }
+
+
+##
+##
+##
+# Scrapers are configured on machine "c", but machine "c" is not in the rsyncd inventory.
+# ALERT ScraperRunningWithoutRsyncd
+# up{service="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
+
+# Rsync inventory includes machine "b", but machine "b" does not have a configured scraper.
+# ALERT RsyncRunningWithoutScraper
+# up{service="rsyncd"} UNLESS ON(machine, experiment) up{service="scraper"}
+
+
+
+##
+## SLOs
+##
+
+# MachineSLO
+ALERT SidestreamIsNotRunning
+  IF sum_over_time(up{service="sidestream"}[10m]) == 0
+        AND ON(machine)
+           sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+  FOR 10m
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "",
+    description = "",
+  }
+
+
+# ScraperSLO
+ALERT ScraperMostRecentArchivedFileTimeIsTooOld
+  IF (time() - scraper_maxrawfiletimearchived{service="scraper-sync"}) > (36 * 60 * 60)
+        AND ON(machine)
+           (time() - process_start_time_seconds{service=”sidestream”}) > (2 * 60 * 60)
+  FOR 10m
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
+    description = "Max file mtime for {{ $labels.rsync_url }} is older than 40 hours.",
+  }


### PR DESCRIPTION
This change includes the remaining "unit tests" for the scraper alerts in the query_tester testdata directory.

As well, this change introduces the initial version of actual alert definitions that depend on the tested queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/39)
<!-- Reviewable:end -->
