### PR TITLE
Increases timeout for tcp_v4_[tls_]online modules from 5s to 10s

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -29,14 +29,14 @@ modules:
   # target=<hostname:port>
   tcp_v4_online:
     prober: tcp
-    timeout: 5s
+    timeout: 10s
     tcp:
       protocol: "tcp4"
 
   # target=<hostname:port>
   ssh_v4_online:
     prober: tcp
-    timeout: 10s
+    timeout: 5s
     tcp:
       protocol: "tcp4"
       query_response:

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -36,7 +36,7 @@ modules:
   # target=<hostname:port>
   ssh_v4_online:
     prober: tcp
-    timeout: 5s
+    timeout: 10s
     tcp:
       protocol: "tcp4"
       query_response:
@@ -45,7 +45,7 @@ modules:
   # target=<hostname:port>
   tcp_v4_tls_online:
     prober: tcp
-    timeout: 5s
+    timeout: 10s
     tcp:
       protocol: "tcp4"
       tls: true

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -29,7 +29,7 @@ modules:
   # target=<hostname:port>
   tcp_v4_online:
     prober: tcp
-    timeout: 10s
+    timeout: 9s
     tcp:
       protocol: "tcp4"
 
@@ -45,7 +45,7 @@ modules:
   # target=<hostname:port>
   tcp_v4_tls_online:
     prober: tcp
-    timeout: 10s
+    timeout: 9s
     tcp:
       protocol: "tcp4"
       tls: true


### PR DESCRIPTION
Intuition would dictate that 5s is more than enough to establish a TCP connection to a remote server, but for some reason a lgood number of the `ndt_ssl` and `ndt_raw` checks are timing out at 5s. In order to find out the depth of this problem, this PR increases the timeout to 10s. If things are still timing out at 10s, then something fundamental must be wrong which will warrant a more in-depth investigation. But currently, we don't know whether the timed-out check would have succeeded a few seconds later, or whether the problem is great enough that it would even timeout at 10s. After this PR we'll be able to assess the situation better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/155)
<!-- Reviewable:end -->
