### PR TITLE
Add missing namespace directive to kube-lego ServiceAccount.

### DIFF
--- a/k8s/prometheus-federation/roles/rbac-kube-lego.yml
+++ b/k8s/prometheus-federation/roles/rbac-kube-lego.yml
@@ -55,6 +55,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-lego
+  namespace: kube-lego
 ---
 # Bind the kube-lego ServiceAccount to the ClusterRole above.
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
The kube-lego ServiceAccount is erroneously missing the directive which scopes it to the kube-lego namespace, which keeps the kube-lego pods from being instantiated on a new cluster. This fixes that problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/205)
<!-- Reviewable:end -->
