### PR TITLE
Adds back the '-args -log.level warn' flag to query_tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
 # Run query "unit tests".
-- go test -v github.com/m-lab/prometheus-support/cmd/query_tester
+- go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn
 
 # Use promtool to check current alerts and rules. This is only a syntax check.
 - promtool check-rules config/federation/prometheus/alerts.yml

--- a/cmd/query_tester/main.go
+++ b/cmd/query_tester/main.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func main() {
 	fmt.Println("To run query tests:")
-	fmt.Println("go test -v github.com/m-lab/prometheus-support/cmd/query_tester")
+	fmt.Println("go test -v github.com/m-lab/prometheus-support/cmd/query_tester -args -log.level warn")
 }


### PR DESCRIPTION
These flags were removed in PR #93.  That PR fixed two issues, and it turns out that the later fix in that PR fixed the previous error. This PR adds those flags back, since they work now, and make Travis build logs less verbose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/94)
<!-- Reviewable:end -->
