### PR TITLE
Fix NDT test counts -- de-dup and zero counts

### DIFF
--- a/config/federation/bigquery/bq_ndt_tests.sql
+++ b/config/federation/bigquery/bq_ndt_tests.sql
@@ -1,19 +1,38 @@
 #standardSQL
+-- bq_ndt_tests counts the number of NDT tests within a REFRESH_RATE_SEC
+-- interval 36 hours earlier than the time of query. The 36 hour offset
+-- maximizes the number of NDT tests processed by the pipeline for that period.
+
+-- timestampAlign aligns the given timestamp to a multiple of alignment seconds.
+-- And, before returning, timestampAlign adds the given offset to the result.
+CREATE TEMPORARY FUNCTION timestampAlign (ts TIMESTAMP, alignment_seconds INT64, offset_seconds INT64)
+  RETURNS TIMESTAMP
+  AS (
+      TIMESTAMP_ADD(
+          TIMESTAMP_SECONDS(
+              CAST(UNIX_SECONDS(ts) / alignment_seconds AS INT64) * alignment_seconds),
+          INTERVAL offset_seconds SECOND
+      )
+  );
 
 SELECT
-  direction,
   machine,
+  direction,
+  -- The inner query operates on a window 6 times larger than REFRESH_RATE_SEC.
+  -- We do this so every machine is present in the result and so COUNTIF can equal
+  -- zero when no tests occur during the current interval of interest.
   COUNTIF(
-          log_time >= TIMESTAMP_SECONDS(CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / REFRESH_RATE_SEC AS INT64) * REFRESH_RATE_SEC - (36 * 60 * 60))
-      AND log_time <  TIMESTAMP_SECONDS(CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / REFRESH_RATE_SEC AS INT64) * REFRESH_RATE_SEC - (36 * 60 * 60) + REFRESH_RATE_SEC)
+          log_time >= TIMESTAMP_SUB(timestampAlign(CURRENT_TIMESTAMP(), REFRESH_RATE_SEC,                0), INTERVAL 36 HOUR)
+      AND log_time <  TIMESTAMP_SUB(timestampAlign(CURRENT_TIMESTAMP(), REFRESH_RATE_SEC, REFRESH_RATE_SEC), INTERVAL 36 HOUR)
   ) as value
-
 FROM (
+  -- De-duplicate results from the inner most query.
   SELECT
       log_time,
       direction,
       machine
   FROM (
+    -- Return all tests from a wider range of time than our area of interest.
     SELECT
       log_time,
       CASE connection_spec.data_direction
@@ -24,13 +43,14 @@ FROM (
       connection_spec.server_hostname AS machine,
       ROW_NUMBER() OVER (PARTITION BY test_id) row_number
     FROM
-      -- Use ndt_fast, which excludes rows from EB
       `measurement-lab.public.ndt`
     WHERE
-          _PARTITIONTIME >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 72 HOUR)
-      AND _PARTITIONTIME <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
-      AND log_time >= TIMESTAMP_SECONDS(CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / REFRESH_RATE_SEC AS INT64) * REFRESH_RATE_SEC - (36 * 60 * 60))
-      AND log_time <  TIMESTAMP_SECONDS(CAST(UNIX_SECONDS(CURRENT_TIMESTAMP()) / REFRESH_RATE_SEC AS INT64) * REFRESH_RATE_SEC - (36 * 60 * 60) + (REFRESH_RATE_SEC * 6))
+      -- Restrict queries to tests in the range 2d <= log_time < today()
+          _PARTITIONTIME >= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+      AND _PARTITIONTIME <  TIMESTAMP(CURRENT_DATE())
+      -- Further restrict queries to a 3x refresh rate window on both sides of the interval of interest.
+      AND log_time >= TIMESTAMP_SUB(timestampAlign(CURRENT_TIMESTAMP(), REFRESH_RATE_SEC, -3 * REFRESH_RATE_SEC), INTERVAL 36 HOUR)
+      AND log_time <  TIMESTAMP_SUB(timestampAlign(CURRENT_TIMESTAMP(), REFRESH_RATE_SEC,  4 * REFRESH_RATE_SEC), INTERVAL 36 HOUR)
   )
   WHERE
     row_number = 1


### PR DESCRIPTION
This change supports more accurate end to end comparisons of the bigquery exporter NDT test counts and the inotify exporter running on M-Lab nodes.

Before this change we observed that low traffic machines or sites had extreme inconsistency between the inotify test counts and the bqe test counts. On low traffic machines, this amounted to a handful of tests, but in aggregate it made the accuracy of the system difficult to assess.

This change revises the ndt test count query to perform two new operations.

 1. De-duplicate tests, which have an exaggerated impact on low-traffic sites.
 2. Return zero counts, for intervals without tests we want the bqe to return 0 for that interval.

With these changes, the sandbox deployment observed a global improvement in accuracy from low-traffic sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/132)
<!-- Reviewable:end -->
