### PR TITLE
Always set GITHUB_RECEIVER_URL

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -81,9 +81,11 @@ kubectl create configmap grafana-env \
 SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
 GITHUB_RECEIVER_URL=
 SHORT_PROJECT=${PROJECT/mlab-/}
-if [[ ${PROJECT} == mlab-oti ]] ; then
-  GITHUB_RECEIVER_URL=http://status.${PROJECT}.measurementlab.net:9393/v1/receiver
-fi
+
+# Note: without a url, alertmanager will fail to start. But, for non-production
+# projects, there will be no github receiver running. This should be a no-op.
+GITHUB_RECEIVER_URL=http://status.${PROJECT}.measurementlab.net:9393/v1/receiver
+
 sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
     -e 's|{{GITHUB_RECEIVER_URL}}|'$GITHUB_RECEIVER_URL'|g' \
     -e 's|{{SHORT_PROJECT}}|'$SHORT_PROJECT'|g' \


### PR DESCRIPTION
This change sets the GITHUB_RECEIVER_URL unconditionally. Previously, the alertmanager configuration would have an empty url for non-production projects. However, perhaps with the upgrade to v0.11 of the alertmanager, an empty url is now an error, and in mlab-staging the AM was not running.

This change sets GITHUB_RECEIVER_URL unconditionally so that a value is present even if it won't be running in non-production projects. The AM trying to send a message to an absent service should be a no-op.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/158)
<!-- Reviewable:end -->
