### PR TITLE
Update internal consistency checks to use lastcollectionattempt

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -80,11 +80,15 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
 
 # Scraper internal consistency.
 #
-# ScraperSyncPresentWithoutScaperCollector,
-#   ScraperCollectorMissingFromScaperSync:
+# Verify that for every running scraper there is a corresponding metric from
+# scraper-sync indicating that a collection was attempted. These should always
+# be in sync with one another.
 #
+# We use scraper_lastcollectionattempt because scraper_maxrawfiletimearchived
+# is not updated until the first successful upload. This is not possible before
+# a machine comes online.
 ALERT ScraperSyncPresentWithoutScaperCollector
-  IF (scraper_maxrawfiletimearchived{container="scraper-sync"}
+  IF (scraper_lastcollectionattempt{container="scraper-sync"}
         UNLESS ON(machine, experiment, rsync_module)
            up{container="scraper"})
   FOR 3h
@@ -99,7 +103,7 @@ ALERT ScraperSyncPresentWithoutScaperCollector
 ALERT ScraperCollectorMissingFromScaperSync
   IF (up{container="scraper"}
         UNLESS ON(machine, experiment, rsync_module)
-           scraper_maxrawfiletimearchived{container="scraper-sync"})
+           scraper_lastcollectionattempt{container="scraper-sync"})
   FOR 3h
   LABELS {
     severity = "page"


### PR DESCRIPTION
The `scraper_maxrawfiletimearchived` metric will not be exported for machines that have never uploaded a tarfile (such as those not yet installed for the first time).

This change uses `scraper_lastcollectionattempt` instead which is guaranteed to always be exported and updated as long as the corresponding scraper is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/54)
<!-- Reviewable:end -->
