### PR TITLE
Add a new prometheus "local" config for testing locally

### DIFF
--- a/config/local/prometheus/README.md
+++ b/config/local/prometheus/README.md
@@ -1,0 +1,15 @@
+# Local Testing
+
+## Start Prometheus with docker
+
+The following mounts the local directory as the Prometheus docker image config
+directory. So, any local files will be visible to the docker image.
+
+```
+cd $HOME/src/github.com/m-lab/prometheus-support/config/local/prometheus
+docker run -it -p 9090:9090 -v `pwd`:/etc/prometheus prom/prometheus:v1.6.2 \
+    -config.file=/etc/prometheus/prometheus.yml \
+    -query.staleness-delta=10s
+```
+
+Then visit: http://localhost:9090/

--- a/config/local/prometheus/prometheus.yml
+++ b/config/local/prometheus/prometheus.yml
@@ -1,0 +1,25 @@
+# M-Lab Prometheus configuration.
+
+global:
+  # These are settings helpful for testing not for production. Feel free to
+  # change them.
+  scrape_interval:     10s
+  evaluation_interval: 10s  # Evaluate rules every n seconds.
+  # scrape_timeout is set to the global default (10s).
+
+rule_files:
+  # - /etc/prometheus/rules.yml
+
+# For testing exporters, static configs are probably easiest. If you
+# need to test new discovery methods, see the relevant docs:
+#   https://prometheus.io/docs/operating/configuration/#<scrape_config>
+scrape_configs:
+
+  - job_name: 'prometheus'
+    static_configs:
+      # Have prometheus scrape itself at least.
+      - targets: ['localhost:9090']
+
+#  - job_name: 'fake-target'
+#    static_configs:
+#      - targets: ['123.45.67.89:9091']


### PR DESCRIPTION
When developing new exporters or experimenting with prometheus settings it can be helpful to do this locally using docker.

This change includes a small README for using the new "local" prometheus config.