### PR TITLE
Add slow-targets configuration

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -476,6 +476,14 @@ scrape_configs:
 
   # Scrape slow targets every 5m (NOTE: do not poll less frequently without
   # updating the prometheus flag -query.staleness-delta).
+  #
+  # TODO(soltesz): make this pattern more generic and consistent. Consider:
+  #  * per-target directories exclusively.
+  #  * create per-interval directories instead of per-target directories,
+  #      e.g. 1m-targets, 5m-targets, 30m-targets.
+  #  * place all target files into a single directory, named appropriately.
+  #      e.g. blackbox-1m-*.json, bq-exporter-5m-*.json, etc.
+  #
   - job_name: 'slow-5m-targets'
     scrape_interval: 5m
     file_sd_configs:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -473,3 +473,14 @@ scrape_configs:
       # Copy all labels from the aeflex service discovery.
       - action: labelmap
         regex: __aef_(.+)
+
+  # Scrape slow targets every 5m (NOTE: do not poll less frequently without
+  # updating the prometheus flag -query.staleness-delta).
+  - job_name: 'slow-5m-targets'
+    scrape_interval: 5m
+    file_sd_configs:
+      - files:
+          - /slow-targets/*-5m.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -93,6 +93,10 @@ spec:
         - mountPath: /snmp-targets
           name: prometheus-storage
           subPath: snmp-targets
+        # /slow-targets should contain slow target config files.
+        - mountPath: /slow-targets
+          name: prometheus-storage
+          subPath: slow-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config


### PR DESCRIPTION
For the bigquery exporter it is helpful to poll the exporter less often than every minute.

This change adds a "slow-5m-targets" job configuration that scrapes targets every 5 min instead of the global 1 min.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/116)
<!-- Reviewable:end -->
