### PR TITLE
Update alert delay threshold for ScraperMostRecentArchivedFileTimeIsTooOld

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -73,8 +73,9 @@ ALERT SidestreamIsNotRunning
 # ParserDailyVolumeTooLow will trigger first.
 #
 # Note: the delay threshold is set to 2h to prevent false positives. For
-# example, a machine is remains running but becomes is not network accessible.
-# After the machine is network accessible, scraper needs time to catch up.
+# example, if a machine remains running while it is not network accessible,
+# then the machine will need time for scraper to catch up once it is network
+# accessible again.
 #
 # TODO(soltesz): remove the != 0 check when legacy records are removed.
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -72,6 +72,10 @@ ALERT SidestreamIsNotRunning
 # affected by this at once, or b) many machines are affected and the
 # ParserDailyVolumeTooLow will trigger first.
 #
+# Note: the delay threshold is set to 2h to prevent false positives. For
+# example, a machine is remains running but becomes is not network accessible.
+# After the machine is network accessible, scraper needs time to catch up.
+#
 # TODO(soltesz): remove the != 0 check when legacy records are removed.
 ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (56 * 60 * 60)
@@ -79,7 +83,7 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
      (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
         UNLESS ON(machine)
      lame_duck_node == 1
-  FOR 10m
+  FOR 2h
   LABELS {
     severity = "page"
   }


### PR DESCRIPTION
This change increases the delay threshold for firing the ScraperMostRecentArchivedFileTimeIsTooOld alert.

The delay threshold is set to 2h to prevent false positives. For example, if a machine remains running while it is not network accessible, then the machine will need time for scraper to catch up once it is network accessible again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/162)
<!-- Reviewable:end -->
