### PR TITLE
Add autorepair and autoupgrade options to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ gcloud container \
   --machine-type=n1-standard-8 \
   --scopes "https://www.googleapis.com/auth/cloud-platform" \
   --num-nodes 3 \
+  --enable-autorepair --enable-autoupgrade \
   --node-labels=prometheus-node=true
 ```
 
@@ -45,6 +46,7 @@ gcloud --project=mlab-staging container node-pools create default-pool-N \
   --zone=us-east1-c \
   --scopes "https://www.googleapis.com/auth/cloud-platform" \
   --node-labels=prometheus-node=true \
+  --enable-autorepair --enable-autoupgrade \
   --machine-type=n1-standard-8
 ```
 
@@ -81,6 +83,7 @@ gcloud --project=mlab-oti container node-pools create prometheus-pool \
   --num-nodes=2 \
   --zone=us-central1-a \
   --node-labels=prometheus-node=true \
+  --enable-autorepair --enable-autoupgrade \
   --machine-type=n1-highmem-16
 ```
 


### PR DESCRIPTION
This change updates documentation to enable autorepair and autoupgrade options when creating a new cluster or node pool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/178)
<!-- Reviewable:end -->
