### PR TITLE
Reduce resource requirements for scraper-cluster in sandbox

### DIFF
--- a/k8s/scraper-cluster/mlab-sandbox.yml
+++ b/k8s/scraper-cluster/mlab-sandbox.yml
@@ -1,5 +1,5 @@
 # Configuration values for mlab-sandbox.
 
-PROMETHEUS_RAM: 96Gi
-PROMETHEUS_CPU: 8000m
+PROMETHEUS_RAM: 20Gi
+PROMETHEUS_CPU: 6000m
 PROMETHEUS_VOLUME_NAME: auto-prometheus-ssd0


### PR DESCRIPTION
We do not run scraper in sandbox and the previous config was not actually working. This changes the resource utilization so that it can work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/102)
<!-- Reviewable:end -->
