### PR TITLE
Increase accuracy of ParserDailyVolumeTooLow

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -262,19 +262,18 @@ ALERT SnmpExporterDownOrMissing
 
 
 # ParserDailyVolumeTooLow: today's test volume has dropped over 80% compared to
-# the 50th percentile test volume from the last three days. The alert condition
-# ignores batch processing.
+# the 50th percentile test volume from the last week. The alert condition
+# ignores batch processing and ignores 20% thresholds less than 1.
 ALERT ParserDailyVolumeTooLow
-  IF sum by(service) (increase(etl_test_count{service!~".*batch.*"}[2h]))
-     < 0.20 * quantile by(service) (0.50,
-         sum by(service) (increase(etl_test_count[2h] offset 1d))
+  IF sum by(service) (rate(etl_test_count{service!~".*batch.*"}[12h]))
+     < (0.20 * quantile by(service) (0.50,
+         sum by(service) (rate(etl_test_count[12h] offset 1d))
             OR
-         sum by(service) (increase(etl_test_count[2h] offset 3d))
+         sum by(service) (rate(etl_test_count[12h] offset 3d))
             OR
-         sum by(service) (increase(etl_test_count[2h] offset 5d))
+         sum by(service) (rate(etl_test_count[12h] offset 5d))
             OR
-         sum by(service) (increase(etl_test_count[2h] offset 7d))
-     )
+         sum by(service) (rate(etl_test_count[12h] offset 7d))) > 1)
   FOR 1h
   LABELS {
     severity = "page"


### PR DESCRIPTION
This change updates the condition for ParserDailyVolumeTooLow to improve accuracy. Since deployment, this alert has fired inaccurately about 7 times and accurately 0 times.

This change uses a longer time range (12h instead of 2h) and ignores small values. This new condition applied to historical data correctly detects the outage from Nov 29th and the surge of sidestream and paris-traceroute processing after updating those parsers. As well, it would only fire once in both cases.

Pipeline outage Nov 29th:
http://status.mlab-oti.measurementlab.net:3000/dashboard/db/parserdailyvolumetoolow?orgId=1&from=1511845200000&to=1512277200000

Sidestream & PTR reprocessing:
http://status.mlab-oti.measurementlab.net:3000/dashboard/db/parserdailyvolumetoolow?orgId=1&from=1512579600000&to=1513184400000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/152)
<!-- Reviewable:end -->
