### PR TITLE
Change the 96Gi request to a 96G request.

### DIFF
--- a/k8s/scraper-cluster/mlab-oti.yml
+++ b/k8s/scraper-cluster/mlab-oti.yml
@@ -1,5 +1,5 @@
 # Configuration values for mlab-oti
 
-PROMETHEUS_RAM: 96Gi
+PROMETHEUS_RAM: 96G
 PROMETHEUS_CPU: 8000m
 PROMETHEUS_VOLUME_NAME: auto-prometheus-ssd1

--- a/k8s/scraper-cluster/mlab-staging.yml
+++ b/k8s/scraper-cluster/mlab-staging.yml
@@ -1,5 +1,5 @@
 # Configuration values for mlab-staging.
 
-PROMETHEUS_RAM: 96Gi
+PROMETHEUS_RAM: 96G
 PROMETHEUS_CPU: 8000m
 PROMETHEUS_VOLUME_NAME: auto-prometheus-ssd0


### PR DESCRIPTION
The servers have 98945476Ki of RAM allocateable, which is less than 96Gi
(100663296Ki) but is more than 96G. So if we drop the i, then then job
will become allocateable on highmem instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/172)
<!-- Reviewable:end -->
