### PR TITLE
Upgrades blackbox_exporter to v0.11.0, and updates config to be compatible.

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -31,14 +31,14 @@ modules:
     prober: tcp
     timeout: 9s
     tcp:
-      protocol: "tcp4"
+      preferred_ip_protocol: "ip4"
 
   # target=<hostname:port>
   ssh_v4_online:
     prober: tcp
     timeout: 5s
     tcp:
-      protocol: "tcp4"
+      preferred_ip_protocol: "ip4"
       query_response:
         - expect: "SSH-2.0-OpenSSH_.+"
 
@@ -47,7 +47,7 @@ modules:
     prober: tcp
     timeout: 9s
     tcp:
-      protocol: "tcp4"
+      preferred_ip_protocol: "ip"
       tls: true
 
   # target=<hostname>:9773/sapi/state
@@ -55,7 +55,7 @@ modules:
     prober: http
     timeout: 5s
     http:
-      protocol: "tcp4"
+      preferred_ip_protocol: "ip4"
       fail_if_not_matches_regexp:
         - "queue_len_cur"
 
@@ -64,7 +64,7 @@ modules:
     prober: tcp
     timeout: 5s
     tcp:
-      protocol: "tcp4"
+      preferred_ip_protocol: "ip4"
       query_response:
         # @RSYNCD: is followed by a version number, e.g. 30.0. Rather than
         # dropping the connection immediately, we simulate a module list
@@ -79,7 +79,6 @@ modules:
     prober: icmp
     timeout: 5s
     icmp:
-      protocol: "icmp"
       preferred_ip_protocol: "ip4"
 
   # target=<http[s]://host:port>
@@ -92,4 +91,4 @@ modules:
     prober: http
     timeout: 5s
     http:
-      method: GET
+      method: "GET"

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -47,7 +47,7 @@ modules:
     prober: tcp
     timeout: 9s
     tcp:
-      preferred_ip_protocol: "ip"
+      preferred_ip_protocol: "ip4"
       tls: true
 
   # target=<hostname>:9773/sapi/state

--- a/k8s/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/prometheus-federation/deployments/blackbox.yml
@@ -32,7 +32,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/blackbox-exporter/tags/ for the current
       # stable version.
-      - image: prom/blackbox-exporter:v0.4.0
+      - image: prom/blackbox-exporter:v0.11.0
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.

--- a/k8s/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/prometheus-federation/deployments/blackbox.yml
@@ -37,7 +37,7 @@ spec:
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: blackbox-server
-        args: ["-config.file=/etc/blackbox/config.yml"]
+        args: ["--config.file=/etc/blackbox/config.yml"]
         ports:
           - containerPort: 9115
         resources:


### PR DESCRIPTION
Our currently running version of blackbox_exporter (0.4.0) is "ancient" (2017-01-12). This PR tells k8s to deploy version v0.11.0 instead. It also makes a few small changes to the config file to make it compatible with this newer version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/156)
<!-- Reviewable:end -->
