### PR TITLE
Increases the timeout for snmp-targets from 30s to 45s

### DIFF
--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -373,7 +373,7 @@ scrape_configs:
   # SNMP configurations.
   - job_name: 'snmp-targets'
     metrics_path: /snmp
-    scrape_timeout: 30s
+    scrape_timeout: 45s
 
     file_sd_configs:
       - files:


### PR DESCRIPTION
There are still just a few stragglers that could use a little longer timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/108)
<!-- Reviewable:end -->
