### PR TITLE
Disable adding a pod name label.

### DIFF
--- a/config/cluster/prometheus/prometheus.yml
+++ b/config/cluster/prometheus/prometheus.yml
@@ -195,10 +195,13 @@ scrape_configs:
         replacement: $1
         target_label: deployment
 
+      # TODO(soltesz): evaluate and remove from config if no-pod name is helpful
+      # in practice.
+      #
       # Add the kubernetes pod name.
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: pod
+      #- source_labels: [__meta_kubernetes_pod_name]
+      #  action: replace
+      #  target_label: pod
 
       # Add the kubernetes pod container name.
       - source_labels: [__meta_kubernetes_pod_container_name]


### PR DESCRIPTION
In practice we've found the creation of new time series to be the most expensive operation for prometheus. This requires creating a new file on disk and adding additional in-memory indexes for all known time series.

At the scale that scraper operates, simply re-deploying all scrapers (3200 x 2) and applying all of them a new pod name creates approximately 1 million new time series (one for every metric exported by every scraper and node-exporter), each with a new pod name.

By removing the pod name, deployments will be identifyable by the "deployment" name, but the change in version will not be evident with the attribute labels.

It's possible we could reserve a single metric for this purpose so pod names are applied to only one or a much smaller sub set rather than all. But, as an experiment, this PR removes the pod label from all metrics.