### PR TITLE
Update Grafana and enable Google OAuth login

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -62,11 +62,16 @@ kubectl create secret generic grafana-secrets \
     --dry-run -o json | kubectl apply -f -
 set -x
 
-if [[ -n "${GRAFANA_DOMAIN}" ]] ; then
-  kubectl create configmap grafana-env \
-      "--from-literal=domain=${GRAFANA_DOMAIN}" \
-      --dry-run -o json | kubectl apply -f -
-fi
+
+GF_CLIENT_SECRET_NAME=GF_AUTH_GOOGLE_CLIENT_SECRET_${PROJECT/-/_}
+GF_CLIENT_ID_NAME=GF_AUTH_GOOGLE_CLIENT_ID_${PROJECT/-/_}
+# TODO: kubectl v1.7  supports --from-env-file=
+kubectl create configmap grafana-env \
+    "--from-literal=domain=${GRAFANA_DOMAIN}" \
+    "--from-literal=gf_auth_google_client_secret=${!GF_CLIENT_SECRET_NAME}" \
+    "--from-literal=gf_auth_google_client_id=${!GF_CLIENT_ID_NAME}" \
+    --dry-run -o json | kubectl apply -f -
+
 
 ## Alertmanager
 # TODO: enable storing slack channels as secrets and generating the config.yml

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -63,6 +63,8 @@ kubectl create secret generic grafana-secrets \
 set -x
 
 
+# Per-project client secrets and client ids should be stored in travis
+# environment variables. If they are not set, then login won't work.
 GF_CLIENT_SECRET_NAME=GF_AUTH_GOOGLE_CLIENT_SECRET_${PROJECT/-/_}
 GF_CLIENT_ID_NAME=GF_AUTH_GOOGLE_CLIENT_ID_${PROJECT/-/_}
 # TODO: kubectl v1.7  supports --from-env-file=

--- a/config/federation/grafana/grafana.ini
+++ b/config/federation/grafana/grafana.ini
@@ -178,7 +178,7 @@
 
 [auth]
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
-;disable_login_form = false
+disable_login_form = true
 
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
@@ -206,15 +206,14 @@
 
 #################################### Google Auth ##########################
 [auth.google]
-;enabled = false
-;allow_sign_up = true
-;client_id = some_client_id
-;client_secret = some_client_secret
-;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
-;auth_url = https://accounts.google.com/o/oauth2/auth
-;token_url = https://accounts.google.com/o/oauth2/token
-;api_url = https://www.googleapis.com/oauth2/v1/userinfo
-;allowed_domains =
+enabled = true
+allow_sign_up = true
+;client_id = <set via environment variable: GF_AUTH_GOOGLE_CLIENT_ID>
+;client_secret = <set via environment variable: GF_AUTH_GOOGLE_CLIENT_SECRET>
+scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+auth_url = https://accounts.google.com/o/oauth2/auth
+token_url = https://accounts.google.com/o/oauth2/token
+api_url = https://www.googleapis.com/oauth2/v1/userinfo
 
 #################################### Generic OAuth ##########################
 [auth.generic_oauth]

--- a/k8s/mlab-sandbox/prometheus-federation/deployments/grafana.yml
+++ b/k8s/mlab-sandbox/prometheus-federation/deployments/grafana.yml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:4.2.0
+      - image: grafana/grafana:4.5.2
         name: grafana-server
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD
@@ -40,6 +40,17 @@ spec:
             configMapKeyRef:
               name: grafana-env
               key: domain
+        - name: GF_AUTH_GOOGLE_CLIENT_SECRET
+          valueFrom:
+            configMapKeyRef:
+              name: grafana-env
+              key: gf_auth_google_client_secret
+        - name: GF_AUTH_GOOGLE_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: grafana-env
+              key: gf_auth_google_client_id
+
         ports:
           - containerPort: 3000
         resources:


### PR DESCRIPTION
This change adds support for Grafana login using Google OAuth.

The client secret and client id are stored as secure environment variables in the travis environment and available and deploy time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/95)
<!-- Reviewable:end -->
