### PR TITLE
Update grafana version to latest

### DIFF
--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:4.5.2
+      - image: grafana/grafana:4.6.2
         name: grafana-server
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD


### PR DESCRIPTION
This upgrades the version of Grafana to use the lastest which includes for graph annotations and better support for loading static dashboards at start time. This is a precursor for static dashboard configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/142)
<!-- Reviewable:end -->
