### PR TITLE
set constants to zero

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -320,12 +320,12 @@ ALERT ParserDailyVolumeTooLow
          label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*"}[24h] offset 3d)),"delay","3d","",".*" ) OR
          label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*"}[24h] offset 5d)),"delay","5d","",".*" ) OR
          label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*"}[24h] offset 7d)),"delay","7d","",".*" ) OR
-         label_replace(label_replace(vector( 500000),"delay","c1","",".*" ), "service", "etl-ndt-parser",        "", ".*") OR
-         label_replace(label_replace(vector( 500000),"delay","c2","",".*" ), "service", "etl-ndt-parser",        "", ".*") OR
-         label_replace(label_replace(vector(2000000),"delay","c1","",".*" ), "service", "etl-sidestream-parser", "", ".*") OR
-         label_replace(label_replace(vector(2000000),"delay","c2","",".*" ), "service", "etl-sidestream-parser", "", ".*") OR
-         label_replace(label_replace(vector(2000000),"delay","c1","",".*" ), "service", "etl-traceroute-parser", "", ".*") OR
-         label_replace(label_replace(vector(2000000),"delay","c2","",".*" ), "service", "etl-traceroute-parser", "", ".*")
+         label_replace(label_replace(vector(0),"delay","c1","",".*" ), "service", "etl-ndt-parser",        "", ".*") OR
+         label_replace(label_replace(vector(0),"delay","c2","",".*" ), "service", "etl-ndt-parser",        "", ".*") OR
+         label_replace(label_replace(vector(0),"delay","c1","",".*" ), "service", "etl-sidestream-parser", "", ".*") OR
+         label_replace(label_replace(vector(0),"delay","c2","",".*" ), "service", "etl-sidestream-parser", "", ".*") OR
+         label_replace(label_replace(vector(0),"delay","c1","",".*" ), "service", "etl-traceroute-parser", "", ".*") OR
+         label_replace(label_replace(vector(0),"delay","c2","",".*" ), "service", "etl-traceroute-parser", "", ".*")
          ))
   FOR 2h
   LABELS {


### PR DESCRIPTION
The alert is used for both staging and production.  Since staging volume is very low, the moderate constant values are much too high.  Zero works quite well unless the pipeline or scraper is down for multiple days, we just change to zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/171)
<!-- Reviewable:end -->
