### PR TITLE
Configures IPv6 modules for the blackbox_exporter

### DIFF
--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -40,12 +40,21 @@ modules:
     tcp:
       preferred_ip_protocol: "ip6"
 
-  # target=<hostname:port>
+  # IPv4 target=<hostname:port>
   ssh_v4_online:
     prober: tcp
     timeout: 9s
     tcp:
       preferred_ip_protocol: "ip4"
+      query_response:
+        - expect: "SSH-2.0-OpenSSH_.+"
+
+  # IPv6 target=<hostname:port>
+  ssh_v6_online:
+    prober: tcp
+    timeout: 9s
+    tcp:
+      preferred_ip_protocol: "ip6"
       query_response:
         - expect: "SSH-2.0-OpenSSH_.+"
 

--- a/config/federation/blackbox/config.yml
+++ b/config/federation/blackbox/config.yml
@@ -26,12 +26,19 @@
 # See https://github.com/prometheus/blackbox_exporter for additional examples.
 
 modules:
-  # target=<hostname:port>
+  # IPv4: target=<hostname:port>
   tcp_v4_online:
     prober: tcp
     timeout: 9s
     tcp:
       preferred_ip_protocol: "ip4"
+
+  # IPv6: target=<hostname:port>
+  tcp_v6_online:
+    prober: tcp
+    timeout: 9s
+    tcp:
+      preferred_ip_protocol: "ip6"
 
   # target=<hostname:port>
   ssh_v4_online:
@@ -42,7 +49,7 @@ modules:
       query_response:
         - expect: "SSH-2.0-OpenSSH_.+"
 
-  # target=<hostname:port>
+  # IPv4: target=<hostname:port>
   tcp_v4_tls_online:
     prober: tcp
     timeout: 9s
@@ -50,12 +57,29 @@ modules:
       preferred_ip_protocol: "ip4"
       tls: true
 
-  # target=<hostname>:9773/sapi/state
-  neubot_online:
+  # IPv6: target=<hostname:port>
+  tcp_v6_tls_online:
+    prober: tcp
+    timeout: 9s
+    tcp:
+      preferred_ip_protocol: "ip6"
+      tls: true
+
+  # IPv4: target=<hostname>:9773/sapi/state
+  neubot_online_v4:
     prober: http
     timeout: 9s
     http:
       preferred_ip_protocol: "ip4"
+      fail_if_not_matches_regexp:
+        - "queue_len_cur"
+
+  # IPv6: target=<hostname>:9773/sapi/state
+  neubot_online_v6:
+    prober: http
+    timeout: 9s
+    http:
+      preferred_ip_protocol: "ip6"
       fail_if_not_matches_regexp:
         - "queue_len_cur"
 

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -159,8 +159,12 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/legacy-targets/ndt_inotify.json",
                 "--http-target=/targets/blackbox-targets/mobiperf.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/mobiperf.json",
+                "--http-target=/targets/blackbox-targets/mobiperf_ipv6.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/mobiperf_ipv6.json",
                 "--http-target=/targets/blackbox-targets/neubot.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/neubot.json",
+                "--http-target=/targets/blackbox-targets/neubot_ipv6.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/neubot_ipv6.json",
                 "--project={{GCLOUD_PROJECT}}"]
         resources:
           requests:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -143,6 +143,8 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/legacy-targets/nodeexporter.json",
                 "--http-target=/targets/blackbox-targets/ssh806.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/ssh806.json",
+                "--http-target=/targets/blackbox-targets/ssh806_ipv6.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/ssh806_ipv6.json",
                 "--http-target=/targets/blackbox-targets/rsyncd.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/rsyncd.json",
                 "--http-target=/targets/snmp-targets/snmpexporter.json",


### PR DESCRIPTION
This PR also configures gcp-service-discovery to fetch IPv6 targets for mobiperf and neubot. These targets will be generated by the changes in m-lab/operator#205.

Our current Nagios configuration checks both IPv4 and IPv6 for neubot and mobiperf. In order to keep parity in our migration from Nagios to Prometheus, we should do IPv6 checks for these services in Prometheus too. In order to achieve this we also need blackbox_exporter modules for IPv4 checks. This PR implements these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/198)
<!-- Reviewable:end -->
