### PR TITLE
Generate Alertmanager configuration from template

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -77,9 +77,9 @@ SHORT_PROJECT=${PROJECT/mlab-/}
 if [[ ${PROJECT} == mlab-oti ]] ; then
   GITHUB_RECEIVER_URL=http://status-mlab-oti.measurementlab.net:9393/v1/receiver
 fi
-sed -e 's/{{SLACK_CHANNEL_URL}}/'${!SLACK_CHANNEL_URL_NAME}'/g' \
-    -e 's/{{GITHUB_RECEIVER_URL}}/'$GITHUB_RECEIVER_URL'/g' \
-    -e 's/{{SHORT_PROJECT}}/'$SHORT_PROJECT'/g' \
+sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
+    -e 's|{{GITHUB_RECEIVER_URL}}|'$GITHUB_RECEIVER_URL'|g' \
+    -e 's|{{SHORT_PROJECT}}|'$SHORT_PROJECT'|g' \
     config/federation/alertmanager/config.yml.template > \
     config/federation/alertmanager/config.yml
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -67,20 +67,26 @@ kubectl create configmap grafana-env \
 
 
 ## Alertmanager
-# TODO: enable storing slack channels as secrets and generating the config.yml
-# Check to see if the alertmanager-config already exists. Do nothing if so.
-AM_CONFIG=$( kubectl get configmaps \
-    alertmanager-config --output=jsonpath={.metadata.name} )
-if [[ -z "${AM_CONFIG}" ]] ; then
-  # Create a default configuration without actual values.
-  cp config/federation/alertmanager/config.yml.template \
-      config/federation/alertmanager/config.yml
 
-  # Create a new configmap.
-  kubectl create configmap alertmanager-config \
-      --from-file=config/federation/alertmanager \
-      --dry-run -o json | kubectl apply -f -
+# Evaluate the configuration template.
+# Note: Slack configuration depends on travis environment variables.
+# Note: Only enable the github reciever for the production project: mlab-oti.
+SHORT_PROJECT=${PROJECT/mlab-/}
+SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
+if [[ ${PROJECT} == mlab-oti ]] ; then
+  GITHUB_RECEIVER_URL=http://status-mlab-oti.measurementlab.net:9393/v1/receiver
 fi
+sed -e 's/{{SLACK_CHANNEL_URL}}/'${!SLACK_CHANNEL_URL_NAME}'/g' \
+    -e 's/{{GITHUB_RECEIVER_URL}}/'$GITHUB_RECEIVER_URL'/g' \
+    -e 's/{{SHORT_PROJECT}}/'$SHORT_PROJECT'/g' \
+    config/federation/alertmanager/config.yml.template > \
+    config/federation/alertmanager/config.yml
+
+# Apply the above configmap.
+kubectl create configmap alertmanager-config \
+    --from-file=config/federation/alertmanager \
+    --dry-run -o json | kubectl apply -f -
+
 
 if [[ -n "${ALERTMANAGER_URL}" ]] ; then
     kubectl create configmap alertmanager-env \

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -71,8 +71,9 @@ kubectl create configmap grafana-env \
 # Evaluate the configuration template.
 # Note: Slack configuration depends on travis environment variables.
 # Note: Only enable the github reciever for the production project: mlab-oti.
-SHORT_PROJECT=${PROJECT/mlab-/}
 SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
+GITHUB_RECEIVER_URL=
+SHORT_PROJECT=${PROJECT/mlab-/}
 if [[ ${PROJECT} == mlab-oti ]] ; then
   GITHUB_RECEIVER_URL=http://status-mlab-oti.measurementlab.net:9393/v1/receiver
 fi

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -80,31 +80,17 @@ receivers:
 - name: 'slack-alerts-page'
   slack_configs:
   - send_resolved: true
-    # sandbox
-    api_url: REPLACE-WITH-ACTUAL-WEBHOOK-URL
-    channel: alerts-sandbox
-    # staging
-    # api_url:
-    # channel: alerts-staging
-    # production
-    # api_url:
-    # channel: alerts-oti
+    api_url: {{SLACK_CHANNEL_URL}}
+    channel: alerts-{{SHORT_PROJECT}}
     username: alert-page
-  #webhook_configs:
-  #- url: 'http://status-mlab-oti.measurementlab.net:9393/v1/receiver'
+  webhook_configs:
+  - url: '{{GITHUB_RECEIVER_URL}}'
 
 - name: 'slack-alerts-email'
   slack_configs:
   - send_resolved: true
-    # sandbox
-    api_url: REPLACE-WITH-ACTUAL-WEBHOOK-URL
-    channel: alerts-sandbox
-    # staging
-    # api_url:
-    # channel: alerts-staging
-    # production
-    # api_url:
-    # channel: alerts-oti
+    api_url: {{SLACK_CHANNEL_URL}}
+    channel: alerts-{{SHORT_PROJECT}}
     username: alert-email
-  #webhook_configs:
-  #- url: 'http://status-mlab-oti.measurementlab.net:9393/v1/receiver'
+  webhook_configs:
+  - url: '{{GITHUB_RECEIVER_URL}}'


### PR DESCRIPTION
This change generates the alertmanager configuration from a template and environment variables provided by travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/105)
<!-- Reviewable:end -->
