### PR TITLE
Add k8s configuration to mlab-oti for alertmanager github receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,8 +486,9 @@ Delete the configmaps.
 
 # Github Receiver
 
-The github receiver implements the Alertmanager Webhook API. So, Alertmanager can
-send alerts to the github receiver and they are converted into Github issues.
+The github receiver implements the Alertmanager Webhook API. So, Alertmanager
+can send alerts to the github receiver and they are converted into Github
+issues.
 
 The github receiver authenticates using Github access tokens. Generate a new one
 at: https://github.com/settings/tokens

--- a/README.md
+++ b/README.md
@@ -484,6 +484,39 @@ Delete the configmaps.
     kubectl delete configmap alertmanager-config
     kubectl delete configmap alertmanage-env
 
+# Github Receiver
+
+The github receiver implements the Alertmanager Webhook API. So, Alertmanager can
+send alerts to the github receiver and they are converted into Github issues.
+
+The github receiver authenticates using Github access tokens. Generate a new one
+at: https://github.com/settings/tokens
+
+Actions authenticated using the token will be associated with your account.
+
+## Create
+
+Create the secrets for the github receiver:
+
+    kubectl create secret generic github-secrets \
+        --from-literal=auth-token=${AUTH_TOKEN}
+
+Create the service and deployment:
+
+    kubectl create -f k8s/<p>/prometheus-federation/services/github-receiver-public-service.yml
+    kubectl create -f k8s/<p>/prometheus-federation/deployments/github-receiver.yml
+
+## Delete
+
+Delete the service and deployment.
+
+    kubectl delete -f k8s/<p>/prometheus-federation/services/github-receiver-public-service.yml
+    kubectl delete -f k8s/<p>/prometheus-federation/deployments/github-receiver.yml
+
+Delete the secrets:
+
+    kubectl delete secret github-secrets
+
 # Blackbox exporter
 
 The blackbox exporter allows probes of endpoints over HTTP, HTTPS, DNS, TCP and

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -90,6 +90,8 @@ receivers:
     # api_url:
     # channel: alerts-oti
     username: alert-page
+  #webhook_configs:
+  #- url: 'http://status-mlab-oti.measurementlab.net:9393/v1/receiver'
 
 - name: 'slack-alerts-email'
   slack_configs:
@@ -104,3 +106,5 @@ receivers:
     # api_url:
     # channel: alerts-oti
     username: alert-email
+  #webhook_configs:
+  #- url: 'http://status-mlab-oti.measurementlab.net:9393/v1/receiver'

--- a/k8s/mlab-oti/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/mlab-oti/prometheus-federation/deployments/github-receiver.yml
@@ -24,8 +24,8 @@ spec:
             secretKeyRef:
               name: github-secrets
               key: auth-token
-        args: [ "--authtoken=$(GITHUB_AUTH_TOKEN)",
-                "--owner=m-lab",
-                "--repo=scraper" ]
+        args: [ "-authtoken=$(GITHUB_AUTH_TOKEN)",
+                "-owner=m-lab",
+                "-repo=scraper" ]
         ports:
         - containerPort: 9393

--- a/k8s/mlab-oti/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/mlab-oti/prometheus-federation/deployments/github-receiver.yml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: github-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: github-receiver
+  template:
+    metadata:
+      labels:
+        run: github-receiver
+      annotations:
+        # TODO(soltesz): add prometheus metrics to this daemon.
+        prometheus.io/scrape: 'false'
+    spec:
+      containers:
+      - name: github-receiver
+        image: measurementlab/alertmanager-github-receiver:v0.0
+        env:
+        - name: GITHUB_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-secrets
+              key: auth-token
+        args: [ "--authtoken=$(GITHUB_AUTH_TOKEN)",
+                "--owner=m-lab",
+                "--repo=scraper" ]
+        ports:
+        - containerPort: 9393

--- a/k8s/mlab-oti/prometheus-federation/services/github-receiver-public-service.yml
+++ b/k8s/mlab-oti/prometheus-federation/services/github-receiver-public-service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-receiver-public-service
+  namespace: default
+spec:
+  ports:
+  - port: 9393
+    protocol: TCP
+    targetPort: 9393
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: github-receiver
+  sessionAffinity: None
+  # Allocate a static IP manually in GCP console: Networking -> Load Balancing.
+  externalIPs:
+    - 35.184.81.106
+  type: ClusterIP


### PR DESCRIPTION
This change includes new k8s configuration in the mlab-oti project for the initial version of the github receiver.