### PR TITLE
Changes switch metric panels to use datasource template value.

### DIFF
--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -1665,7 +1665,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "mlab-oti prometheus",
+          "datasource": "$datasource",
           "fill": 0,
           "id": 21,
           "legend": {
@@ -1781,7 +1781,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "mlab-oti prometheus",
+          "datasource": "$datasource",
           "fill": 0,
           "id": 19,
           "legend": {
@@ -1865,7 +1865,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "mlab-oti prometheus",
+          "datasource": "$datasource",
           "fill": 0,
           "id": 20,
           "legend": {
@@ -1960,9 +1960,10 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "mlab-oti prometheus",
-          "value": "mlab-oti prometheus"
+          "selected": false,
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "label": "Data source",
@@ -1977,8 +1978,8 @@
         "allValue": null,
         "current": {
           "tags": [],
-          "text": "yyz",
-          "value": "yyz"
+          "text": "acc",
+          "value": "acc"
         },
         "datasource": "$datasource",
         "hide": 0,
@@ -1988,7 +1989,7 @@
         "name": "site",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "acc",
             "value": "acc"
           },
@@ -2268,7 +2269,7 @@
             "value": "yyc"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "yyz",
             "value": "yyz"
           }


### PR DESCRIPTION
The current Ops_PlatformOverview Grafana dashboard has a bug. The switch metric panels specifically target the "mlab-oti prometheus" datasource, instead of using the dashboard's datasource template value. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/220)
<!-- Reviewable:end -->
