### PR TITLE
Add basic auth credentials to alertmanager URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,3 +160,5 @@ deploy:
 before_install:
 - travis/decrypt.sh "$encrypted_1c8dd3704323_key" "$encrypted_1c8dd3704323_iv"
   keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
+- sudo apt-get -qq update
+- sudo apt-get install -y apache2-utils

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -67,7 +67,7 @@ kubectl create secret generic grafana-secrets \
 export PROM_AUTH_USER=PROMETHEUS_BASIC_AUTH_USER_${PROJECT/-/_}
 export PROM_AUTH_PASS=PROMETHEUS_BASIC_AUTH_PASS_${PROJECT/-/_}
 kubectl create secret generic prometheus-auth \
-    "--from-literal=auth=$(htpasswd -nb ${!PROM_AUTH_USER} ${!PROM_USER_PASS})"\
+    "--from-literal=auth=$(htpasswd -nb ${!PROM_AUTH_USER} ${!PROM_AUTH_PASS})"\
     --dry-run -o json | kubectl apply -f -
 AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 export ALERTMANAGER_URL=https://$AUTH@alertmanager.${PROJECT}.measurementlab.net

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -65,9 +65,12 @@ kubectl create secret generic grafana-secrets \
     "--from-literal=admin-password=${GRAFANA_PASSWORD}" \
     --dry-run -o json | kubectl apply -f -
 
-PROMETHEUS_BASIC_AUTH=PROMETHEUS_BASIC_AUTH_${PROJECT/-/_}
+# Generate the basic auth string for Prometheus.
+export PROMETHEUS_BASIC_AUTH_USER=PROMETHEUS_BASIC_AUTH_USER_${PROJECT/-/_}
+export PROMETHEUS_BASIC_AUTH_PASS=PROMETHEUS_BASIC_AUTH_PASS_${PROJECT/-/_}
 kubectl create secret generic prometheus-auth \
-    "--from-literal=auth=${!PROMETHEUS_BASIC_AUTH}" \
+    "--from-literal=auth=$(htpasswd -nb ${!PROMETHEUS_BASIC_AUTH_USER}\ 
+    ${!PROMETHEUS_BASIC_AUTH_PASS})" \
     --dry-run -o json | kubectl apply -f -
 set -x
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -24,8 +24,6 @@ PROJECT=${PROJECT:?Please provide project id: $USAGE}
 CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
 
 export GRAFANA_DOMAIN=grafana.${PROJECT}.measurementlab.net
-# TODO: Add inline basic-auth credentials.
-export ALERTMANAGER_URL=https://alertmanager.${PROJECT}.measurementlab.net
 
 # Config maps and Secrets
 
@@ -66,12 +64,13 @@ kubectl create secret generic grafana-secrets \
     --dry-run -o json | kubectl apply -f -
 
 # Generate the basic auth string for Prometheus.
-export PROMETHEUS_BASIC_AUTH_USER=PROMETHEUS_BASIC_AUTH_USER_${PROJECT/-/_}
-export PROMETHEUS_BASIC_AUTH_PASS=PROMETHEUS_BASIC_AUTH_PASS_${PROJECT/-/_}
+export PROM_AUTH_USER=PROMETHEUS_BASIC_AUTH_USER_${PROJECT/-/_}
+export PROM_AUTH_PASS=PROMETHEUS_BASIC_AUTH_PASS_${PROJECT/-/_}
 kubectl create secret generic prometheus-auth \
-    "--from-literal=auth=$(htpasswd -nb ${!PROMETHEUS_BASIC_AUTH_USER}\ 
-    ${!PROMETHEUS_BASIC_AUTH_PASS})" \
+    "--from-literal=auth=$(htpasswd -nb ${!PROM_AUTH_USER} ${!PROM_USER_PASS})"\
     --dry-run -o json | kubectl apply -f -
+AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
+export ALERTMANAGER_URL=https://$AUTH@alertmanager.${PROJECT}.measurementlab.net
 set -x
 
 

--- a/k8s/prometheus-federation/deployments/nginx.yml
+++ b/k8s/prometheus-federation/deployments/nginx.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Syntax for nginx configuration measurement units can be found here:
 # https://nginx.org/en/docs/syntax.html
 data:
-  proxy-connect-timeout: "15s"
+  proxy-connect-timeout: "300s"
   proxy-read-timeout: "600s"
   proxy-send-timeout: "600s"
   hsts-include-subdomains: "false"


### PR DESCRIPTION
This prepends the basic auth credentials for prometheus to the alertmanager URL, so that alerts sent to Slack can be clicked on directly and be authenticated without additional user interaction. Accordingly, the way that the basic authorization string is generated is changed. The string is now generated by Travis, using plaintext username and password added as separate environment variables in the Travis environment and the `htpasswd` utility that has been added to Travis. The alertmanager pod must be restarted before the modified URLs are used.

In addition to the above changes, the `proxy-connect-timeout` for the nginx ingress is increased to 300 seconds.