### PR TITLE
Add notes for running Grafana locally and examples of Dashboards-as-code

### DIFF
--- a/config/local/grafana/README.md
+++ b/config/local/grafana/README.md
@@ -1,5 +1,16 @@
 # Local Testing
 
+## Installing grafanalib
+
+Grafanalib depends on python3. On Ubuntu 14.04, I was able to install and run
+the generator using:
+
+```
+apt-get install -y python3-pip
+pip3 install grafanalib
+python3 /usr/local/bin/generate-dashboard -o example.json example.dashboard.py
+```
+
 ## Start grafana with docker
 
 The following mounts local directories for Grafana dashboards so we can use an

--- a/config/local/grafana/README.md
+++ b/config/local/grafana/README.md
@@ -1,0 +1,53 @@
+# Local Testing
+
+## Start grafana with docker
+
+The following mounts local directories for Grafana dashboards so we can use an
+upstream Grafana docker image.
+
+Grafana performs aggressive changes on file modes and ownership. As well, it is
+extremely conservative with modes for reading files. So, use caution when
+locally mounting `/etc/grafana` because Grafana may modify the permissions to be
+unsuable after the container exits. Also, be certain that dashboard files and
+directory are 644 and 755.
+
+```
+cd $HOME/src/github.com/m-lab/prometheus-support/config/local/grafana
+```
+
+The first time we run the docker image we will create a persistent volume where
+the grafana.db and other settings are saved across runs. The first start up will
+take about two minutes. Just wait for the server to start and then Ctrl-C to
+exit.
+
+```
+docker run -it -p 3000:3000 -v /var/lib/grafana --name grafana-storage \
+    -e "GF_SERVER_ROOT_URL=http://localhost:3000" \
+    -e "GF_SECURITY_ADMIN_PASSWORD=secret" \
+    grafana/grafana:latest
+```
+
+Now that the grafana storage volume is initialized, we can restart the server
+using the persistent volume and mounting the local dashboards directory for
+experimentation.
+
+```
+docker run -it -p 3000:3000 \
+    -v `pwd`/dashboards:/grafana/dashboards \
+    -e "GF_DASHBOARDS_JSON_ENABLED=true" \
+    -e "GF_DASHBOARDS_JSON_PATH=/grafana/dashboards" \
+    -e "GF_SERVER_ROOT_URL=http://localhost:3000"  \
+    -e "GF_SECURITY_ADMIN_PASSWORD=secret" \
+    --volumes-from grafana-storage \
+    grafana/grafana:latest
+```
+
+NOTE & TODO: Soon it will be possible to specify datasources in a static
+configuration. Until then you must manually add datasources through the grafana
+web ui. The persistent volume will save that setting across restarts.
+
+NOTE: permissions on the dashboards files and directory must allow world
+reading. Also, if any file or subdirectory cannot be read, grafana fails to load
+everything. Ask me how I learned this. (╯°□°）╯︵┻━┻
+
+Visit: http://localhost:3000/

--- a/config/local/grafana/README.md
+++ b/config/local/grafana/README.md
@@ -26,10 +26,11 @@ directory are 644 and 755.
 cd $HOME/src/github.com/m-lab/prometheus-support/config/local/grafana
 ```
 
-The first time we run the docker image we will create a persistent volume where
-the grafana.db and other settings are saved across runs. The first start up will
-take about two minutes. Just wait for the server to start and then Ctrl-C to
-exit.
+The first time we run the docker image, docker creates a persistent volume
+(transparently saved within the docker root directory, i.e. /var/lib/docker by
+default) where the grafana.db and other settings are saved across runs. The
+first start up will take about two minutes. Just wait for the server to start
+and then Ctrl-C to exit.
 
 ```
 docker run -it -p 3000:3000 -v /var/lib/grafana --name grafana-storage \
@@ -61,4 +62,5 @@ NOTE: permissions on the dashboards files and directory must allow world
 reading. Also, if any file or subdirectory cannot be read, grafana fails to load
 everything. Ask me how I learned this. (╯°□°）╯︵┻━┻
 
-Visit: http://localhost:3000/
+Next, visit http://localhost:3000 and login with the username/password
+"admin"/"secret" (without quotes).

--- a/config/local/grafana/dashboards/example.dashboard.py
+++ b/config/local/grafana/dashboards/example.dashboard.py
@@ -1,0 +1,49 @@
+from grafanalib.core import *
+
+dashboard = Dashboard(
+  title='Frontend Stats2',
+  refresh='',
+  time=Time('now-12h', 'now'),
+  rows=[
+    Row(
+      height=Pixels(500),
+      panels=[
+        Graph(
+          title="Frontend QPS",
+          dataSource='Prometheus',
+          targets=[
+            Target(
+                expr='sum by(code) (rate(http_requests_total{container="prometheus"}[2m]))',
+                legendFormat="{{code}}",
+                refId='A',
+            ),
+          ],
+          yAxes=[
+            YAxis(format=OPS_FORMAT),
+            YAxis(format=SHORT_FORMAT),
+          ],
+          legend=Legend(
+              alignAsTable=True,
+              rightSide=True,
+          ),
+        ),
+        Graph(
+          title="Handler latency",
+          dataSource='Prometheus',
+          targets=[
+            Target(
+              expr='sum by (handler) (rate(http_request_duration_microseconds{quantile="0.9"}[2m]))',
+              legendFormat="{{handler}}",
+              refId='A',
+            ),
+          ],
+          yAxes=single_y_axis(format='µs'),
+          legend=Legend(
+              alignAsTable=True,
+              rightSide=True,
+          ),
+        ),
+      ],
+    ),
+  ],
+).auto_panel_ids()

--- a/config/local/grafana/dashboards/generate.sh
+++ b/config/local/grafana/dashboards/generate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+BASEDIR=$( dirname "${BASH_SOURCE[0]}" )
+# Grafana requires world readership. Setting umask only affects the local shell.
+umask 0002
+for file in `ls ${BASEDIR}/*.dashboard.py` ; do
+  prefix=${file%%.dashboard.py}
+  echo "Generating: ${prefix}.json"
+  python3 /usr/local/bin/generate-dashboard -o ${prefix}.json ${file}
+done


### PR DESCRIPTION
This change adds a "local" configuration example for running Grafana for testing and loading dashboards generated by "grafanalib" from weaveworks. https://www.weave.works/blog/grafana-dashboards-as-code/

This is a precursor to applying this configuration to our production configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/139)
<!-- Reviewable:end -->
