### PR TITLE
Increase process start time threshold for ScraperMostRecentArchivedFileTimeIsTooOld

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -70,14 +70,14 @@ ALERT SidestreamIsNotRunning
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (36 * 60 * 60)
         AND ON(machine)
-           (time() - process_start_time_seconds{service="sidestream"}) > (24 * 60 * 60)
+           (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
   FOR 10m
   LABELS {
     severity = "page"
   }
   ANNOTATIONS {
     summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
-    description = "Max file mtime for {{ $labels.rsync_url }} is older than 40 hours.",
+    description = "Max file mtime for {{ $labels.rsync_url }} is older than 36 hours.",
   }
 
 # Scraper internal consistency.


### PR DESCRIPTION
Over time, the ScraperMostRecentArchivedFileTimeIsTooOld has generated over 10
spurious alerts, firing and then resolving automatically within a few hours.

This can happen for example, after a machine restart and before scraper has
completed updating the scraper_maxrawfiletimearchived value for the last day.

By observation, all instances of this alert resolved this is within 1 to 5
hours, so increasing the sidestream threadhold to 30 hours should be adequate
to prevent all of the spurious alerts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/88)
<!-- Reviewable:end -->
