### PR TITLE
Increase blackbox exporter CPU alloc to 1 CPU

### DIFF
--- a/k8s/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/prometheus-federation/deployments/blackbox.yml
@@ -43,10 +43,10 @@ spec:
         resources:
           requests:
             memory: "100Mi"
-            cpu: "100m"
+            cpu: "1000m"
           limits:
             memory: "100Mi"
-            cpu: "100m"
+            cpu: "1000m"
         volumeMounts:
         # /etc/blackbox/config.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/blackbox


### PR DESCRIPTION
We are observing the blackbox probes failing too often and the number of probes that appear to timeout is also too high for the probe_success metric.

This change increases the CPU allocation to 1 CPU based on the belief that the blackbox exporter is simply resource constrained.

http://status.mlab-oti.measurementlab.net:9090/graph?g0.range_input=6h&g0.end_input=2017-11-14+20%3A14&g0.step_input=20&g0.stacked=0&g0.expr=sum+by(container_name)+(rate(container_cpu_usage_seconds_total%7Bcontainer_name%3D%22blackbox-server%22%7D%5B10m%5D))&g0.tab=0&g1.range_input=12h&g1.expr=container_memory_usage_bytes%7Bcontainer_name%3D%22blackbox-server%22%7D&g1.tab=0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/137)
<!-- Reviewable:end -->
