### PR TITLE
Add bq_ipv6_bias and bt_ndt_server queries to the bigquery exporter

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -119,7 +119,7 @@ fi
 CFG=/tmp/${CLUSTER}-${PROJECT}.yml
 kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     -f k8s/${CLUSTER}/${PROJECT}.yml > ${CFG}
-kubectl apply -f ${CFG}
+kubectl apply -f ${CFG} || cat ${CFG}
 
 
 # Reload configurations. If the deployment configuration has changed then this

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -119,7 +119,7 @@ fi
 CFG=/tmp/${CLUSTER}-${PROJECT}.yml
 kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     -f k8s/${CLUSTER}/${PROJECT}.yml > ${CFG}
-kubectl apply -f ${CFG} || cat ${CFG}
+kubectl apply -f ${CFG} || (cat ${CFG} && exit 1)
 
 
 # Reload configurations. If the deployment configuration has changed then this

--- a/config/federation/bigquery/bq_ipv6_bias.sql
+++ b/config/federation/bigquery/bq_ipv6_bias.sql
@@ -1,0 +1,34 @@
+-- bq_ipv6_bias collects the number of tests within a given day that 
+#standardSQL
+
+SELECT
+    site, address_type, window_scale, count(*) as value
+
+FROM (
+    SELECT
+      substr(connection_spec.server_hostname, 7, 5) AS site,
+      IF(REGEXP_CONTAINS(connection_spec.server_ip, ':'), "v6", "v4") as address_type,
+      CASE WHEN web100_log_entry.snap.SndWindScale = -1 THEN "ws0"
+           WHEN 1 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 2 THEN "ws12"
+           WHEN 3 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 5 THEN "ws345"
+           WHEN 6 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 8 THEN "ws678"
+           WHEN 9 <= web100_log_entry.snap.SndWindScale THEN "ws9up"
+           ELSE "wsUnknown"
+           END as window_scale
+
+    FROM
+        `measurement-lab.public.ndt`
+
+    WHERE
+        SUBSTR(connection_spec.server_hostname, 7, 5) in ('lax01', 'mia03', 'ham01', 'hnd01')
+        # phase 1 IPv6 canary
+    -- AND _PARTITIONTIME = TIMESTAMP('2017-11-11')   # test code to speed testing
+        UNIX_SECONDS(log_time) > CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60)
+    AND UNIX_SECONDS(log_time) < CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60) + (86400)
+)
+
+GROUP BY
+   site, address_type, window_scale
+
+ORDER BY
+   site, address_type, window_scale

--- a/config/federation/bigquery/bq_ipv6_bias.sql
+++ b/config/federation/bigquery/bq_ipv6_bias.sql
@@ -23,11 +23,11 @@ FROM
     `measurement-lab.public.ndt`
 
 WHERE
-    -- To guarantee the period queried is up to date (all data collected and
-    -- parsed), we should wait 36hours after the start of a given day. To also
-    -- use _PARTITIONTIME boundaries, we must look at least one day in the past.
-    -- The following calculates the most recent "complete" _PARTITIONTIME. The following
-    -- should be equivalent to pseudo code: TruncateTimeToDay(now() - 12h) - 1d
+    -- For faster queries we use _PARTITIONTIME boundaries. And, to guarantee
+    -- the _PARTITIONTIME data is "complete" (all data collected and parsed) we
+    -- should wait 36 hours after start of a given day.  The following is
+    -- equivalent to the pseudo code:
+    --     date(now() - 12h) - 1d
     _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
 
 GROUP BY

--- a/config/federation/bigquery/bq_ipv6_bias.sql
+++ b/config/federation/bigquery/bq_ipv6_bias.sql
@@ -22,9 +22,9 @@ FROM (
     WHERE
         SUBSTR(connection_spec.server_hostname, 7, 5) in ('lax01', 'mia03', 'ham01', 'hnd01')
         # phase 1 IPv6 canary
-    -- AND _PARTITIONTIME = TIMESTAMP('2017-11-11')   # test code to speed testing
-        UNIX_SECONDS(log_time) > CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60)
-    AND UNIX_SECONDS(log_time) < CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60) + (86400)
+    -- TODO: use _PARTITIONTIME as date boundaries. e.g. _PARTITIONTIME = (CURRENT_DATE() - 1day)
+    AND UNIX_SECONDS(log_time) < CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60)
+    AND UNIX_SECONDS(log_time) > CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / (86400) AS INT64) * (86400) - (36 * 60 * 60) - (86400)
 )
 
 GROUP BY

--- a/config/federation/bigquery/bq_ipv6_bias.sql
+++ b/config/federation/bigquery/bq_ipv6_bias.sql
@@ -1,16 +1,18 @@
--- bq_ipv6_bias collects the number of daily tests broken down by site, address
--- type an window scale. The query reports data from two days ago according to
--- the public ndt table's _PARTITIONTIME.
 #standardSQL
+-- bq_ipv6_bias collects the number of daily tests broken down by site, address
+-- type and window scale. The query reports data from two days ago according to
+-- the public ndt table's _PARTITIONTIME.
 
 SELECT
   SUBSTR(connection_spec.server_hostname, 7, 5) AS site,
   IF(REGEXP_CONTAINS(connection_spec.server_ip, ':'), "v6", "v4") AS address_type,
-  CASE WHEN web100_log_entry.snap.SndWindScale = -1 THEN "wsnone"
-       WHEN web100_log_entry.snap.SndWindScale =  0 THEN "ws0"
+  CASE WHEN -1 = web100_log_entry.snap.SndWindScale THEN "wsnone"
+       WHEN 0 = web100_log_entry.snap.SndWindScale  THEN "ws0"
        WHEN 1 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 2 THEN "ws12"
        WHEN 3 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 5 THEN "ws345"
-       WHEN 6 <= web100_log_entry.snap.SndWindScale AND web100_log_entry.snap.SndWindScale <= 8 THEN "ws678"
+       WHEN 6 = web100_log_entry.snap.SndWindScale  THEN "ws6"
+       WHEN 7 = web100_log_entry.snap.SndWindScale  THEN "ws7"
+       WHEN 8 = web100_log_entry.snap.SndWindScale  THEN "ws8"
        WHEN 9 <= web100_log_entry.snap.SndWindScale THEN "ws9up"
        ELSE "wsUnknown"
        END AS window_scale,

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -56,16 +56,16 @@ FROM (
        `measurement-lab.public.ndt`
 
     WHERE
-        -- NOTE: to guarantee the _PARTITIONTIME data is up to date we should
-        -- wait 36hours. So, this query should be run either at the end of the
-        -- following day, or more often (e.g. hourly) so future queries see all
-        -- data.
+        -- For faster queries we use _PARTITIONTIME boundaries. And, to
+        -- guarantee the _PARTITIONTIME data is "complete" (all data collected
+        -- and parsed) we should wait 36 hours after start of a given day.
+        -- The following is equivalent to the pseudo code:
+        --     date(now() - 12h) - 1d
         _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
-
-    -- Basic test quality filters for safe division.
-    AND web100_log_entry.snap.Duration > 0
-    AND (web100_log_entry.snap.SndLimTimeRwin + web100_log_entry.snap.SndLimTimeCwnd + web100_log_entry.snap.SndLimTimeSnd) > 0
-    AND web100_log_entry.snap.CountRTT > 0
+        -- Basic test quality filters for safe division.
+        AND web100_log_entry.snap.Duration > 0
+        AND (web100_log_entry.snap.SndLimTimeRwin + web100_log_entry.snap.SndLimTimeCwnd + web100_log_entry.snap.SndLimTimeSnd) > 0
+        AND web100_log_entry.snap.CountRTT > 0
 )
 GROUP BY
     machine

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -1,0 +1,68 @@
+-- bq_ndt_metrics calculates the daily median rtt as well as avg and median
+-- upload and download rates per machine. These values can help recognize major
+-- performance regressions of servers or kernels.
+--
+-- Note: this query returns multiple values. So, resulting metrics will be:
+--   bq_ndt_server_tests
+--   bq_ndt_server_download_avg_rate
+--   bq_ndt_server_download_median_rate
+--   bq_ndt_server_download_median_rtt
+--   bq_ndt_server_upload_avg_rate
+--   bq_ndt_server_upload_median_rate
+--   bq_ndt_server_upload_median_rtt
+#standardSQL
+
+SELECT
+    machine,
+    AVG(IF(direction = "s2c", download, NULL)) AS value_download_avg_rate,
+    AVG(IF(direction = "c2s", upload, NULL)) AS value_upload_avg_rate,
+    APPROX_QUANTILES(IF(direction = "s2c", download, NULL), 2)[OFFSET(1)] as value_download_median_rate,
+    APPROX_QUANTILES(IF(direction = "c2s", upload, NULL), 2)[OFFSET(1)] as value_upload_median_rate,
+    APPROX_QUANTILES(IF(direction = "s2c", rtt, NULL), 2)[OFFSET(1)] as value_download_median_rtt,
+    APPROX_QUANTILES(IF(direction = "c2s", rtt, NULL), 2)[OFFSET(1)] as value_upload_median_rtt,
+    COUNT(*) AS value_tests
+FROM (
+    SELECT
+        -- Machine
+        connection_spec.server_hostname AS machine,
+
+        -- Direction
+        CASE connection_spec.data_direction
+          WHEN 0 THEN "c2s"
+          WHEN 1 THEN "s2c"
+          ELSE "error"
+          END as direction,
+
+        -- Download as bits-per-second
+        8 * 1000000 * (web100_log_entry.snap.HCThruOctetsAcked /
+              (web100_log_entry.snap.SndLimTimeRwin +
+                    web100_log_entry.snap.SndLimTimeCwnd +
+                        web100_log_entry.snap.SndLimTimeSnd)) AS download,
+
+        -- Upload as bits-per-second
+        8 * 1000000 * (web100_log_entry.snap.HCThruOctetsReceived /
+              web100_log_entry.snap.Duration) as upload,
+
+        -- Average RTT as seconds
+        web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT/1000 as rtt
+
+    FROM
+       `measurement-lab.public.ndt`
+
+    WHERE
+        -- NOTE: to guarantee the _PARTITIONTIME data is up to date we should
+        -- wait 36hours. So, this query should be run either at the end of the
+        -- following day, or more often (e.g. hourly) so future queries see all
+        -- data.
+        _PARTITIONTIME = TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+
+    -- Basic test quality filters for safe division.
+    AND web100_log_entry.snap.Duration > 0
+    AND (web100_log_entry.snap.SndLimTimeRwin + web100_log_entry.snap.SndLimTimeCwnd + web100_log_entry.snap.SndLimTimeSnd) > 0
+    AND web100_log_entry.snap.CountRTT > 0
+)
+GROUP BY
+    machine
+
+ORDER BY
+    machine

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -1,5 +1,5 @@
 #standardSQL
--- bq_ndt_metrics calculates the daily median rtt as well as avg and median
+-- bq_ndt_metrics calculates the daily median rtt AS well AS avg and median
 -- upload and download rates per machine. These values can help recognize major
 -- performance regressions of servers or kernels.
 --
@@ -14,12 +14,18 @@
 
 SELECT
     machine,
+    APPROX_QUANTILES(IF(direction = "s2c", download, NULL), 2)[OFFSET(1)] AS value_download_median_rate,
+    APPROX_QUANTILES(IF(direction = "c2s", upload, NULL), 2)[OFFSET(1)] AS value_upload_median_rate,
+    APPROX_QUANTILES(IF(direction = "s2c", rtt, NULL), 2)[OFFSET(1)] AS value_download_median_rtt,
+    APPROX_QUANTILES(IF(direction = "c2s", rtt, NULL), 2)[OFFSET(1)] AS value_upload_median_rtt,
+    -- TODO: evaluate utility of avg data.
     AVG(IF(direction = "s2c", download, NULL)) AS value_download_avg_rate,
     AVG(IF(direction = "c2s", upload, NULL)) AS value_upload_avg_rate,
-    APPROX_QUANTILES(IF(direction = "s2c", download, NULL), 2)[OFFSET(1)] as value_download_median_rate,
-    APPROX_QUANTILES(IF(direction = "c2s", upload, NULL), 2)[OFFSET(1)] as value_upload_median_rate,
-    APPROX_QUANTILES(IF(direction = "s2c", rtt, NULL), 2)[OFFSET(1)] as value_download_median_rtt,
-    APPROX_QUANTILES(IF(direction = "c2s", rtt, NULL), 2)[OFFSET(1)] as value_upload_median_rtt,
+    -- TODO: evaluate utility of percentile data.
+    APPROX_QUANTILES(IF(direction = "s2c", download, NULL), 100)[OFFSET(99)] AS value_download_99th_rate,
+    APPROX_QUANTILES(IF(direction = "s2c", download, NULL), 1000)[OFFSET(999)] AS value_download_999th_rate,
+    APPROX_QUANTILES(IF(direction = "c2s", upload, NULL), 100)[OFFSET(99)] AS value_upload_99th_rate,
+    APPROX_QUANTILES(IF(direction = "c2s", upload, NULL), 1000)[OFFSET(999)] AS value_upload_99_9th_rate,
     COUNT(*) AS value_tests
 FROM (
     SELECT
@@ -31,20 +37,20 @@ FROM (
           WHEN 0 THEN "c2s"
           WHEN 1 THEN "s2c"
           ELSE "error"
-          END as direction,
+          END AS direction,
 
-        -- Download as bits-per-second
+        -- Download AS bits-per-second
         8 * 1000000 * (web100_log_entry.snap.HCThruOctetsAcked /
               (web100_log_entry.snap.SndLimTimeRwin +
                     web100_log_entry.snap.SndLimTimeCwnd +
                         web100_log_entry.snap.SndLimTimeSnd)) AS download,
 
-        -- Upload as bits-per-second
+        -- Upload AS bits-per-second
         8 * 1000000 * (web100_log_entry.snap.HCThruOctetsReceived /
-              web100_log_entry.snap.Duration) as upload,
+              web100_log_entry.snap.Duration) AS upload,
 
-        -- Average RTT as seconds
-        web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT/1000 as rtt
+        -- Average RTT AS seconds
+        web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT/1000 AS rtt
 
     FROM
        `measurement-lab.public.ndt`
@@ -54,7 +60,7 @@ FROM (
         -- wait 36hours. So, this query should be run either at the end of the
         -- following day, or more often (e.g. hourly) so future queries see all
         -- data.
-        _PARTITIONTIME = TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+        _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
 
     -- Basic test quality filters for safe division.
     AND web100_log_entry.snap.Duration > 0

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -1,3 +1,4 @@
+#standardSQL
 -- bq_ndt_metrics calculates the daily median rtt as well as avg and median
 -- upload and download rates per machine. These values can help recognize major
 -- performance regressions of servers or kernels.
@@ -10,7 +11,6 @@
 --   bq_ndt_server_upload_avg_rate
 --   bq_ndt_server_upload_median_rate
 --   bq_ndt_server_upload_median_rtt
-#standardSQL
 
 SELECT
     machine,

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -1,5 +1,5 @@
 #standardSQL
--- bq_ndt_metrics calculates the daily median rtt AS well AS avg and median
+-- bq_ndt_metrics calculates the daily median rtt as well as avg and median
 -- upload and download rates per machine. These values can help recognize major
 -- performance regressions of servers or kernels.
 --
@@ -39,17 +39,17 @@ FROM (
           ELSE "error"
           END AS direction,
 
-        -- Download AS bits-per-second
+        -- Download as bits-per-second
         8 * 1000000 * (web100_log_entry.snap.HCThruOctetsAcked /
               (web100_log_entry.snap.SndLimTimeRwin +
                     web100_log_entry.snap.SndLimTimeCwnd +
                         web100_log_entry.snap.SndLimTimeSnd)) AS download,
 
-        -- Upload AS bits-per-second
+        -- Upload as bits-per-second
         8 * 1000000 * (web100_log_entry.snap.HCThruOctetsReceived /
               web100_log_entry.snap.Duration) AS upload,
 
-        -- Average RTT AS seconds
+        -- Average RTT as seconds
         web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT/1000 AS rtt
 
     FROM

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -20,7 +20,7 @@ spec:
         # TODO: replace queries with Standard SQL versions when bqe is v1.0.
         args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
-                "--type=gauge", "--query=/queries/ndt_test_count_total.sql" ]
+                "--type=gauge", "--query=/queries/ndt_test_count_total.sql",
                 "--type=gauge", "--query=/queries/bq_ipv6_bias.sql" ]
         ports:
         - containerPort: 9050

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -21,6 +21,7 @@ spec:
         args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
                 "--type=gauge", "--query=/queries/ndt_test_count_total.sql" ]
+                "--type=gauge", "--query=/queries/bq_ipv6_bias.sql" ]
         ports:
         - containerPort: 9050
         volumeMounts:

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -16,16 +16,15 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:production-0.2
-        # TODO: replace queries with Standard SQL versions when bqe is v1.0.
+        image: measurementlab/prometheus-bigquery-exporter:production-0.3
         args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
                 "--type=gauge", "--query=/queries/ndt_test_count_total.sql",
-                "--type=gauge", "--query=/queries/bq_ipv6_bias.sql" ]
+                "--type=gauge", "--query=/queries/bq_ipv6_bias.sql",
+                "--type=gauge", "--query=/queries/bq_ndt_server.sql" ]
         ports:
         - containerPort: 9050
         volumeMounts:
-        # /prometheus stores all metric data. Declared as VOLUME in base image.
         - mountPath: /queries
           name: bigquery-config
 

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -46,7 +46,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.
-      - image: prom/prometheus:v1.6.2
+      - image: prom/prometheus:v1.8.2
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.


### PR DESCRIPTION
This change adds two new standardSQL queries for the bigquery exporter.

 * bq_ipv6_bias -- per-machine, per-address-type, and per-window scale metrics for measuring bias introduced by IPv6 configuration on M-Lab servers. This will allow us to safely monitor new deployments.
 * bq_ndt_server -- per-machine summary metrics for NDT uploads, downloads, and RTT. This will allow us to observe changes in "normal" behavior over time from NDT server or kernel upgrades.

This change also includes two minor changes to the apply-global-prometheus.sh script to report configs in the event of errors, and an update of the prometheus container version from 1.6.2 to 1.8.2. The 1.8 version includes features for more easily migrating to version 2.0, which uses a different backing store format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/131)
<!-- Reviewable:end -->
