### PR TITLE
Support a longer timeout for graceful shutdown of prometheus.

### DIFF
--- a/k8s/cluster/prometheus.yml
+++ b/k8s/cluster/prometheus.yml
@@ -49,6 +49,10 @@ spec:
       nodeSelector:
         prometheus-node: 'true'
 
+      # When prometheus receives SIGTERM, it begins a new checkpoint. This can
+      # take longer than the default grace period of 30s.
+      terminationGracePeriodSeconds: 240
+
       # Place the pod into the Guaranteed QoS by setting equal resource
       # requests and limits for *all* containers in the pod.
       # For more background, see:

--- a/k8s/federation/prometheus.yml
+++ b/k8s/federation/prometheus.yml
@@ -33,6 +33,10 @@ spec:
       nodeSelector:
         prometheus-node: 'true'
 
+      # When prometheus receives SIGTERM, it begins a new checkpoint. This can
+      # take longer than the default grace period of 30s.
+      terminationGracePeriodSeconds: 240
+
       # Place the pod into the Guaranteed QoS by setting equal resource
       # requests and limits for *all* containers in the pod.
       # For more background, see:


### PR DESCRIPTION
Kubernetes normally sends a SIGTERM to pid 1 when shutting down a container, during a pod delete or apply operation. The default timeout of 30s was not sufficient, and would interrupt prometheus during it's clean shutdown process. As a result, the prometheus data volume was left in an inconsistent state that needed a lengthy recovery process on startup.

This longer grace period should allow prometheus to shutdown cleanly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/46)
<!-- Reviewable:end -->
