### PR TITLE
Adds node_exporter targets for snmp-exporter and script-exporter jobs

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -293,16 +293,6 @@ scrape_configs:
       - targets: ['nagios-oam.measurementlab.net:9267']
 
 
-  # Scrape config for the snmp_exporter. There is one snmp_exporter service
-  # running in a Docker container on a GCE VM in each GCP project.
-  #
-  # The snmp_exporter generates its own labels.
-  - job_name: 'snmp-exporter'
-    static_configs:
-      - targets:
-        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116
-
-
   # Scrape config for federation.
   #
   # The '/federate' target allows retrieving a set of timeseries from other
@@ -390,6 +380,18 @@ scrape_configs:
         target_label: __address__
         replacement: blackbox-public-service.default.svc.cluster.local:9115
 
+
+  # Scrape config for the snmp_exporter. There is one snmp_exporter service
+  # running in a Docker container on a GCE VM in each GCP project.
+  #
+  # The snmp_exporter generates its own labels.
+  - job_name: 'snmp-exporter'
+    static_configs:
+      - targets:
+        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116
+        - snmp-exporter.{{PROJECT}}.measurementlab.net:9100
+
+
   # SNMP configurations.
   - job_name: 'snmp-targets'
     metrics_path: /snmp
@@ -442,6 +444,17 @@ scrape_configs:
         regex: (uplink)-.*
         target_label: ifAlias
         replacement: ${1}
+
+
+  # Scrape config for the script_exporter. There is one script_exporter service
+  # running in a Docker container on a GCE VM in each GCP project.
+  #
+  # The script_exporter generates its own labels.
+  - job_name: 'script-exporter'
+    static_configs:
+      - targets:
+        - script-exporter.{{PROJECT}}.measurementlab.net:9172
+        - script-exporter.{{PROJECT}}.measurementlab.net:9100
 
 
   # script_exporter configurations. The scrape_timeout is set very high because


### PR DESCRIPTION
* Adds a new target for the `snmp-exporter` job to scrape the node_exporter instance that is running inside each snmp-exporter VM.  Also, moves the entire `snmp-exporter` job so it sits directly above the `snmp-targets` job for easier reading of the config (grouping like configs).

* Add a new job named `script-exporter` with two targets:
  * A target to scrape any metrics the script-exporter exports about its own operation
  * A target to scrape the node_exporter instance that runs inside of each script-exporter VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/190)
<!-- Reviewable:end -->
