### PR TITLE
Adds JSON for Ops_PlatformOverview Grafana dashboard.

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -53,9 +53,9 @@ kubectl create configmap grafana-config \
     --dry-run -o json | kubectl apply -f -
 
 ## Grafana dashboards
-kubectl replace configmap grafana-dashboards \
+kubectl create configmap grafana-dashboards \
     --from-file=config/federation/grafana/dashboards \
-    --dry-run -o json | kubectl apply -f -
+    --dry-run -o json | kubectl replace -f -
 
 # Keep the password a secret.
 set +x

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -53,6 +53,12 @@ kubectl create configmap grafana-config \
     --dry-run -o json | kubectl apply -f -
 
 ## Grafana dashboards
+# We are piping the configmap data to `kubectl replace` here (instead of
+# `kubectl create`) due to a limitation of the size of metadata.annotations in
+# k8s. When using `create` we hit an error complaining about metadata.annotation
+# exceeding 262144 characters. Using `replace` apparently overwrites old
+# metadata allowing room for the new. We will still have a problem when the
+# total size of the JSON files exceeds the maximium size for a ConfigMap.
 kubectl create configmap grafana-dashboards \
     --from-file=config/federation/grafana/dashboards \
     --dry-run -o json | kubectl replace -f -

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -53,7 +53,7 @@ kubectl create configmap grafana-config \
     --dry-run -o json | kubectl apply -f -
 
 ## Grafana dashboards
-kubectl create configmap grafana-dashboards \
+kubectl replace configmap grafana-dashboards \
     --from-file=config/federation/grafana/dashboards \
     --dry-run -o json | kubectl apply -f -
 

--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -1,0 +1,2320 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 145,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": -2578,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 25,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)\n/\ncount(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n)",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "95,98",
+          "title": "% NDT up",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 31,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "NDT up",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "hideTimeOverride": false,
+          "id": 26,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "Value",
+          "targets": [
+            {
+              "expr": "count_scalar(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n  )\n)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "1m",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "10,20",
+          "title": "NDT down",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 27,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "count_scalar(\n  script_success{service=\"ndt_queue\"} == 0 AND ON(machine)\n    script_exit_code{} == 5\n)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "NDT queueing",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 185,
+      "panels": [
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "100%",
+          "id": 34,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "link": false,
+              "pattern": "Time",
+              "type": "string"
+            },
+            {
+              "alias": "Node",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "link": false,
+              "pattern": "/Metric/",
+              "preserveFormat": true,
+              "sanitize": true,
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum_over_time(probe_success{service=\"ssh806\"}[10m]) < 5 AND changes(probe_success{service=\"ssh806\"}[1w]) > 0",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "<font color=\"red\">{{machine}}</font>",
+              "refId": "A"
+            }
+          ],
+          "title": "Nodes down",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "100%",
+          "id": 35,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Node",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "lame_duck_node{} == 1",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lame ducks",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "description": "Returns a switch when more than 50% of the last 10 probes have failed.",
+          "fontSize": "100%",
+          "id": 36,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Switch",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "preserveFormat": true,
+              "sanitize": true,
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum_over_time(up{job=\"snmp-targets\"}[10m]) < 5",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "<font color=\"red\">s1.{{site}}</font>",
+              "refId": "A"
+            }
+          ],
+          "title": "Switches down",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 326,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "decimals": 0,
+          "fill": 0,
+          "id": 23,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/(Down:|Lame-ducked:)/",
+              "lines": false
+            },
+            {
+              "alias": "/(Down|Lame-ducked)[^:]/",
+              "legend": false
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "count_scalar(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n    UNLESS ON(machine) (\n      probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n      probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n      script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n      vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n    )\n)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Down count",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "expr": "probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n  )",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}}",
+              "refId": "B"
+            },
+            {
+              "expr": "count_scalar(\n  probe_success{service=\"ndt_ssl\"} == 0 AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Down ndt_ssl",
+              "refId": "E"
+            },
+            {
+              "expr": "count_scalar(\n  probe_success{service=\"ndt_raw\"} == 0 AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Down ndt_raw",
+              "refId": "F"
+            },
+            {
+              "expr": "count_scalar(\n  script_success{service=\"ndt_e2e\"} == 0 AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Down ndt_e2e",
+              "refId": "G"
+            },
+            {
+              "expr": "count_scalar(\n  vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} > 0.8 AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Down disk full",
+              "refId": "H"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "NDT down",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "decimals": 0,
+          "fill": 1,
+          "id": 24,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/Queueing count/",
+              "legend": false
+            },
+            {
+              "alias": "/Queueing:/",
+              "lines": false
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "count_scalar(\n  script_success{service=\"ndt_queue\"} == 0 AND ON(machine)\n    script_exit_code{} == 5 AND ON(machine)\n    up{service=\"nodeexporter\"} == 1\n)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Queueing count",
+              "refId": "A"
+            },
+            {
+              "expr": "script_success{service=\"ndt_queue\"} == 0 AND ON(machine)\n  script_exit_code{} == 5 AND ON(machine)\n  up{service=\"nodeexporter\"} == 1",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "NDT queueing",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "100%",
+          "id": 29,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 4,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "link": false,
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgb(128, 80, 80)",
+                "rgb(55, 76, 49)",
+                "#0a50a1"
+              ],
+              "decimals": 0,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Node (service)",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Metric/",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                ""
+              ],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=\"ndt_ssl\", machine=~\".*$site.*\"} AND ON(machine)\n  up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n  lame_duck_node{} == 1",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}} ({{service}})",
+              "refId": "A"
+            },
+            {
+              "expr": "probe_success{service=\"ndt_raw\", machine=~\".*$site.*\"} AND ON(machine)\n  up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n  lame_duck_node{} == 1",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}} ({{service}})",
+              "refId": "B"
+            },
+            {
+              "expr": "script_success{service=\"ndt_e2e\", machine=~\".*$site.*\"} AND ON(machine)\n  up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n  lame_duck_node{} == 1",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{machine}} ({{service}})",
+              "refId": "C"
+            }
+          ],
+          "timeFrom": null,
+          "title": "$site: NDT status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 335,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "id": 17,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, nagios_check_disk_boot_perf_data_used / nagios_check_disk_boot_perf_data_total)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{hostname}}",
+              "refId": "A",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Usage rootfs: Top 10",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, vdlimit_used{experiment=\"ndt.iupui\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ instance }}",
+              "refId": "A",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Usage NDT: Top 10",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "deckbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "id": 15,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "vdlimit_used{machine=~\".*$site.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{experiment}} {{machine}}",
+              "refId": "A",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$site: NDT Disk Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "deckbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 349,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 6,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[5m]) / 1000)",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A",
+              "step": 120
+            },
+            {
+              "expr": "max(rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[10m]) / 1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Max",
+              "refId": "B",
+              "step": 600
+            },
+            {
+              "expr": "quantile(0.99, rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[10m]) / 1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "99th %",
+              "refId": "E",
+              "step": 600
+            },
+            {
+              "expr": "quantile(0.90, rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[10m]) / 1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "90th %",
+              "refId": "C",
+              "step": 600
+            },
+            {
+              "expr": "quantile(0.50, rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[10m]) / 1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "50th %",
+              "refId": "D",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "% of time spent doing Disk IO (sec/sec)",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 7,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(5, rate(node_disk_io_time_ms{device=\"dm-2\", machine!~\".*mlab4.*\"}[2m]) / 1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "B",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Top 2 (% of time spent doing Disk IO (sec/sec))",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 16,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(node_disk_io_time_ms{instance=~\".*$site.*\", device=\"dm-2\"}[2m]) / 1000",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "B",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$site:  % of time spent doing Disk IO (sec/sec)",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 381,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 12,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max(node_load15{machine!=\".*mlab4.*\"})",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "Max",
+              "metric": "",
+              "refId": "D",
+              "step": 300
+            },
+            {
+              "expr": "quantile(0.99, node_load15{machine!=\".*mlab4.*\"})",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "99th %",
+              "metric": "",
+              "refId": "B",
+              "step": 300
+            },
+            {
+              "expr": "quantile(0.90, node_load15{machine!=\".*mlab4.*\"})",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "90th %",
+              "metric": "",
+              "refId": "A",
+              "step": 300
+            },
+            {
+              "expr": "quantile(0.50, node_load15{machine!=\".*mlab4.*\"})",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "50th %",
+              "metric": "",
+              "refId": "C",
+              "step": 300
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Load15 Avg",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 11,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "sort": "current",
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(2, node_load15{machine!=\".*mlab4.*\"})",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "{{machine}}",
+              "metric": "",
+              "refId": "A",
+              "step": 300
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Top 2: Load15 Avg",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 0,
+          "id": 18,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "sort": "current",
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_load15{instance=~\".*$site.*\"}",
+              "format": "time_series",
+              "interval": "60s",
+              "intervalFactor": 1,
+              "legendFormat": "{{machine}}",
+              "metric": "",
+              "refId": "A",
+              "step": 300
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$site: Load15 Avg",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 378,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "mlab-oti prometheus",
+          "fill": 0,
+          "id": 21,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max(8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Max Out",
+              "refId": "E",
+              "step": 600
+            },
+            {
+              "expr": "quantile(0.99, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99% Out",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "quantile(0.90, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "90% Out",
+              "refId": "C",
+              "step": 600
+            },
+            {
+              "expr": "- max(8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Max In",
+              "refId": "F",
+              "step": 600
+            },
+            {
+              "expr": "- quantile(0.99, 8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99% In",
+              "refId": "B",
+              "step": 600
+            },
+            {
+              "expr": "- quantile(0.90, 8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "90% In",
+              "refId": "D",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Switch Uplink Percentiles",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "mlab-oti prometheus",
+          "fill": 0,
+          "id": 19,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(5, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{site}}",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "bottomk(5, -8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{site}}",
+              "refId": "B",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Switch Uplink: Top 5",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "mlab-oti prometheus",
+          "fill": 0,
+          "id": 20,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "8 * rate(ifHCOutOctets{site=~\"$site.*\", ifAlias=\"uplink\"}[2m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{site}} Out",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "- 8 * rate(ifHCInOctets{site=~\"$site.*\", ifAlias=\"uplink\"}[2m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{site}} In",
+              "refId": "B",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$site: Switch Uplink",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "mlab-oti prometheus",
+          "value": "mlab-oti prometheus"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "yyz",
+          "value": "yyz"
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Site",
+        "multi": false,
+        "name": "site",
+        "options": [
+          {
+            "selected": false,
+            "text": "acc",
+            "value": "acc"
+          },
+          {
+            "selected": false,
+            "text": "akl",
+            "value": "akl"
+          },
+          {
+            "selected": false,
+            "text": "ams",
+            "value": "ams"
+          },
+          {
+            "selected": false,
+            "text": "arn",
+            "value": "arn"
+          },
+          {
+            "selected": false,
+            "text": "ath",
+            "value": "ath"
+          },
+          {
+            "selected": false,
+            "text": "atl",
+            "value": "atl"
+          },
+          {
+            "selected": false,
+            "text": "bcn",
+            "value": "bcn"
+          },
+          {
+            "selected": false,
+            "text": "beg",
+            "value": "beg"
+          },
+          {
+            "selected": false,
+            "text": "bkk",
+            "value": "bkk"
+          },
+          {
+            "selected": false,
+            "text": "bog",
+            "value": "bog"
+          },
+          {
+            "selected": false,
+            "text": "bom",
+            "value": "bom"
+          },
+          {
+            "selected": false,
+            "text": "bru",
+            "value": "bru"
+          },
+          {
+            "selected": false,
+            "text": "den",
+            "value": "den"
+          },
+          {
+            "selected": false,
+            "text": "dfw",
+            "value": "dfw"
+          },
+          {
+            "selected": false,
+            "text": "dub",
+            "value": "dub"
+          },
+          {
+            "selected": false,
+            "text": "fln",
+            "value": "fln"
+          },
+          {
+            "selected": false,
+            "text": "fra",
+            "value": "fra"
+          },
+          {
+            "selected": false,
+            "text": "ham",
+            "value": "ham"
+          },
+          {
+            "selected": false,
+            "text": "hnd",
+            "value": "hnd"
+          },
+          {
+            "selected": false,
+            "text": "iad",
+            "value": "iad"
+          },
+          {
+            "selected": false,
+            "text": "jnb",
+            "value": "jnb"
+          },
+          {
+            "selected": false,
+            "text": "lax",
+            "value": "lax"
+          },
+          {
+            "selected": false,
+            "text": "lba",
+            "value": "lba"
+          },
+          {
+            "selected": false,
+            "text": "lca",
+            "value": "lca"
+          },
+          {
+            "selected": false,
+            "text": "lga",
+            "value": "lga"
+          },
+          {
+            "selected": false,
+            "text": "lhr",
+            "value": "lhr"
+          },
+          {
+            "selected": false,
+            "text": "lis",
+            "value": "lis"
+          },
+          {
+            "selected": false,
+            "text": "lju",
+            "value": "lju"
+          },
+          {
+            "selected": false,
+            "text": "los",
+            "value": "los"
+          },
+          {
+            "selected": false,
+            "text": "mad",
+            "value": "mad"
+          },
+          {
+            "selected": false,
+            "text": "mia",
+            "value": "mia"
+          },
+          {
+            "selected": false,
+            "text": "mil",
+            "value": "mil"
+          },
+          {
+            "selected": false,
+            "text": "mnl",
+            "value": "mnl"
+          },
+          {
+            "selected": false,
+            "text": "mpm",
+            "value": "mpm"
+          },
+          {
+            "selected": false,
+            "text": "nbo",
+            "value": "nbo"
+          },
+          {
+            "selected": false,
+            "text": "nuq",
+            "value": "nuq"
+          },
+          {
+            "selected": false,
+            "text": "ord",
+            "value": "ord"
+          },
+          {
+            "selected": false,
+            "text": "par",
+            "value": "par"
+          },
+          {
+            "selected": false,
+            "text": "prg",
+            "value": "prg"
+          },
+          {
+            "selected": false,
+            "text": "sea",
+            "value": "sea"
+          },
+          {
+            "selected": false,
+            "text": "sin",
+            "value": "sin"
+          },
+          {
+            "selected": false,
+            "text": "sjc",
+            "value": "sjc"
+          },
+          {
+            "selected": false,
+            "text": "svg",
+            "value": "svg"
+          },
+          {
+            "selected": false,
+            "text": "syd",
+            "value": "syd"
+          },
+          {
+            "selected": false,
+            "text": "tnr",
+            "value": "tnr"
+          },
+          {
+            "selected": false,
+            "text": "tpe",
+            "value": "tpe"
+          },
+          {
+            "selected": false,
+            "text": "trn",
+            "value": "trn"
+          },
+          {
+            "selected": false,
+            "text": "tun",
+            "value": "tun"
+          },
+          {
+            "selected": false,
+            "text": "tyo",
+            "value": "tyo"
+          },
+          {
+            "selected": false,
+            "text": "vie",
+            "value": "vie"
+          },
+          {
+            "selected": false,
+            "text": "wlg",
+            "value": "wlg"
+          },
+          {
+            "selected": false,
+            "text": "yqm",
+            "value": "yqm"
+          },
+          {
+            "selected": false,
+            "text": "yul",
+            "value": "yul"
+          },
+          {
+            "selected": false,
+            "text": "yvr",
+            "value": "yvr"
+          },
+          {
+            "selected": false,
+            "text": "ywg",
+            "value": "ywg"
+          },
+          {
+            "selected": false,
+            "text": "yyc",
+            "value": "yyc"
+          },
+          {
+            "selected": true,
+            "text": "yyz",
+            "value": "yyz"
+          }
+        ],
+        "query": "label_values(hostname)",
+        "refresh": 0,
+        "regex": ".*([a-z]{3}).*.measurement-lab.org",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Ops: Platform Overview",
+  "version": 166
+}


### PR DESCRIPTION
This PR also modifies `apply-global-prometheus.sh`, changing `kubectl create` to `kubectl replace` when creating the grafana-dashboards configmap to get around an error that was being thrown:

```
+kubectl create configmap grafana-dashboards --from-file=config/federation/grafana/dashboards --dry-run -o json
The ConfigMap "grafana-dashboards" is invalid: metadata.annotations: Too long: must have at most 262144 characters
Script failed with status 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/217)
<!-- Reviewable:end -->
