### PR TITLE
Pins promtool to v1.8.0 and removes unsupported flag from query_tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ go_import_path: github.com/m-lab/prometheus-support
 install:
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=1.8.0;
-  go get -d $PROMTOOL_URL;
+  go get -d $PROMTOOL_URI;
   git -C $GOPATH/src/$PROMTOOL_URI
   checkout -b $PROMTOOL_VERSION tags/v$PROMTOOL_VERSION;
   go install $PROMTOOL_URI

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ cache:
 go_import_path: github.com/m-lab/prometheus-support
 
 install:
-- go get github.com/prometheus/prometheus/cmd/promtool
+- go get -d github.com/prometheus/prometheus/cmd/promtool
+- git -C $GOPATH/src/github.com/prometheus/prometheus/cmd/promtool/ checkout -b 1.8.0 tags/v1.8.0
+- go install github.com/prometheus/prometheus/cmd/promtool
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl
 
 script:
@@ -21,8 +23,8 @@ script:
 - go test -v github.com/m-lab/prometheus-support/cmd/query_tester
 
 # Use promtool to check current alerts and rules. This is only a syntax check.
-- promtool check rules config/federation/prometheus/alerts.yml
-- promtool check rules config/federation/prometheus/rules.yml
+- promtool check-rules config/federation/prometheus/alerts.yml
+- promtool check-rules config/federation/prometheus/rules.yml
 
 # TODO(soltesz): support check-config.
 # promtool check-config config/federation/prometheus/prometheus.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 script:
 # Run query "unit tests".
-- go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn
+- go test -v github.com/m-lab/prometheus-support/cmd/query_tester
 
 # Use promtool to check current alerts and rules. This is only a syntax check.
 - promtool check-rules config/federation/prometheus/alerts.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
 - go test -v github.com/m-lab/prometheus-support/cmd/query_tester
 
 # Use promtool to check current alerts and rules. This is only a syntax check.
-- promtool check-rules config/federation/prometheus/alerts.yml
-- promtool check-rules config/federation/prometheus/rules.yml
+- promtool check rules config/federation/prometheus/alerts.yml
+- promtool check rules config/federation/prometheus/rules.yml
 
 # TODO(soltesz): support check-config.
 # promtool check-config config/federation/prometheus/prometheus.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 go_import_path: github.com/m-lab/prometheus-support
 
 install:
+  # Install promtool and pin it at the latest stable version, currently 1.8.0
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=1.8.0;
   go get -d $PROMTOOL_URI;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ cache:
 go_import_path: github.com/m-lab/prometheus-support
 
 install:
-- go get -d github.com/prometheus/prometheus/cmd/promtool
-- git -C $GOPATH/src/github.com/prometheus/prometheus/cmd/promtool/ checkout -b 1.8.0 tags/v1.8.0
-- go install github.com/prometheus/prometheus/cmd/promtool
+- PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
+  PROMTOOL_VERSION=1.8.0;
+  go get -d $PROMTOOL_URL;
+  git -C $GOPATH/src/$PROMTOOL_URI
+  checkout -b $PROMTOOL_VERSION tags/v$PROMTOOL_VERSION;
+  go install $PROMTOOL_URI
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl
 
 script:

--- a/cmd/query_tester/main.go
+++ b/cmd/query_tester/main.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func main() {
 	fmt.Println("To run query tests:")
-	fmt.Println("go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn")
+	fmt.Println("go test -v github.com/m-lab/prometheus-support/cmd/query_tester")
 }


### PR DESCRIPTION
When attempting to build this repository a while ago the Travis-CI build log reported:

```
$ go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn
flag provided but not defined: -log.level
```

This PR removes `-args -log.level warn` to avoid this error.

After fixing that, builds were still failing with:

```
$ promtool check-rules config/federation/prometheus/rules.yml
promtool: error: expected command but got "check-rules", try --help
```

Not only has `check-rules` changed to `check rules` in the current HEAD of promtools, but the checks were failing our YML files, which apparently no longer conform to the latest format. To get around this, this PR also pins the version of promtool to the latest stable version (as of this writing), which is v1.8.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/93)
<!-- Reviewable:end -->
