### PR TITLE
Update Alertmanager & Github Receiver Versions

### DIFF
--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -29,7 +29,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/alertmanager/tags/ for the current
       # stable version.
-      - image: prom/alertmanager:v0.7.1
+      - image: prom/alertmanager:v0.11.0
         name: alertmanager-server
         env:
         - name: ALERTMANAGER_EXTERNAL_URL

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: github-receiver
-        image: measurementlab/alertmanager-github-receiver:v0.0
+        image: measurementlab/alertmanager-github-receiver:v0.2
         env:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:


### PR DESCRIPTION
This change updates  the alertmanager & github receiver versions to provide new functionality.

In the case of Alertmanager, there are numberous bug fixes as well as UI enhancements. In particular, URLs in alert annotations are auto-linked making it easy to navigate from alertmanager to a dashboard (or other resource) when handling an alert.

In the case of the github receiver, the latest version disables issue closing once an alert is resolved. This will require explicit resolution of alerts with a person evaluating how the alert should be resolved long term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/147)
<!-- Reviewable:end -->
