### PR TITLE
Adds snmp_exporter targets to gcp-service-discovery.

### DIFF
--- a/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
@@ -131,7 +131,7 @@ spec:
                 "--http-target=/targets/legacy-targets/sidestream.json",
                 "--http-target=/targets/blackbox-targets/ssh806.json",
                 "--http-target=/targets/blackbox-targets/rsyncd.json",
-                "--http-target=/targets/blackbox-targets/snmpexporter.json",
+                "--http-target=/targets/snmp-targets/snmpexporter.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",

--- a/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
@@ -127,9 +127,11 @@ spec:
                 "--http-target=/targets/legacy-targets/sidestream.json",
                 "--http-target=/targets/blackbox-targets/ssh806.json",
                 "--http-target=/targets/blackbox-targets/rsyncd.json",
+                "--http-target=/targets/blackbox-targets/snmpexporter.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/snmpexporter.json",
                 "--project=$(GCLOUD_PROJECT)"]
         resources:
           requests:

--- a/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/prometheus.yml
@@ -89,6 +89,10 @@ spec:
         - mountPath: /aeflex-targets
           name: prometheus-storage
           subPath: aeflex-targets
+        # /snmp-targets should contain snmp_exporter target config files.
+        - mountPath: /snmp-targets
+          name: prometheus-storage
+          subPath: snmp-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -131,7 +135,7 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/legacy-targets/sidestream.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/ssh806.json",
                 "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/rsyncd.json",
-                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/blackbox-targets/snmpexporter.json",
+                "--http-source=https://storage.googleapis.com/operator-$(GCLOUD_PROJECT)/prometheus/snmp-targets/snmpexporter.json",
                 "--project=$(GCLOUD_PROJECT)"]
         resources:
           requests:


### PR DESCRIPTION
This PR is complementary to [m-lab/operator/pull/152](https://github.com/m-lab/operator/pull/152).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/82)
<!-- Reviewable:end -->
