### PR TITLE
Drops all 'ifAlias' labels that are just empty strings. 

### DIFF
--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -408,6 +408,13 @@ scrape_configs:
         target_label: __address__
         replacement: snmp-exporter.${1}.measurementlab.net:9116
 
+      # Most all 'ifAlias' labels will be empty. Rather than pollute the
+      # datastore with a bunch of empty labels, only keep the ones that have
+      # some value.
+      - source_labels: [ifAlias]
+        regex: .+
+        action: labelkeep
+
   # Scrape config for pushgateway.
   #
   # Push gateways allow services to publish metrics for later collection by

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -416,8 +416,9 @@ scrape_configs:
       # datastore with a bunch of empty labels, only keep the ones that have
       # some value.
       - source_labels: [ifAlias]
-        regex: .+
-        action: labelkeep
+        regex: ^$
+        target_label: ifAlias
+        replacement: ""
 
   # Scrape config for pushgateway.
   #

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -408,6 +408,10 @@ scrape_configs:
         target_label: __address__
         replacement: snmp-exporter.${1}.measurementlab.net:9116
 
+    # This relabel config is the last relabel processed before ingesting data
+    # into the datastore.
+    metric_relabel_configs:
+
       # Most all 'ifAlias' labels will be empty. Rather than pollute the
       # datastore with a bunch of empty labels, only keep the ones that have
       # some value.


### PR DESCRIPTION
In other words, only keep the label if it has a value. The vast majority of `ifAlias` labels will have no value. Don't pollute the datastore with empty labels, but instead just drop empty ones and only keep ones with some value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/107)
<!-- Reviewable:end -->
