### PR TITLE
Add a link to slack messages with a link to open github alerts

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -124,8 +124,6 @@ if [[ ${PROJECT} = "mlab-oti" ]] ; then
   # For production, annotate slack messages with a link to view open alert issues.
   GITHUB_ISSUE_QUERY="https://github.com/issues?q=is%3Aissue+user%3Am-lab+author%3Ameasurementlab+is%3Aopen"
 fi
-# TODO: remote after testing sandbox.
-GITHUB_ISSUE_QUERY="https://github.com/issues?q=is%3Aissue+user%3Am-lab+author%3Ameasurementlab+is%3Aopen"
 
 # Note: without a url, alertmanager will fail to start. But, for non-production
 # projects, there will be no github receiver running. This should be a no-op.

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -124,6 +124,8 @@ if [[ ${PROJECT} = "mlab-oti" ]] ; then
   # For production, annotate slack messages with a link to view open alert issues.
   GITHUB_ISSUE_QUERY="https://github.com/issues?q=is%3Aissue+user%3Am-lab+author%3Ameasurementlab+is%3Aopen"
 fi
+# TODO: remote after testing sandbox.
+GITHUB_ISSUE_QUERY="https://github.com/issues?q=is%3Aissue+user%3Am-lab+author%3Ameasurementlab+is%3Aopen"
 
 # Note: without a url, alertmanager will fail to start. But, for non-production
 # projects, there will be no github receiver running. This should be a no-op.

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -83,7 +83,7 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-page
-	text: '{{GITHUB_ISSUE_QUERY}}'
+    text: '{{GITHUB_ISSUE_QUERY}}'
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'
 
@@ -93,6 +93,6 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-email
-	text: '{{GITHUB_ISSUE_QUERY}}'
+    text: '{{GITHUB_ISSUE_QUERY}}'
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -83,6 +83,7 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-page
+	text: '{{GITHUB_ISSUE_QUERY}}'
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'
 
@@ -92,5 +93,6 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-email
+	text: '{{GITHUB_ISSUE_QUERY}}'
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'


### PR DESCRIPTION
This change adds a "text" message to slack messages that contains a link to search github issues for open alerts.

This should help responders find the correct issue quickly to update and resolve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/235)
<!-- Reviewable:end -->
