### PR TITLE
Change pod service discovery to include all explicitly declared containerPorts

### DIFF
--- a/config/cluster/prometheus/prometheus.yml
+++ b/config/cluster/prometheus/prometheus.yml
@@ -137,13 +137,19 @@ scrape_configs:
       - role: pod
 
     relabel_configs:
+      # If the pod is ready, keep it. Otierwise, ignore it.
+      - source_labels: [__meta_kubernetes_pod_ready]
+        regex: true
+        action: keep
+
       # Check for the prometheus.io/scrape=true annotation.
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
+
       # Check for the prometheus.io/port=<port> annotation.
-      - source_labels: [__address__,
-                        __meta_kubernetes_pod_annotation_prometheus_io_port]
+      # Check for the declared container port number.
+      - source_labels: [__address__, __meta_kubernetes_pod_container_port_number]
         action: replace
         target_label: __address__
         # A google/re2 regex, matching addresses with or without default ports.
@@ -151,19 +157,40 @@ scrape_configs:
         # IPv4 addresses for internal network and GCE doesn not support IPv6.
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
+
       # Copy all pod labels from kubernetes to the Prometheus metrics.
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+
       # Add the kubernetes namespace as a Prometheus label.
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
+
+      # Extract the cluster-pool name from the GKE node name.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        regex: gke-(.*)-[^-]+-[^-]+
+        replacement: $1
+        target_label: cluster
+
+      # bug: this truncates pod names from daemon sets.
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        regex: (.*)-[^-]+-[^-]+
+        replacement: $1
+        target_label: deployment
+
       # Add the kubernetes pod name as a Prometheus label.
       # TODO(soltesz): pod names include a randomly generated portion. This
       # could make historical queries more complex. Do we need this?
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: kubernetes_pod_name
+        target_label: pod
+
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: container
 
 
   # Scrape config for kubernetes service endpoints.

--- a/config/cluster/prometheus/prometheus.yml
+++ b/config/cluster/prometheus/prometheus.yml
@@ -167,28 +167,31 @@ scrape_configs:
       # Extract the "<cluster>-<node-pool>" name from the GKE node name.
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
-        regex: gke-(.*)-[^-]+-[^-]+
+        regex: gke-(.*)(-[^-]+){2}
         replacement: $1
         target_label: cluster
 
-      # Copy a portion of the pod name corresponding to the deployment. This
-      # requires two steps. Two steps are necessary to handle both daemon sets
-      # and deployments correctly.
-      # Step 1: unconditionally remove the last field of a pod name.
-      #   e.g. prometheus-server-3165440997(-ppf9w)
+      # Identify the deployment name of a pod or daemon set. This requires two
+      # steps. Two steps are necessary to handle both daemon set pod names and
+      # deployment pod names correctly. And, because, evidently, a combined
+      # regex doesn't work as expected.
+      #
+      # Step 1: unconditionally remove the last field of a pod or daemonset.
+      #   e.g. prometheus-server-3165440997-ppf9w
+      #   e.g. node-exporter-ltxgz
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)-[^-]+
+        regex: (.*)(-[^-]{5})
         replacement: $1
         target_label: deployment
 
-      # Step 2: Remove the next trailing field if it's the same as
-      # pod_template_hash. The source labels construct a pattern like:
-      #   e.g. prometheus-server-3165440997-3165440997
-      - source_labels: [deployment, __meta_kubernetes_pod_label_pod_template_hash]
+      # Step 2: Remove the trailing pod_template_hash if present.
+      # In the case of a daemon set that does not have the trailing hash, the
+      # regex will not match and deployment remains unchanged.
+      #   e.g. prometheus-server-3165440997
+      - source_labels: [deployment]
         action: replace
-        separator: '-'
-        regex: (.*)(-[^-]+){2}
+        regex: (.*)(-[0-9]+)
         replacement: $1
         target_label: deployment
 

--- a/config/cluster/prometheus/prometheus.yml
+++ b/config/cluster/prometheus/prometheus.yml
@@ -124,39 +124,36 @@ scrape_configs:
   # Kubernetes pods are scraped when they have an annotation:
   #   `prometheus.io/scrape=true`.
   #
-  # Port 80 is sraped by default. To use a different port, use the annotation:
-  #   `prometheus.io/port=9090`.
+  # Only container that include an explicit containerPort declaration are
+  # scraped. For example:
+  #
+  #      ports:
+  #        - containerPort: 9090
   #
   # Configuration expects the default HTTP protocol scheme.
   # Configuration expects the default path of /metrics on targets.
-  #
-  # NB: Pods report every declared container port. So, it's possible that not
-  # all ports will be instrumented. So, in the future, we may add some filters.
   - job_name: 'kubernetes-pods'
     kubernetes_sd_configs:
       - role: pod
 
     relabel_configs:
-      # If the pod is ready, keep it. Otierwise, ignore it.
+      # For inventory, record whether a pod is ready. This helps distinguish
+      # between: missing from inventory, not ready and failing, ready but
+      # failing, ready and working.
+      # and working.
       - source_labels: [__meta_kubernetes_pod_ready]
-        regex: true
-        action: keep
+        action: replace
+        target_label: ready
 
       # Check for the prometheus.io/scrape=true annotation.
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
 
-      # Check for the prometheus.io/port=<port> annotation.
-      # Check for the declared container port number.
-      - source_labels: [__address__, __meta_kubernetes_pod_container_port_number]
-        action: replace
-        target_label: __address__
-        # A google/re2 regex, matching addresses with or without default ports.
-        # NB: this will not work with IPv6 addresses. But, atm, kubernetes uses
-        # IPv4 addresses for internal network and GCE doesn not support IPv6.
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
+      # Only keep containers that have a declared container port.
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: (\d+)
 
       # Copy all pod labels from kubernetes to the Prometheus metrics.
       - action: labelmap
@@ -167,27 +164,40 @@ scrape_configs:
         action: replace
         target_label: namespace
 
-      # Extract the cluster-pool name from the GKE node name.
+      # Extract the "<cluster>-<node-pool>" name from the GKE node name.
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         regex: gke-(.*)-[^-]+-[^-]+
         replacement: $1
         target_label: cluster
 
-      # bug: this truncates pod names from daemon sets.
+      # Copy a portion of the pod name corresponding to the deployment. This
+      # requires two steps. Two steps are necessary to handle both daemon sets
+      # and deployments correctly.
+      # Step 1: unconditionally remove the last field of a pod name.
+      #   e.g. prometheus-server-3165440997(-ppf9w)
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)-[^-]+-[^-]+
+        regex: (.*)-[^-]+
         replacement: $1
         target_label: deployment
 
-      # Add the kubernetes pod name as a Prometheus label.
-      # TODO(soltesz): pod names include a randomly generated portion. This
-      # could make historical queries more complex. Do we need this?
+      # Step 2: Remove the next trailing field if it's the same as
+      # pod_template_hash. The source labels construct a pattern like:
+      #   e.g. prometheus-server-3165440997-3165440997
+      - source_labels: [deployment, __meta_kubernetes_pod_label_pod_template_hash]
+        action: replace
+        separator: '-'
+        regex: (.*)(-[^-]+){2}
+        replacement: $1
+        target_label: deployment
+
+      # Add the kubernetes pod name.
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
 
+      # Add the kubernetes pod container name.
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: container

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -4,8 +4,8 @@ metadata:
   name: prometheus-public-service
   namespace: default
   annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '9090'
+    # prometheus.io/scrape: 'true'
+    # prometheus.io/port: '9090'
     gke-prometheus-federation/scrape: 'true'
 spec:
   ports:
@@ -44,7 +44,7 @@ spec:
         # Tell prometheus service discovery to scrape the node-exporter running
         # within the prometheus-server pod.
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '9100'
+        # prometheus.io/port: '9100'
     spec:
       # Clusters running a prometheus instance must label nodes exclusively for
       # use by prometheus. See README for steps to create a GKE cluster for
@@ -74,11 +74,11 @@ spec:
           - containerPort: 9090
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "3000m"
+            memory: "3Gi"
+            cpu: "500m"
           limits:
-            memory: "8Gi"
-            cpu: "3000m"
+            memory: "3Gi"
+            cpu: "500m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus
@@ -88,6 +88,18 @@ spec:
         - mountPath: /legacy-targets
           name: prometheus-storage
           subPath: legacy-targets
+        # /federation-targets should contain federation target config files.
+        - mountPath: /federation-targets
+          name: prometheus-storage
+          subPath: federation-targets
+        # /blackbox-targets should contain blackbox target config files.
+        - mountPath: /blackbox-targets
+          name: prometheus-storage
+          subPath: blackbox-targets
+        # /aeflex-targets should contain AppEngine target config files.
+        - mountPath: /aeflex-targets
+          name: prometheus-storage
+          subPath: aeflex-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -111,6 +123,33 @@ spec:
             cpu: "50m"
         volumeMounts:
         - mountPath: /prometheus
+          name: prometheus-storage
+
+      - image: measurementlab/gcp-service-discovery
+        name: service-discovery
+        env:
+        - name: GCLOUD_PROJECT
+          value: mlab-sandbox
+        args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
+                "--gke-target=/targets/federation-targets/prometheus-clusters.json",
+                "--http-target=/targets/legacy-targets/sidestream.json",
+                "--http-target=/targets/blackbox-targets/ssh806.json",
+                "--http-target=/targets/blackbox-targets/rsyncd.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
+                "--project=$(GCLOUD_PROJECT)"]
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "50m"
+          limits:
+            memory: "150Mi"
+            cpu: "50m"
+        volumeMounts:
+        # Mount the the prometheus-storage for write access to the target
+        # directories.
+        - mountPath: /targets
           name: prometheus-storage
 
       # Disks created manually, can be named here explicitly using

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -4,8 +4,6 @@ metadata:
   name: prometheus-public-service
   namespace: default
   annotations:
-    # prometheus.io/scrape: 'true'
-    # prometheus.io/port: '9090'
     gke-prometheus-federation/scrape: 'true'
 spec:
   ports:
@@ -73,11 +71,11 @@ spec:
           - containerPort: 9090
         resources:
           requests:
-            memory: "3Gi"
-            cpu: "500m"
+            memory: "8Gi"
+            cpu: "3000m"
           limits:
-            memory: "3Gi"
-            cpu: "500m"
+            memory: "8Gi"
+            cpu: "3000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus
@@ -87,18 +85,6 @@ spec:
         - mountPath: /legacy-targets
           name: prometheus-storage
           subPath: legacy-targets
-        # /federation-targets should contain federation target config files.
-        - mountPath: /federation-targets
-          name: prometheus-storage
-          subPath: federation-targets
-        # /blackbox-targets should contain blackbox target config files.
-        - mountPath: /blackbox-targets
-          name: prometheus-storage
-          subPath: blackbox-targets
-        # /aeflex-targets should contain AppEngine target config files.
-        - mountPath: /aeflex-targets
-          name: prometheus-storage
-          subPath: aeflex-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -122,33 +108,6 @@ spec:
             cpu: "50m"
         volumeMounts:
         - mountPath: /prometheus
-          name: prometheus-storage
-
-      - image: measurementlab/gcp-service-discovery
-        name: gcp-service-discovery
-        env:
-        - name: GCLOUD_PROJECT
-          value: mlab-sandbox
-        args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
-                "--gke-target=/targets/federation-targets/prometheus-clusters.json",
-                "--http-target=/targets/legacy-targets/sidestream.json",
-                "--http-target=/targets/blackbox-targets/ssh806.json",
-                "--http-target=/targets/blackbox-targets/rsyncd.json",
-                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
-                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
-                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
-                "--project=$(GCLOUD_PROJECT)"]
-        resources:
-          requests:
-            memory: "150Mi"
-            cpu: "50m"
-          limits:
-            memory: "150Mi"
-            cpu: "50m"
-        volumeMounts:
-        # Mount the the prometheus-storage for write access to the target
-        # directories.
-        - mountPath: /targets
           name: prometheus-storage
 
       # Disks created manually, can be named here explicitly using

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -44,7 +44,6 @@ spec:
         # Tell prometheus service discovery to scrape the node-exporter running
         # within the prometheus-server pod.
         prometheus.io/scrape: 'true'
-        # prometheus.io/port: '9100'
     spec:
       # Clusters running a prometheus instance must label nodes exclusively for
       # use by prometheus. See README for steps to create a GKE cluster for
@@ -63,7 +62,7 @@ spec:
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
-        name: prometheus-server
+        name: prometheus
         # Note: Set retention time to 120 days. (default retention is 30d).
         args: ["-config.file=/etc/prometheus/prometheus.yml",
                "-storage.local.path=/prometheus",
@@ -108,7 +107,7 @@ spec:
       # access to the same namespace and volumes as the prometheus-server. This
       # allows simple disk usage monitoring of the "/prometheus" mount point.
       - image: prom/node-exporter:v0.13.0
-        name: fs-exporter
+        name: node-exporter
         # Note: only enable the filesystem collector, and ignore system paths.
         args: [ "--collectors.enabled=filesystem",
                 "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)"]
@@ -126,7 +125,7 @@ spec:
           name: prometheus-storage
 
       - image: measurementlab/gcp-service-discovery
-        name: service-discovery
+        name: gcp-service-discovery
         env:
         - name: GCLOUD_PROJECT
           value: mlab-sandbox


### PR DESCRIPTION
This change updates the pod service discovery behavior to use explicitly declared container ports as a way of identifying targets.

Also, this change updates the labels assigned to discovered k8s pod targets. In particular, the following labels are now assigned to pods:

 * container - the container name.
 * pod - the pod name.
 * deployment - the deployment name (derived from pod name)
 * namespace - the k8s namespace.
 * cluster - the k8s cluster and node-pool name.
 * ready - is the pod ready

TODO: if this works as intended, similar changes are needed to the `config/federation/prometheus` config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/40)
<!-- Reviewable:end -->
