### PR TITLE
Add new rules for boolean threshold violations

### DIFF
--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -94,30 +94,30 @@ ndt:vdlimit_used:predict_linear3h_12h =
 # ranges are chosen for lower sensitivity.
 #
 # 90th percentile boolean threshold violations.
-site:uplink:90th_quantile_gt_500mbps =
-    quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[15m]) > bool 500000000
+candidate_site:uplink:90th_quantile =
+    quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[15m])
 
-machine:inotify_extension_create_rpm:90th_quantile_gt_60 =
-    quantile_over_time(0.90, machine:inotify_extension_create:rpm2m[30m]) > bool 60
+candidate_machine:inotify_extension_create_rpm:90th_quantile =
+    quantile_over_time(0.90, machine:inotify_extension_create:rpm2m[30m])
 
-machine:node_disk_io_time_ratio:90th_quantile_gt_50_pct =
-    quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m[1h]) > bool 0.5
+candidate_machine:node_disk_io_time_ratio:90th_quantile =
+    quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m[1h])
 
-ndt:vdlimit_used_12h_prediction:90th_quantile_gt_50000000 =
-    quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h[3h]) > bool 50000000
+candidate_ndt:vdlimit_used_12h_prediction:90th_quantile =
+    quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h[3h])
 
 
 ## NDT Early Warning 2x site capacity thresholds.
 #
 # Raw boolean threshold violations.
-site:uplink:gt_500mbps =
+candidate_site:uplink:gt_500mbps =
     switch:ifHCOutOctets:bps2m{ifAlias="uplink"} > bool 500000000
 
-machine:inotify_extension_create_rpm:gt_60 =
+candidate_machine:inotify_extension_create_rpm:gt_60 =
     machine:inotify_extension_create:rpm2m > bool 60
 
-machine:node_disk_io_time_ratio:gt_50_pct =
+candidate_machine:node_disk_io_time_ratio:gt_50_pct =
     machine:node_disk_io_time_ms:max_ratio2m > bool 0.5
 
-ndt:vdlimit_used_12h_prediction:gt_50000000 =
+candidate_ndt:vdlimit_used_12h_prediction:gt_50gb =
     ndt:vdlimit_used:predict_linear3h_12h > bool 50000000

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -73,7 +73,41 @@ switch:ifHCOutOctets:bps2m =
 machine:node_disk_io_time_ms:max_ratio2m =
     max without(device) (irate(node_disk_io_time_ms{service="nodeexporter"}[4m])) / 1000
 
-# NDT vserver disk quota utilization, 12 hour estimate.
+# NDT vserver disk quota utilization, 12 hour estimate. Base 12h estimate on a
+# time range at least 25% of the time forward.
 # Units: KB
-ndt:vdlimit_used:predict_linear1h_12h =
-    predict_linear(vdlimit_used{experiment="ndt.iupui"}[1h], 12*60*60)
+ndt:vdlimit_used:predict_linear3h_12h =
+    predict_linear(vdlimit_used{experiment="ndt.iupui"}[3h], 12*60*60)
+
+
+## NDT Early Warning 2x site capacity thresholds.
+#
+# Shorter time ranges are chosen to favor faster sensitivity and longer time
+# ranges are chosen for slower sensitivity.
+
+# 90th percentile boolean threshold violations.
+site:uplink:90th_quantile_gt_500mbps =
+    quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[15m]) > bool 500000000
+
+machine:inotify_extension_create_rpm:90th_quantile_gt_60 =
+    quantile_over_time(0.90, machine:inotify_extension_create:rpm2m[30m]) > bool 60
+
+machine:node_disk_io_time_ratio:90th_quantile_gt_50_pct =
+    quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m[1h]) > bool 0.5
+
+ndt:vdlimit_used_12h_prediction:90th_quantile_gt_50000000 =
+    quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h[3h]) > bool 50000000
+
+
+# Raw boolean threshold violations.
+site:uplink:gt_500mbps =
+    switch:ifHCOutOctets:bps2m{ifAlias="uplink"} > bool 500000000
+
+machine:inotify_extension_create_rpm:gt_60 =
+    machine:inotify_extension_create:rpm2m > bool 60
+
+machine:node_disk_io_time_ratio:gt_50_pct =
+    machine:node_disk_io_time_ms:max_ratio2m > bool 0.5
+
+ndt:vdlimit_used_12h_prediction:gt_50000000 =
+    ndt:vdlimit_used:predict_linear3h_12h > bool 50000000

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -80,11 +80,19 @@ ndt:vdlimit_used:predict_linear3h_12h =
     predict_linear(vdlimit_used{experiment="ndt.iupui"}[3h], 12*60*60)
 
 
+##############################################################################
+# Candidate recording rules.
+##############################################################################
+# TODO: remove rules that are not actively used.
+#
+# Do not build dependencies on these rules until they have been moved out of
+# this candidate rule area.
+
 ## NDT Early Warning 2x site capacity thresholds.
 #
-# Shorter time ranges are chosen to favor faster sensitivity and longer time
-# ranges are chosen for slower sensitivity.
-
+# Shorter time ranges are chosen to favor higher sensitivity and longer time
+# ranges are chosen for lower sensitivity.
+#
 # 90th percentile boolean threshold violations.
 site:uplink:90th_quantile_gt_500mbps =
     quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[15m]) > bool 500000000
@@ -99,6 +107,8 @@ ndt:vdlimit_used_12h_prediction:90th_quantile_gt_50000000 =
     quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h[3h]) > bool 50000000
 
 
+## NDT Early Warning 2x site capacity thresholds.
+#
 # Raw boolean threshold violations.
 site:uplink:gt_500mbps =
     switch:ifHCOutOctets:bps2m{ifAlias="uplink"} > bool 500000000


### PR DESCRIPTION
This change adds new recording rules that calculate instantaneous violations of 2x site capacity thresholds. With these rules, it will be possible to calculate a percentage over a time range (e.g. day, week, or longer) that the 2x site capacity was violated.

For example, the following would calculate the percentage of time the site had at least 2x headroom:
```
1 - sum_over_time(site:uplink:gt_500mbps{site=~"$site.*"}[24h]) / count_over_time(site:uplink:gt_500mbps{site=~"$site.*"}[24h])
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/150)
<!-- Reviewable:end -->
