### PR TITLE
Update delay for firing ClusterDown alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -28,7 +28,7 @@
 # All scraper metrics come from federated targets, so this is critical.
 ALERT ClusterDown
   IF up{job="federation-targets"} == 0
-  FOR 3m
+  FOR 10m
   LABELS {
     severity = "page"
   }


### PR DESCRIPTION
This change is to address false-positives due to cluster node auto upgrades, such as in:
https://github.com/m-lab/scraper/issues/245

The server was down for less than 5m, so a threshold of 10m should be a better threshold that something needs attention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/180)
<!-- Reviewable:end -->
