### PR TITLE
Fixes an invalid scrape target URL for the snmp_exporter. 

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -292,7 +292,7 @@ scrape_configs:
   - job_name: 'snmp-exporter'
     static_configs:
       - targets:
-        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116/metrics
+        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116
 
 
   # Scrape config for federation.


### PR DESCRIPTION
The path `/metrics` is implied, and is an error when included in the target URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/112)
<!-- Reviewable:end -->
