### PR TITLE
Update downloader alert and federation configuration

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -238,7 +238,7 @@ ALERT DownloaderIsFailingToUpdate
 
 # DownloaderNotRunning: The downloader cluster crashed and not running at all.
 ALERT DownloaderDownOrMissing
-  IF up{job="downloader"} == 0 OR absent(up{job="downloader"})
+  IF up{container="downloader"} == 0 OR absent(up{container="downloader"})
   FOR 10m
   LABELS {
     severity = "ticket"

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -316,6 +316,7 @@ scrape_configs:
         # Note: For now collect only the metrics necessary for alerts. There
         # must be at least one match parameter.Prometheus selects the union of
         # all match parameters.
+        - 'up{container="downloader"}'
         - 'up{application="scraper"}'
         - 'up{application="scraper-sync"}'
         - 'downloader_last_success_time_seconds'


### PR DESCRIPTION
This change adds the `up{..}` metric to the prometheus federation scrape configuration. This is necessary since the `downloader` runs in a separate cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/141)
<!-- Reviewable:end -->
