### PR TITLE
Adds static scrape configs for the snmp_exporter VMs running in each GCP project.

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -34,6 +34,13 @@ kubectl create configmap blackbox-config \
     --dry-run -o json | kubectl apply -f -
 
 ## Prometheus
+
+# Evaluate the configuration template.
+sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
+    config/federation/prometheus/prometheus.yml.template > \
+    config/federation/prometheus/prometheus.yml
+
+# Apply the above configmap.
 kubectl create configmap prometheus-federation-config \
     --from-literal=gcloud-project=${PROJECT} \
     --from-file=config/federation/prometheus \

--- a/config/federation/prometheus/prometheus.yml
+++ b/config/federation/prometheus/prometheus.yml
@@ -284,6 +284,19 @@ scrape_configs:
     static_configs:
       - targets: ['nagios.measurementlab.net:9267']
 
+
+  # Scrape config for the snmp_exporter. There is one snmp_exporter service
+  # running in a Docker container on a GCE VM in each GCP project.
+  #
+  # The snmp_exporter generates its own labels.
+  - job_name: 'snmp-exporter'
+    static_configs:
+      - targets:
+        - snmp-exporter.mlab-sandbox.measurementlab.net:9116/metrics
+        - snmp-exporter.mlab-staging.measurementlab.net:9116/metrics
+        - snmp-exporter.mlab-oti.measurementlab.net:9116/metrics
+
+
   # Scrape config for federation.
   #
   # The '/federate' target allows retrieving a set of timeseries from other

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -292,9 +292,7 @@ scrape_configs:
   - job_name: 'snmp-exporter'
     static_configs:
       - targets:
-        - snmp-exporter.mlab-sandbox.measurementlab.net:9116/metrics
-        - snmp-exporter.mlab-staging.measurementlab.net:9116/metrics
-        - snmp-exporter.mlab-oti.measurementlab.net:9116/metrics
+        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116/metrics
 
 
   # Scrape config for federation.


### PR DESCRIPTION
This will start monitoring our snmp_exporter services, running in GCE VMs. Once in place, we can possibly add rules for the AlertManager to alert on the instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/111)
<!-- Reviewable:end -->
