### PR TITLE
Add alert case for nagios exporter when `up == 0`

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -369,7 +369,7 @@ ALERT ParserDailyVolumeTooLow
     url = "http://status.mlab-oti.measurementlab.net:3000/dashboard/file/Alert_ParserDailyVolumeTooLow.json"
   }
 
-# Nagios exporter is not responding.
+# Nagios exporter cannot be scrapped (i.e. is down according to prometheus).
 ALERT NagiosExporterDown
   IF up{job="nagios-oam-exporter"} == 0 OR up{job="nagios-exporter"} == 0
   FOR 10m
@@ -381,7 +381,7 @@ ALERT NagiosExporterDown
     hints = "The Nagios exporter instance runs in a Linode VM."
   }
 
-# Nagios is not running on nagios[-oam].measurementlab.net.
+# Nagios exporter is running but not fully functional.
 ALERT NagiosExporterUnavailable
   IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR nagios_livestatus_available{job="nagios-exporter"} == 0
   FOR 10m
@@ -393,7 +393,7 @@ ALERT NagiosExporterUnavailable
     hints = "The Nagios exporter instance runs in a Linode VM."
   }
 
-# Prometheus is not scraping metrics from the nagios exporter.
+# Nagios exporter is not scraped at all.
 ALERT NagiosExporterMissing
   IF absent(up{job="nagios-oam-exporter"}) OR absent(up{job="nagios-exporter"})
   FOR 10m

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -369,15 +369,27 @@ ALERT ParserDailyVolumeTooLow
     url = "http://status.mlab-oti.measurementlab.net:3000/dashboard/file/Alert_ParserDailyVolumeTooLow.json"
   }
 
-# Nagios is not running on nagios[-oam].measurementlab.net.
+# Nagios exporter is not responding.
 ALERT NagiosExporterDown
-  IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR nagios_livestatus_available{job="nagios-exporter"} == 0
+  IF up{job="nagios-oam-exporter"} == 0 OR up{job="nagios-exporter"} == 0
   FOR 10m
   LABELS {
     severity = "ticket"
   }
   ANNOTATIONS {
     summary = "The Nagios exporter instance is down on {{ $labels.instance }}.",
+    hints = "The Nagios exporter instance runs in a Linode VM."
+  }
+
+# Nagios is not running on nagios[-oam].measurementlab.net.
+ALERT NagiosExporterUnavailable
+  IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR nagios_livestatus_available{job="nagios-exporter"} == 0
+  FOR 10m
+  LABELS {
+    severity = "ticket"
+  }
+  ANNOTATIONS {
+    summary = "The Nagios exporter instance is unavailable on {{ $labels.instance }}.",
     hints = "The Nagios exporter instance runs in a Linode VM."
   }
 


### PR DESCRIPTION
Recently, the nagios-exporter was not responding ( `up == 0`) but there was no alert firing.

Previously, the alerts covered two cases:
 * `up` is absent
 * `nagios_livestatus_available == 0`, the exporter is running but has incomplete data.

The third case:
 * `up == 0` when the nagios exporter has an `up` metric but is nonfunctional.

This PR adds an alert for the third case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/214)
<!-- Reviewable:end -->
