### PR TITLE
Split uplink and speed labels on snmp metrics.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -423,10 +423,9 @@ scrape_configs:
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.
     metric_relabel_configs:
-
       # 'ifAlias' labels use the format "uplink-<speed>" where speed is one of
-	  # "1g" or "10g". These rules split the two fields and adds a new label
-	  # for the speed.
+      # "1g" or "10g". These rules split the two fields and adds a new label
+      # for the speed.
       - source_labels: [ifAlias]
         regex: uplink-(.*)
         target_label: speed

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -424,13 +424,17 @@ scrape_configs:
     # into the datastore.
     metric_relabel_configs:
 
-      # Most all 'ifAlias' labels will be empty. Rather than pollute the
-      # datastore with a bunch of empty labels, only keep the ones that have
-      # some value.
+      # 'ifAlias' labels use the format "uplink-<speed>" where speed is one of
+	  # "1g" or "10g". These rules split the two fields and adds a new label
+	  # for the speed.
       - source_labels: [ifAlias]
-        regex: ^$
+        regex: uplink-(.*)
+        target_label: speed
+        replacement: ${1}
+      - source_labels: [ifAlias]
+        regex: (uplink)-.*
         target_label: ifAlias
-        replacement: ""
+        replacement: ${1}
 
   # Scrape config for pushgateway.
   #


### PR DESCRIPTION
This change will re-label snmp metrics whose ifAlias label is in the form `uplink-<speed>`.

This will allow us to identify 1g vs 10g sites in monitoring and dashboards and alert appropriately.

The rule should have no effect on ifAlias values that do not start with "uplink". The rule should also have no effect on existing ifAlias values of only "uplink".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/151)
<!-- Reviewable:end -->
