### PR TITLE
Simulate a module list command to avoid log errors

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -49,9 +49,13 @@ modules:
     tcp:
       protocol: "tcp4"
       query_response:
-        # @RSYNCD: is followed by a version number, e.g. 30.0. For more
-        # flexibility we do not require a specific version here.
+        # @RSYNCD: is followed by a version number, e.g. 30.0. Rather than
+        # dropping the connection immediately, we simulate a module list
+        # request to the rsyncd server. Rsyncd automatically closes the
+        # connection in response.
         - expect: "@RSYNCD: .+"
+        - send: "@RSYNCD: 30.0\n#list"
+        - expect: "@RSYNCD: EXIT"
 
   # target=<hostname>
   icmp:


### PR DESCRIPTION
Previously, when the blackbox exporter would probe the rsyncd server, it would drop the connection immediately after getting the greeting from rsyncd. Since this is not how well behaved clients act, rsyncd would log an error like:

```
Sep 10 03:39:30 mlab1 rsyncd[16964]: rsync: connection unexpectedly closed (0 bytes received so far) [receiver]
Sep 10 03:39:30 mlab1 rsyncd[16964]: rsync error: error in rsync protocol data stream (code 12) at io.c(600) [receiver=3.0.6]
```

With this change, the blackbox exporter uses a valid request to list the modules, which causes the rsyncd server to shutdown the connection cleanly. Now logs will contain:

```
Sep 25 18:16:37 mlab2 rsyncd[1051]: connect from 87.93.148.146.bc.googleusercontent.com (146.148.93.87)
Sep 25 18:16:42 mlab2 rsyncd[1051]: module-list request from 87.93.148.146.bc.googleusercontent.com (146.148.93.87)
```

Once deployed, this change should resolve https://github.com/m-lab/ops-tracker/issues/212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/84)
<!-- Reviewable:end -->
