### PR TITLE
Wait for machines to be online for 24h

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -70,7 +70,7 @@ ALERT SidestreamIsNotRunning
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (36 * 60 * 60)
         AND ON(machine)
-           (time() - process_start_time_seconds{service="sidestream"}) > (2 * 60 * 60)
+           (time() - process_start_time_seconds{service="sidestream"}) > (24 * 60 * 60)
   FOR 10m
   LABELS {
     severity = "page"


### PR DESCRIPTION
Since scrapers normally upload tar archives once a day, the `scraper_maxrawfiletimearchived` may not be updated for up to 24 hours.

This change requires that the sidestream process start time (a proxy for system start time) be longer than 24 hours.

TODO: we must replace `process_start_time_seconds` for the actual system uptime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/57)
<!-- Reviewable:end -->
