### PR TITLE
Adds a new alert which will fire when scraping SNMP from a switch fails

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -284,7 +284,7 @@ ALERT SnmpExporterMissingMetrics
 
 # Prometheus is unable to scrape SNMP data from a switch.
 # Note: ignores testing pod switches.
-ALERT SnmpScrapingFailing
+ALERT SnmpScrapeFailing
   IF sum_over_time(up{job="snmp-targets", site!~".*t"}[15m]) == 0
   FOR 15m
   LABELS {
@@ -292,7 +292,7 @@ ALERT SnmpScrapingFailing
   }
   ANNOTATIONS {
     summary = "Scraping SNMP data from a switch is failing.",
-    hints = "Did the SNMP community string change on the switch? The snmp_exporter may be running with an old config. Check that the switch-config submodule is up-to-date in the m-lab/prometheus-snmp-exporter repo",
+    hints = "Did the SNMP community string change on the switch? The snmp_exporter may be running with an old config. If so, it may be necessary to trigger a new deployment of https://github.com/m-lab/prometheus-snmp-exporter."
   }
 
 # Prometheus is unable to get data from the script_exporter service.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -282,6 +282,19 @@ ALERT SnmpExporterMissingMetrics
     dashboard = "http://status.mlab-oti.measurementlab.net:3000/dashboard/db/switch-metrics"
   }
 
+# Prometheus is unable to scrape SNMP data from a switch.
+# Note: ignores testing pod switches.
+ALERT SnmpScrapingFailing
+  IF sum_over_time(up{job="snmp-targets", site!~".*t"}[15m]) == 0
+  FOR 15m
+  LABELS {
+    severity = "page"
+  }
+  ANNOTATIONS {
+    summary = "Scraping SNMP data from a switch is failing.",
+    hints = "Did the SNMP community string change on the switch? The snmp_exporter may be running with an old config. Check that the switch-config submodule is up-to-date in the m-lab/prometheus-snmp-exporter repo",
+  }
+
 # Prometheus is unable to get data from the script_exporter service.
 ALERT ScriptExporterDownOrMissing
   IF up{job="script-exporter"} == 0 OR absent(up{job="script-exporter"})


### PR DESCRIPTION
We need to be alerted when Prometheus is unable to scrape SNMP metrics from a switch for more than a certain amount of time. 

**NOTE**: One small problem with the alert is that it ultimately relies on sites in sites.py, which may contains sites which aren't even launched yet (don't have a switch). Questions:

* How do we cleanly suppress alerts for sites which don't even exist in reality?
* How do we cleanly handle sites where we know/expect a switch will be down for a long time (e.g., bog01, lga02 (being upgraded))?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/193)
<!-- Reviewable:end -->
