### PR TITLE
Rollback -- create alert issues in scraper public repo

### DIFF
--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -26,6 +26,6 @@ spec:
               key: auth-token
         args: [ "-authtoken=$(GITHUB_AUTH_TOKEN)",
                 "-owner=m-lab",
-                "-repo=dev-tracker" ]
+                "-repo=scraper" ]
         ports:
         - containerPort: 9393


### PR DESCRIPTION
The current implementation of github-receiver does not yet support, searching or creating issues on private repos.

Until that can be fixed, we're reverting this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/236)
<!-- Reviewable:end -->
