### PR TITLE
Sets machine-dependent alerts to not alert on nodes in lame-duck mode.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -48,8 +48,9 @@ ALERT ClusterDown
 ALERT SidestreamIsNotRunning
   IF sum_over_time(up{service="sidestream"}[10m]) == 0
         AND ON(machine)
-           sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
-        UNLESS ON(machine) lame_duck_node == 1
+     sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+        UNLESS ON(machine)
+     lame_duck_node == 1
   FOR 10m
   LABELS {
     severity = "page"
@@ -71,8 +72,9 @@ ALERT SidestreamIsNotRunning
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (36 * 60 * 60)
         AND ON(machine)
-           (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
-        UNLESS ON(machine) lame_duck_node == 1
+     (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
+        UNLESS ON(machine)
+     lame_duck_node == 1
   FOR 10m
   LABELS {
     severity = "page"

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -49,6 +49,7 @@ ALERT SidestreamIsNotRunning
   IF sum_over_time(up{service="sidestream"}[10m]) == 0
         AND ON(machine)
            sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
+        UNLESS ON(machine) lame_duck_node == 1
   FOR 10m
   LABELS {
     severity = "page"
@@ -71,6 +72,7 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (36 * 60 * 60)
         AND ON(machine)
            (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
+        UNLESS ON(machine) lame_duck_node == 1
   FOR 10m
   LABELS {
     severity = "page"


### PR DESCRIPTION
If a node has been put in lame-duck mode, then all bets are off for machine-dependent services. This PR negates an alert condition if the node is in lame-duck mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/118)
<!-- Reviewable:end -->
