### PR TITLE
Scrape nagios_exporter on nagios-oam, and alert if Nagios is down.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -304,3 +304,17 @@ ALERT ParserDailyVolumeTooLow
     hints = "Are machines online? Is data being collected? Is the parser working?",
     url = "http://status.mlab-oti.measurementlab.net:3000/dashboard/db/parserdailyvolumetoolow"
   }
+
+# Nagios is not running (or otherwise broken) on nagios-oam.measurementlab.net,
+# or the Prometheus job for scraping the nagios_exporter on this instance is
+# missing.
+ALERT NagiosOamDownOrMissing
+  IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR absent(up{job="nagios-oam-exporter"})
+  FOR 10m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "The Nagios OA&M instance is down on {{ $labels.instance }}.",
+    hints = "The Nagios OA&M instance runs in a Linode VM."
+  }

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -285,6 +285,14 @@ scrape_configs:
       - targets: ['nagios.measurementlab.net:9267']
 
 
+  # Scrape config for the nagios-oam exporter.
+  #
+  # The nagios exporter generates its own labels.
+  - job_name: 'nagios-oam-exporter'
+    static_configs:
+      - targets: ['nagios-oam.measurementlab.net:9267']
+
+
   # Scrape config for the snmp_exporter. There is one snmp_exporter service
   # running in a Docker container on a GCE VM in each GCP project.
   #


### PR DESCRIPTION
We have a secondary, and very small, Nagios instance that runs in a Linode VM whose sole purpose is to monitor critical infrastructure machines and services. For example, this instance monitors to be sure that eb.measurementlab.net is up and that Nagios is running. It monitors that dns.measurementlab.net is up, etc. However, nothing currently monitors whether this instance is running or not. This PR tells Prometheus to scrape the nagios_exporter running on that VM, and to alert if Nagios is not running, or if the `nagios-oam-exporter` job doesn't exist for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/164)
<!-- Reviewable:end -->
