### PR TITLE
Add recording rules for NDT Early warnings

### DIFF
--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -49,6 +49,7 @@ machine:inotify_extension_create:rpm2m =
     # NOTE: using 'without' instead of 'by' preserves all other labels.
     60.0 * sum without(ext) (rate(inotify_extension_create_total{ext=~".*_snaplog"}[2m]))
 
+# TODO: aggregate on per-machine aliases when available.
 # Per-switch "Out" (i.e. Download) bits per second.
 # Units: bits per second.
 uplink:ifHCOutOctets:bps2m =

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -44,18 +44,22 @@ lsb:sidestream_connection_count:increase2m =
 ## NDT Early Warning aggregation rules.
 
 # Per-machine inotify creation rates, using only c2s_snaplog + s2c_snaplog files.
-machine:inotify_extension_create:rate2m =
+# Units: requests per minute.
+machine:inotify_extension_create:rpm2m =
     # NOTE: using 'without' instead of 'by' preserves all other labels.
     60.0 * sum without(ext) (rate(inotify_extension_create_total{ext=~".*_snaplog"}[2m]))
 
 # Per-switch "Out" (i.e. Download) bits per second.
-uplink:ifHCOutOctets:bits_per_second_rate2m =
+# Units: bits per second.
+uplink:ifHCOutOctets:bps2m =
     8 * rate(ifHCOutOctets{ifAlias="uplink"}[2m])
 
-# Ratio of time spent performing I/O on the /vservers partition.
-vserver_partition:node_disk_io_time_ms:ratio_rate2m =
-    rate(node_disk_io_time_ms{device="dm-2"}[2m]) / 1000
+# The maximum ratio of time spent performing I/O of all devices per machine.
+# Units: none
+machine:node_disk_io_time_ms:max_ratio2m =
+    max without(device) (rate(node_disk_io_time_ms{service="nodeexporter"}[2m])) / 1000
 
 # NDT vserver disk quota utilization, 12 hour estimate.
+# Units: KB
 ndt:vdlimit_used:predict_linear1h_12h =
     predict_linear(vdlimit_used{experiment="ndt.iupui"}[1h], 12*60*60)

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -55,7 +55,7 @@ machine:inotify_extension_create:rpm2m =
 switch:ifHCOutOctets:bps2m =
     8 * rate(ifHCOutOctets{ifAlias="uplink"}[2m])
 
-# The maximum ratio of time spent performing I/O of all devices per machine.
+# Per-machine maximum ratio of time spent performing I/O on all devices.
 # Units: none
 machine:node_disk_io_time_ms:max_ratio2m =
     max without(device) (rate(node_disk_io_time_ms{service="nodeexporter"}[2m])) / 1000

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -49,7 +49,7 @@ machine:inotify_extension_create:rpm2m =
     # NOTE: using 'without' instead of 'by' preserves all other labels.
     60.0 * sum without(ext) (rate(inotify_extension_create_total{ext=~".*_snaplog"}[2m]))
 
-# TODO: aggregate on per-machine aliases when available.
+# TODO: aggregate on per-machine interface aliases when available.
 # Per-switch "Out" (i.e. Download) bits per second.
 # Units: bits per second.
 switch:ifHCOutOctets:bps2m =

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -6,15 +6,20 @@
 #  * https://prometheus.io/docs/querying/rules/
 #  * https://prometheus.io/docs/practices/rules/
 #
-# NOTE: As of 2017-03, all rules are evalutated in parallel. Their evaluation
-# order is not guaranteed, and dependencies between rules are not respected.
-# Using recording rules on the right hand side of an expression can have
-# undefined behavior and may result in recording old data or other errors.
+# NOTE: As of 2017-11, the Prometheus v1.x series evaluates all rules in
+# parallel. So, rule evaluation order is not guaranteed, and dependencies
+# between rules are not respected. Using recording rules on the right hand
+# side of an expression can have undefined behavior and may result in recording
+# old data or other errors. This is also true for Alerts. This limitation is
+# fixed in the Prometheus v2.x series.
 #
-#    https://github.com/prometheus/prometheus/blob/master/rules/manager.go#L240
+# TODO: Prometheus v2.x rules are evaluated in order.
+#
+#    https://github.com/prometheus/prometheus/blob/v1.8.2/rules/manager.go#L254
 #
 # DO:
 #  * Do use raw prometheus expressions on the right hand side of a new rule.
+#  * "Recording rules should be of the general form level:metric:operations."
 #
 # DO NOT:
 #  * Do not use recording rules on the right hand side of a new rule.
@@ -33,3 +38,24 @@ instance:sidestream_connection_count:increase2m =
 # Precalculate the sum of sidestream connections per experiment "last six bits".
 lsb:sidestream_connection_count:increase2m =
     sum by(lsb) (increase(sidestream_connection_count{type=~"ipv4|ipv6"}[2m]))
+
+
+
+## NDT Early Warning aggregation rules.
+
+# Per-machine inotify creation rates, using only c2s_snaplog + s2c_snaplog files.
+machine:inotify_extension_create:rate2m =
+    # NOTE: using 'without' instead of 'by' preserves all other labels.
+    60.0 * sum without(ext) (rate(inotify_extension_create_total{ext=~".*_snaplog"}[2m]))
+
+# Per-switch "Out" (i.e. Download) bits per second.
+uplink:ifHCOutOctets:bits_per_second_rate2m =
+    8 * rate(ifHCOutOctets{ifAlias="uplink"}[2m])
+
+# Ratio of time spent performing I/O on the /vservers partition.
+vserver_partition:node_disk_io_time_ms:ratio_rate2m =
+    rate(node_disk_io_time_ms{device="dm-2"}[2m]) / 1000
+
+# NDT vserver disk quota utilization, 12 hour estimate.
+ndt:vdlimit_used:predict_linear1h_12h =
+    predict_linear(vdlimit_used{experiment="ndt.iupui"}[1h], 12*60*60)

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -52,7 +52,7 @@ machine:inotify_extension_create:rpm2m =
 # TODO: aggregate on per-machine aliases when available.
 # Per-switch "Out" (i.e. Download) bits per second.
 # Units: bits per second.
-uplink:ifHCOutOctets:bps2m =
+switch:ifHCOutOctets:bps2m =
     8 * rate(ifHCOutOctets{ifAlias="uplink"}[2m])
 
 # The maximum ratio of time spent performing I/O of all devices per machine.

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -55,6 +55,7 @@ spec:
         args: ["-config.file=/etc/prometheus/prometheus.yml",
                "-storage.local.path=/prometheus",
                "-storage.local.retention=2880h",
+               "-log.level=debug",
                "-alertmanager.url=http://alertmanager-public-service.default.svc.cluster.local:9093",
                "-web.external-url=http://status.{{GCLOUD_PROJECT}}.measurementlab.net:9090",
                "-web.console.libraries=/usr/share/prometheus/console_libraries",


### PR DESCRIPTION
This change adds four new recording rules to the prometheus configuration for the NDT early warning system.

This change also enables debug logging on the Prometheus server to help locate the source of "dropped metric" errors cited in https://github.com/m-lab/prometheus-support/issues/144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/145)
<!-- Reviewable:end -->
