### PR TITLE
Changes all references to http://status-<project> to http://status.<project>

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ The steps are:
  * Name the source, e.g. "Prometheus"
  * Select the Type as "Prometheus"
  * Use a public URI corresponding to the service name, i.e.
-   http://status-mlab-sandbox.measurementlab.net:9090
+   http://status.mlab-sandbox.measurementlab.net:9090
    The name provided must be a fully qualified URL. You may also use the public
    IP.
  * Leave the Access as "proxy"

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -23,8 +23,8 @@ USAGE="PROJECT=<projectid> CLUSTER=<cluster> $0"
 PROJECT=${PROJECT:?Please provide project id: $USAGE}
 CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
 
-export GRAFANA_DOMAIN=status-${PROJECT}.measurementlab.net
-export ALERTMANAGER_URL=http://status-${PROJECT}.measurementlab.net:9093
+export GRAFANA_DOMAIN=status.${PROJECT}.measurementlab.net
+export ALERTMANAGER_URL=http://status.${PROJECT}.measurementlab.net:9093
 
 # Config maps and Secrets
 
@@ -75,7 +75,7 @@ SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
 GITHUB_RECEIVER_URL=
 SHORT_PROJECT=${PROJECT/mlab-/}
 if [[ ${PROJECT} == mlab-oti ]] ; then
-  GITHUB_RECEIVER_URL=http://status-mlab-oti.measurementlab.net:9393/v1/receiver
+  GITHUB_RECEIVER_URL=http://status.${PROJECT}.measurementlab.net:9393/v1/receiver
 fi
 sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
     -e 's|{{GITHUB_RECEIVER_URL}}|'$GITHUB_RECEIVER_URL'|g' \
@@ -115,4 +115,4 @@ kubectl apply -f ${CFG}
 # TODO: there is an indeterminate delay between the time that a configmap is
 # updated and it becomes available to the container. So, this reload may fail
 # since the configmap is not yet up to date.
-curl -X POST http://status-${PROJECT}.measurementlab.net:9090/-/reload || :
+curl -X POST http://status.${PROJECT}.measurementlab.net:9090/-/reload || :

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -56,7 +56,7 @@ spec:
                "-storage.local.path=/prometheus",
                "-storage.local.retention=2880h",
                "-alertmanager.url=http://alertmanager-public-service.default.svc.cluster.local:9093",
-               "-web.external-url=http://status-{{GCLOUD_PROJECT}}.measurementlab.net:9090",
+               "-web.external-url=http://status.{{GCLOUD_PROJECT}}.measurementlab.net:9090",
                "-web.console.libraries=/usr/share/prometheus/console_libraries",
                "-web.console.templates=/usr/share/prometheus/consoles"]
         ports:


### PR DESCRIPTION
These new project subdomains are managed in Google Cloud DNS, where as the old-style ones (e.g., status-mlab-staging.measurementlab.net) are manually managed in the measurementlab.net zonefile in the m-lab/dns-zones repository.  Having this configuration will make managing DNS much easier because we'll be able to use the GCP API for pretty much everything.

**NOTE**: this PR depends on [PR 28 in the m-lab/dns-zones repository](https://github.com/m-lab/dns-zones/pull/28).

I have already created the DNS records that these changes require in the Google Cloud DNS console for each project.

* https://console.cloud.google.com/net-services/dns/zones/mlab-oti-measurementlab-net?project=mlab-oti
* https://console.cloud.google.com/net-services/dns/zones/mlab-staging-measurementlab-net?project=mlab-staging
* https://console.cloud.google.com/net-services/dns/zones/mlab-sandbox-measurementlab-net?project=mlab-sandbox

@stephen-soltesz: are there other places in the configs that I've missed?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/109)
<!-- Reviewable:end -->
