### PR TITLE
Increase resource alloc for blackbox exporter

### DIFF
--- a/k8s/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/prometheus-federation/deployments/blackbox.yml
@@ -41,12 +41,15 @@ spec:
         ports:
           - containerPort: 9115
         resources:
+          # TODO: reduce resource allocation once
+          # https://github.com/prometheus/blackbox_exporter/issues/270 is
+          # resolved. These values are much more than what should be needed.
           requests:
-            memory: "100Mi"
-            cpu: "1000m"
+            memory: "500Mi"
+            cpu: "2000m"
           limits:
-            memory: "100Mi"
-            cpu: "1000m"
+            memory: "500Mi"
+            cpu: "2000m"
         volumeMounts:
         # /etc/blackbox/config.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/blackbox


### PR DESCRIPTION
This change addresses a performance regression in the blackbox exporter.

We believe that the issue is due to the Go GC as originally reported in https://github.com/prometheus/blackbox_exporter/issues/270

It may be that one day the Go compiler will fix the inefficiency but until then, we can simply provide more resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/159)
<!-- Reviewable:end -->
