### PR TITLE
Add new service to export k8s states

### DIFF
--- a/k8s/kube-state-metrics.yml
+++ b/k8s/kube-state-metrics.yml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        application: kube-state-metrics
+        version: "v0.5.0"
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        prometheus-node: 'true'
+      containers:
+      - name: kube-state-metrics
+        image: gcr.io/google_containers/kube-state-metrics:v0.5.0
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
By default the built-in scrape targets on the k8s api server does not expose information about the state of the objects known to k8s, e.g. (pod is in an Error, Creating, Pending, or Running state).

This makes it impossible to know or create alerts for certain kinds of failures.  This change adds the kube-state-metrics service that exports metrics in a useful form for Prometheus.

Documentation for kube-state-metrics and the metrics it exports are at: https://github.com/kubernetes/kube-state-metrics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/44)
<!-- Reviewable:end -->
