### PR TITLE
Update the prometheus configuration apply scripts

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -6,15 +6,15 @@
 #
 # Example:
 #
-#   ./apply-cluster.sh
+#   PROJECT=mlab-sandbox CLUSTER=scraper-cluster ./apply-cluster.sh
 
 set -x
 set -e
 set -u
 
-USAGE="$0 <project-id> <cluster-name>"
-PROJECT=${1:?Please provide project id: $USAGE}
-CLUSTER=${2:?Please provide cluster name: $USAGE}
+USAGE="PROJECT=<projectid> CLUSTER=<cluster> $0"
+PROJECT=${PROJECT:?Please provide project id: $USAGE}
+CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
 
 # Roles.
 kubectl apply -f "k8s/${PROJECT}/${CLUSTER}/roles"

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -38,6 +38,6 @@ PUBLIC_IP=$( kubectl get services \
   -o jsonpath='{.items[?(@.metadata.name=="prometheus-public-service")].status.loadBalancer.ingress[0].ip}' )
 if [[ -n "${PUBLIC_IP}" ]] ; then
   # Reload configurations. If the deployment configuration has changed then this
-  # request may fail becuase the container has already shutdown.
+  # request may fail because the container has already shutdown.
   curl -X POST http://${PUBLIC_IP}:9090/-/reload || :
 fi

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -32,3 +32,12 @@ kubectl apply -f "k8s/${PROJECT}/${CLUSTER}/services"
 
 # Deployments
 kubectl apply -f "k8s/${PROJECT}/${CLUSTER}/deployments"
+
+# Get the public IP for the prometheus service.
+PUBLIC_IP=$( kubectl get services \
+  -o jsonpath='{.items[?(@.metadata.name=="prometheus-public-service")].status.loadBalancer.ingress[0].ip}' )
+if [[ -n "${PUBLIC_IP}" ]] ; then
+  # Reload configurations. If the deployment configuration has changed then this
+  # request may fail becuase the container has already shutdown.
+  curl -X POST http://${PUBLIC_IP}:9090/-/reload || :
+fi

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -70,7 +70,7 @@ fi
 
 ## Alertmanager
 # TODO: enable storing slack channels as secrets and generating the config.yml
-# Check to se if the alertmanager-config already exists. Do nothing if so.
+# Check to see if the alertmanager-config already exists. Do nothing if so.
 AM_CONFIG=$( kubectl get configmaps \
     alertmanager-config --output=jsonpath={.metadata.name} )
 if [[ -z "${AM_CONFIG}" ]] ; then

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -10,15 +10,18 @@
 #
 # Example:
 #
-#   ./apply-global-prometheus.sh mlab-sandbox prometheus-federation
+#   PROJECT=mlab-sandbox \
+#     CLUSTER=prometheus-federation ./apply-global-prometheus.sh
 
 set -x
 set -e
 set -u
 
-USAGE="$0 <projectid> <cluster>"
-PROJECT=${1:?Please provide project id: $USAGE}
-CLUSTER=${2:?Please provide cluster name: $USAGE}
+# Get project and cluster from the environment.
+
+USAGE="PROJECT=<projectid> CLUSTER=<cluster> $0"
+PROJECT=${PROJECT:?Please provide project id: $USAGE}
+CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
 
 export GRAFANA_DOMAIN=status-${PROJECT}.measurementlab.net
 export ALERTMANAGER_URL=http://status-${PROJECT}.measurementlab.net:9093

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -15,7 +15,7 @@ route:
   # Group incoming alerts together with these labels. For example:
   #   For example: multiple individual alerts for instance=A and
   #   alertname=LatencyHigh would be batched into a single group.
-  group_by: ['alertname', 'instance', 'service']
+  group_by: ['alertname']
 
   # By default, wait at least 'group_wait' before sending a notification to get
   # a set of alerts to 'group_by'.
@@ -30,7 +30,7 @@ route:
   repeat_interval: 3h
 
   # When no other routes match, use the default receiver.
-  receiver: slack-alerts-sandbox-email
+  receiver: slack-alerts-email
 
   # The above attributes are inherited by all child routes. Children can
   # overwrite any value.
@@ -48,7 +48,7 @@ route:
     routes:
     - match:
         severity: page
-      receiver: slack-alerts-sandbox-page
+      receiver: slack-alerts-page
 
 
 # When two alerts are firing at the same time, we can "inhibit" one based on
@@ -65,24 +65,38 @@ inhibit_rules:
 - source_match:
     severity: 'page'
   target_match:
-    severity: 'warning'
+    severity: 'ticket'
   # Apply inhibition if the group is the same.
-  equal: ['alertname', 'instance', 'service']
+  equal: ['instance', 'service']
 
 
 receivers:
 # For M-Lab Slack, visit:
 #   https://measurementlab.slack.com/apps/manage/custom-integrations
-- name: 'slack-alerts-sandbox-page'
+- name: 'slack-alerts-page'
   slack_configs:
   - send_resolved: true
+    # sandbox
     api_url: REPLACE-WITH-ACTUAL-WEBHOOK-URL
     channel: alerts-sandbox
+    # staging
+    # api_url:
+    # channel: alerts-staging
+    # production
+    # api_url:
+    # channel: alerts-oti
     username: alert-page
 
-- name: 'slack-alerts-sandbox-email'
+- name: 'slack-alerts-email'
   slack_configs:
   - send_resolved: true
+    # sandbox
     api_url: REPLACE-WITH-ACTUAL-WEBHOOK-URL
     channel: alerts-sandbox
+    # staging
+    # api_url:
+    # channel: alerts-staging
+    # production
+    # api_url:
+    # channel: alerts-oti
     username: alert-email

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -73,6 +73,10 @@ inhibit_rules:
 receivers:
 # For M-Lab Slack, visit:
 #   https://measurementlab.slack.com/apps/manage/custom-integrations
+# Follow the "Incoming WebHooks link", and either add a new configuration or
+# edit one of the existing configurations. Copy the "Webhook URL" from the
+# slack configuration to the `api_url` values below.
+
 - name: 'slack-alerts-page'
   slack_configs:
   - send_resolved: true


### PR DESCRIPTION
This change updates the `apply-global-prometheus.sh` and `apply-cluster.sh` scripts in preparation for automated deployment using travis.

apply-global-prometheus uses given parameters to generate the expected URLs and generates a random grafana admin password, which can be recovered manually via k8s if necessary.

Both scripts attempts to reload the prometheus configuration using the public service address.

Finally, this change includes an update to the alertmanager template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/60)
<!-- Reviewable:end -->
