### PR TITLE
better handle jobs with many instances

### DIFF
--- a/k8s/mlab-oti/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-oti/prometheus-federation/deployments/prometheus.yml
@@ -67,10 +67,10 @@ spec:
         resources:
           requests:
             memory: "12Gi"
-            cpu: "3000m"
+            cpu: "6000m"
           limits:
             memory: "12Gi"
-            cpu: "3000m"
+            cpu: "6000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus

--- a/k8s/mlab-staging/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-staging/prometheus-federation/deployments/prometheus.yml
@@ -66,10 +66,10 @@ spec:
         resources:
           requests:
             memory: "12Gi"
-            cpu: "3000m"
+            cpu: "6000m"
           limits:
             memory: "12Gi"
-            cpu: "3000m"
+            cpu: "6000m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /prometheus


### PR DESCRIPTION
When running batch processing jobs through ETL, we may have up to 50 instances or more.  Prometheus starts choking badly around 20 to 25 instances, when using "increase" queries.  This should provide a bit more headroom.
