### PR TITLE
Removes the count() function from the LameDuckMtericMissingForNode alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -429,9 +429,8 @@ ALERT MobiperfMetricsMissing
 
 # Some number of nodes don't have a lame-duck status.
 ALERT LameDuckMetricMissingForNode
-  IF count(
-    up{service="nodeexporter"} == 1 UNLESS ON(machine) lame_duck_node{}
-  ) > 0
+  IF up{service="nodeexporter"} == 1
+        UNLESS ON(machine) lame_duck_node{}
   FOR 30m
   LABELS {
     severity = "ticket"


### PR DESCRIPTION
The `count()` function wasn't adding anything useful, was actually totally superfluous, and more importantly was causing needed labels to not be part of the alert.

This should resolve these issues:
https://github.com/m-lab/prometheus-support/issues/227
https://github.com/m-lab/ops-tracker/issues/387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/229)
<!-- Reviewable:end -->
