### PR TITLE
Add explicit version of gcp-service-discovery docker image

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -133,7 +133,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/gcp-service-discovery
+      - image: measurementlab/gcp-service-discovery:v1.0
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",


### PR DESCRIPTION
This change adds an explicit version to the gcp-service-discovery docker image.

After fixing a bug earlier today, the "latest" tag in dockerhub is replaced with the new "latest" version. This was fine, but it means if the staging or production instances are restarted they will get the updated version without notice.

By adding an explicit version we can prevent unintended side effects on production environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/189)
<!-- Reviewable:end -->
