### PR TITLE
Add scrape annotations for blackbox deployment

### DIFF
--- a/k8s/mlab-oti/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/mlab-oti/prometheus-federation/deployments/blackbox.yml
@@ -21,6 +21,9 @@ spec:
         # Note: run=blackbox-server should match a service config with a
         # public IP and port so that it is publically accessible.
         run: blackbox-server
+      annotations:
+        # Tell prometheus service discovery to scrape the blackbox container.
+        prometheus.io/scrape: 'true'
     spec:
       # Place the pod into the Guaranteed QoS by setting equal resource
       # requests and limits for *all* containers in the pod.

--- a/k8s/mlab-oti/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-oti/prometheus-federation/deployments/prometheus.yml
@@ -22,15 +22,12 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '9100'
     spec:
       # References a service account with RBAC permissions for accessing node
       # metrics. This is required for k8s version 1.6+.
-      # TODO(soltesz): enable when cluster is upgraded to 1.6+
-      # serviceAccountName: prometheus
+      serviceAccountName: prometheus
 
       # Clusters running a prometheus instance must label nodes exclusively for
       # use by prometheus. See README for steps to create a GKE cluster for

--- a/k8s/mlab-oti/scraper-cluster/deployments/prometheus.yml
+++ b/k8s/mlab-oti/scraper-cluster/deployments/prometheus.yml
@@ -22,8 +22,7 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
     spec:
       # References a service account with RBAC permissions for accessing node

--- a/k8s/mlab-sandbox/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/blackbox.yml
@@ -21,6 +21,9 @@ spec:
         # Note: run=blackbox-server should match a service config with a
         # public IP and port so that it is publically accessible.
         run: blackbox-server
+      annotations:
+        # Tell prometheus service discovery to scrape the blackbox container.
+        prometheus.io/scrape: 'true'
     spec:
       # Place the pod into the Guaranteed QoS by setting equal resource
       # requests and limits for *all* containers in the pod.

--- a/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
@@ -22,10 +22,8 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '9100'
     spec:
       # References a service account with RBAC permissions for accessing node
       # metrics. This is required for k8s version 1.6+.

--- a/k8s/mlab-sandbox/scraper-cluster/deployments/prometheus.yml
+++ b/k8s/mlab-sandbox/scraper-cluster/deployments/prometheus.yml
@@ -22,8 +22,7 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
     spec:
       # References a service account with RBAC permissions for accessing node

--- a/k8s/mlab-staging/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/mlab-staging/prometheus-federation/deployments/blackbox.yml
@@ -21,6 +21,9 @@ spec:
         # Note: run=blackbox-server should match a service config with a
         # public IP and port so that it is publically accessible.
         run: blackbox-server
+      annotations:
+        # Tell prometheus service discovery to scrape the blackbox container.
+        prometheus.io/scrape: 'true'
     spec:
       # Place the pod into the Guaranteed QoS by setting equal resource
       # requests and limits for *all* containers in the pod.

--- a/k8s/mlab-staging/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-staging/prometheus-federation/deployments/prometheus.yml
@@ -22,10 +22,8 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '9100'
     spec:
       # References a service account with RBAC permissions for accessing node
       # metrics. This is required for k8s version 1.6+.

--- a/k8s/mlab-staging/scraper-cluster/deployments/prometheus.yml
+++ b/k8s/mlab-staging/scraper-cluster/deployments/prometheus.yml
@@ -22,8 +22,7 @@ spec:
         # public IP and port so that it is publically accessible.
         run: prometheus-server
       annotations:
-        # Tell prometheus service discovery to scrape the node-exporter running
-        # within the prometheus-server pod.
+        # Tell prometheus service discovery to scrape the pod containers.
         prometheus.io/scrape: 'true'
     spec:
       # References a service account with RBAC permissions for accessing node


### PR DESCRIPTION
This PR adds the `prometheus.io/scrape: 'true'` to the blackbox service, previously missing. This will allow the prometheus server to scrape metrics about the blackbox service itself.

As well, this PR includes minor comment updates to the prometheus deployment configs, and enables the 'prometheus' service account in mlab-oti (a step that should have been completed already).