### PR TITLE
Add ParserDailyVolumeTooLow alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -249,10 +249,15 @@ ALERT SnmpExporterDownOrMissing
   }
 
 
-# ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to yesterday's volume. The alert condition ignores batch processing.
+# ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to yesterday's
+# or last week's test volume. The alert condition ignores batch processing.
 ALERT ParserDailyVolumeTooLow
   IF sum by(service) (increase(etl_test_count{service!~".*batch.*"}[2h]))
-        < 0.20 * sum by(service) (increase(etl_test_count[2h] offset 24h))
+     < 0.20 * max by(service) (
+         sum by(service) (increase(etl_test_count[2h] offset 24h))
+            OR
+         sum by(service) (increase(etl_test_count[2h] offset 1w))
+     )
   FOR 1h
   LABELS {
     severity = "page"

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -254,7 +254,7 @@ ALERT SnmpExporterDownOrMissing
 # ignores batch processing.
 ALERT ParserDailyVolumeTooLow
   IF sum by(service) (increase(etl_test_count{service!~".*batch.*"}[2h]))
-     < 0.20 * quantile by(service) (.5,
+     < 0.20 * quantile by(service) (0.50,
          sum by(service) (increase(etl_test_count[2h] offset 1d))
             OR
          sum by(service) (increase(etl_test_count[2h] offset 3d))

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -257,9 +257,11 @@ ALERT ParserDailyVolumeTooLow
      < 0.20 * quantile by(service) (.5,
          sum by(service) (increase(etl_test_count[2h] offset 1d))
             OR
-         sum by(service) (increase(etl_test_count[2h] offset 2d))
-            OR
          sum by(service) (increase(etl_test_count[2h] offset 3d))
+            OR
+         sum by(service) (increase(etl_test_count[2h] offset 5d))
+            OR
+         sum by(service) (increase(etl_test_count[2h] offset 7d))
      )
   FOR 1h
   LABELS {

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -85,7 +85,7 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   }
   ANNOTATIONS {
     summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
-    description = "Max file mtime for {{ $labels.rsync_url }} is older than 60 hours.",
+    description = "Max file mtime for {{ $labels.rsync_url }} is older than 56 hours.",
   }
 
 # Scraper internal consistency.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -243,3 +243,17 @@ ALERT SnmpExporterDownOrMissing
     summary = "The snmp_exporter service is down on {{ $labels.instance }}.",
     hints = "The snmp_exporter service runs in a Docker container on a GCE VM named 'snmp-exporter' in each M-Lab GCP project. Look at the Travis-CI builds/deploys for m-lab/prometheus-snmp-exporter, or SSH to the VM and poke around."
   }
+
+
+# ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to yesterday's volume. The alert condition ignores batch processing.
+ALERT ParserDailyVolumeTooLow
+  IF sum by(service) (increase(etl_test_count{service!~".*batch.*"}[2h]))
+        < 0.20 * sum by(service) (increase(etl_test_count[2h] offset 24h))
+  FOR 1h
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "Today's test volume is less than 20% of yesterday's volume.",
+    hints = "Are machines online? Is data being collected? Is the parser working?"
+  }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -249,14 +249,17 @@ ALERT SnmpExporterDownOrMissing
   }
 
 
-# ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to yesterday's
-# or last week's test volume. The alert condition ignores batch processing.
+# ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to
+# the 50th percentile test volume from the last three days. The alert condition
+# ignores batch processing.
 ALERT ParserDailyVolumeTooLow
   IF sum by(service) (increase(etl_test_count{service!~".*batch.*"}[2h]))
-     < 0.20 * max by(service) (
-         sum by(service) (increase(etl_test_count[2h] offset 24h))
+     < 0.20 * quantile by(service) (.5,
+         sum by(service) (increase(etl_test_count[2h] offset 1d))
             OR
-         sum by(service) (increase(etl_test_count[2h] offset 1w))
+         sum by(service) (increase(etl_test_count[2h] offset 2d))
+            OR
+         sum by(service) (increase(etl_test_count[2h] offset 3d))
      )
   FOR 1h
   LABELS {

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -64,13 +64,17 @@ ALERT SidestreamIsNotRunning
 # ScraperSLO
 #
 # ScraperMostRecentArchivedFileTimeIsTooOld: scraper uploads archives for a
-# machine once a day. If the machine is online (for at least 2 hours), but
-# scraper has not uploaded an archive for that machine for more than 36 hours,
-# there is a problem.
+# machine once a day. If the machine is online (for at least 30 hours), but
+# scraper has not uploaded an archive for that machine for more than two days
+# plus 8 hours, there is a problem.
+#
+# Note: we can wait two days because we expect that either a) few machines are
+# affected by this at once, or b) many machines are affected and the
+# ParserDailyVolumeTooLow will trigger first.
 #
 # TODO(soltesz): remove the != 0 check when legacy records are removed.
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld
-  IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (36 * 60 * 60)
+  IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (56 * 60 * 60)
         AND ON(machine)
      (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
         UNLESS ON(machine)
@@ -81,7 +85,7 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   }
   ANNOTATIONS {
     summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
-    description = "Max file mtime for {{ $labels.rsync_url }} is older than 36 hours.",
+    description = "Max file mtime for {{ $labels.rsync_url }} is older than 60 hours.",
   }
 
 # Scraper internal consistency.


### PR DESCRIPTION
This change adds a new alert for the M-Lab test parsers.

The alert checks whether today's test volume is less than 20% of yesterday's volume. Since the parser schedule for all test data is periodic this appears to work well for NDT, and paris traceroute parsers. The alert explicitly ignores "batch" jobs which do not necessarily follow a predictable schedule.

This change also includes a complementary change to ScraperMostRecentArchivedFileTimeIsTooOld by extending the threshold to 56hours. This provides enough time for daily configuration jobs to run. And, prevents creation of a redundant alert with ParserDailyVolumeTooLow when many machines are affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/134)
<!-- Reviewable:end -->
