### PR TITLE
Remerges the script-exporter jobs

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -444,56 +444,15 @@ scrape_configs:
         replacement: ${1}
 
 
-  # script_exporter configurations for the ndt_e2e script. The scrape_timeout is
-  # set very high because one of the NDT end-to-end test will take around 35
-  # seconds.
-  - job_name: 'script-targets-ndt-e2e'
+  # script_exporter configurations. The scrape_timeout is set very high because
+  # the NDT end-to-end test will take around 35 seconds.
+  - job_name: 'script-targets'
     metrics_path: /probe
-    scrape_interval: 10m
     scrape_timeout: 45s
 
     file_sd_configs:
       - files:
-          - /script-targets/ndt_e2e.json
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    # This relabel config is necessary. The relabel config redefines the address
-    # to scrape and sets the correct parameters to pass to the scrape target.
-    relabel_configs:
-      # The value of the source label named "service" must match the name of a
-      # configured script in the script_exporter configuration. See this file:
-      # https://github.com/m-lab/prometheus-script-exporter/blob/master/script_exporter.yml
-      - source_labels: [service]
-        regex: (.*)
-        target_label: __param_name
-        replacement: ${1}
-
-      # The default __address__ value is a target host from the config file.
-      # Here, we set (i.e. "replace") a request parameter "target" equal to the
-      # host value.
-      - source_labels: [__address__]
-        regex: (.*)
-        target_label: __param_target
-        replacement: ${1}
-
-      # Since __address__ is the target that prometheus will contact,
-      # unconditionally reset the __address__ label to the script_exporter
-      # address.
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: script-exporter.{{PROJECT}}.measurementlab.net:9172
-
-
-  # script_exporter configurations for the ndt_queue script.
-  - job_name: 'script-targets-ndt-queue'
-    metrics_path: /probe
-    scrape_timeout: 15s
-
-    file_sd_configs:
-      - files:
-          - /script-targets/ndt_queue.json
+          - /script-targets/*.json
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 


### PR DESCRIPTION
PR #183 split the script-exporter Prom job into two separate jobs because one (the NDT e2e) test needed a `scrape_interval` of 10m. However, we've come to discover that Prometheus doesn't recommend an interval of more than 2m, and if you have one you start running into the [staleness gotcha](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness).

I've now modified the script-exporter ndt_e2e.sh script to cache results and return the cached result if it is less than 10m old. With this change, Prom can now start polling it every minute, so we don't need to split the jobs apart. This PR essentially undoes #183.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/187)
<!-- Reviewable:end -->
