### PR TITLE
Sets scrape_timeout for snmp-targets to 30s.

### DIFF
--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -376,6 +376,7 @@ scrape_configs:
   # SNMP configurations.
   - job_name: 'snmp-targets'
     metrics_path: /snmp
+    scrape_timeout: 30s
 
     file_sd_configs:
       - files:


### PR DESCRIPTION
Currently, quite a lot of the snmp-targets are timing out (i.e., taking longer than the 10s global default). 30s should be enough for any of those snmp_exporter requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/89)
<!-- Reviewable:end -->
