### PR TITLE
Use latest Prometheus version with more RAM and SSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ gcloud container \
 
 No special scopes are required for the prometheus cluster configuration.
 
+However, for very large number of time series a highmem node pool is necessary.
+
 ```
 gcloud --project=mlab-oti container node-pools create prometheus-pool \
   --cluster=scraper-cluster \
   --num-nodes=2 \
   --zone=us-central1-a \
   --node-labels=prometheus-node=true \
-  --machine-type=n1-standard-8
+  --machine-type=n1-highmem-16
 ```
 
 # Using Kubernetes config files

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -56,26 +56,35 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.
-      - image: prom/prometheus:v1.5.2
+      - image: prom/prometheus:v1.6.3
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: prometheus
         # Note: Set retention time to 120 days. (default retention is 30d).
+        #
+        # See https://www.youtube.com/watch?v=hPC60ldCGm8 for ~recent
+        # configuration best practices.
+        #
+        # TODO(soltesz): we're setting -storage.local.target-heap-size to ~75%
+        # of available RAM. They recommend preserving a 50% headroom, but I'm
+        # setting it higher right now to over-provision and leave fine-tuning
+        # to a later step.
         args: ["-config.file=/etc/prometheus/prometheus.yml",
                "-storage.local.path=/prometheus",
                "-storage.local.retention=2880h",
+               "-storage.local.target-heap-size=75161927680",
                "-web.console.libraries=/usr/share/prometheus/console_libraries",
                "-web.console.templates=/usr/share/prometheus/consoles"]
         ports:
           - containerPort: 9090
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "3000m"
+            memory: "96Gi"
+            cpu: "8000m"
           limits:
-            memory: "8Gi"
-            cpu: "3000m"
+            memory: "96Gi"
+            cpu: "8000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus
@@ -115,7 +124,7 @@ spec:
       volumes:
       - name: prometheus-storage
         persistentVolumeClaim:
-          claimName: auto-prometheus-disk0
+          claimName: auto-prometheus-ssd0
       - name: prometheus-config
         configMap:
           name: prometheus-cluster-config

--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -70,6 +70,10 @@ spec:
         # of available RAM. They recommend preserving a 50% headroom, but I'm
         # setting it higher right now to over-provision and leave fine-tuning
         # to a later step.
+        #
+        # TODO(soltesz): Update these default values.
+        #   -storage.local.checkpoint-dirty-series-limit 5000
+        #   -storage.local.checkpoint-interval 5m0s
         args: ["-config.file=/etc/prometheus/prometheus.yml",
                "-storage.local.path=/prometheus",
                "-storage.local.retention=2880h",

--- a/k8s/persistent-volumes.yml
+++ b/k8s/persistent-volumes.yml
@@ -36,3 +36,16 @@ spec:
   resources:
     requests:
       storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: auto-prometheus-ssd0
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "fast"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi

--- a/k8s/storage-class.yml
+++ b/k8s/storage-class.yml
@@ -5,3 +5,11 @@ metadata:
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd


### PR DESCRIPTION
To accommodate the load generated by the scraper deployment in mlab-oti we're increasing the RAM used as well as using an SSD for metric storage.

This configuration has run over the weekend with 75% of the scraper instances. It is expected to remain stable at 100%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/43)
<!-- Reviewable:end -->
