### PR TITLE
Create github issues for alerts in dev-tracker

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -114,6 +114,13 @@ SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
 GITHUB_RECEIVER_URL=
 SHORT_PROJECT=${PROJECT/mlab-/}
 
+if [[ ${PROJECT} = "mlab-oti" ]] ; then
+  # Only create one instance of the github-receiver across all projects.
+  kubectl create secret generic github-secrets \
+      "--from-literal=auth-token=${GITHUB_RECEIVER_AUTH_TOKEN}" \
+      --dry-run -o json | kubectl apply -f -
+fi
+
 # Note: without a url, alertmanager will fail to start. But, for non-production
 # projects, there will be no github receiver running. This should be a no-op.
 GITHUB_RECEIVER_URL=http://github-receiver-service.default.svc.cluster.local:9393/v1/receiver

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -26,6 +26,6 @@ spec:
               key: auth-token
         args: [ "-authtoken=$(GITHUB_AUTH_TOKEN)",
                 "-owner=m-lab",
-                "-repo=scraper" ]
+                "-repo=dev-tracker" ]
         ports:
         - containerPort: 9393


### PR DESCRIPTION
This PR changes the target repo used by the github-receiver when creating github issues for alerts. Rather than creating issues in the "scraper" repo, we will now create alerts in the "dev-tracker" repo.

This resolves issues:
https://github.com/m-lab/prometheus-support/issues/231
https://github.com/m-lab/prometheus-support/issues/129

These changes are prerequisites for enabling routing of issues to either the "dev-tracker" or "ops-tracker" repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/232)
<!-- Reviewable:end -->
