### PR TITLE
Update version of github receiver to support alert routing

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -30,7 +30,8 @@ ALERT ClusterDown
   IF up{job="federation-targets"} == 0
   FOR 10m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Instance {{ $labels.instance }} down",
@@ -54,7 +55,8 @@ ALERT CoreServices_SidestreamIsNotRunning
      lame_duck_node == 1
   FOR 10m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -87,7 +89,8 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
      lame_duck_node == 1
   FOR 2h
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Scraper max file mtime is too old {{ $labels.rsync_url }}",
@@ -109,7 +112,8 @@ ALERT ScraperSyncPresentWithoutScraperCollector
            up{container="scraper"})
   FOR 3h
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -122,7 +126,8 @@ ALERT ScraperCollectorMissingFromScraperSync
            scraper_lastcollectionattempt{container="scraper-sync"})
   FOR 3h
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -137,7 +142,8 @@ ALERT InventoryConfigurationIsMissing
   IF absent(up{service="ssh806"}) OR absent(up{service="rsyncd"})
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Inventory configuration {{ $labels.service }} is missing.",
@@ -149,7 +155,8 @@ ALERT InventoryMachinesWithoutRsyncd
   IF up{service="ssh806"} UNLESS ON(machine) up{service="rsyncd"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Rsyncd configuration is missing from some machines.",
@@ -160,7 +167,8 @@ ALERT InventoryRsyncdWithoutMachines
   IF up{service="rsyncd"} UNLESS ON(machine) up{service="ssh806"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Machine configuration is missing for some rsyncd services.",
@@ -176,7 +184,8 @@ ALERT SidestreamServicesAreMissing
   IF absent(up{service="sidestream"})
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -187,7 +196,8 @@ ALERT SidestreamRunningWithoutMachine
   IF up{service="sidestream"} UNLESS ON(machine) up{service="ssh806"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -198,7 +208,8 @@ ALERT MachineWithoutSidestreamRunning
   IF up{service="ssh806"} UNLESS ON(machine) up{service="sidestream"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -210,7 +221,8 @@ ALERT ScraperRunningWithoutRsyncd
   IF up{container="scraper"} UNLESS ON(machine, experiment) up{service="rsyncd"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -222,7 +234,8 @@ ALERT RsyncRunningWithoutScraper
   IF up{service="rsyncd"} UNLESS ON(machine, experiment) up{container="scraper"}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "",
@@ -235,7 +248,8 @@ ALERT DownloaderIsFailingToUpdate
   IF time()-downloader_last_success_time_seconds > (21 * 60 * 60)
   FOR 5m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Neither of the last two attempts to download the maxmind/routeviews feeds were successful.",
@@ -247,7 +261,8 @@ ALERT DownloaderDownOrMissing
   IF up{container="downloader"} == 0 OR absent(up{container="downloader"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The downloader for maxmind/routeviews feeds is down on {{ $labels.instance }}.",
@@ -259,7 +274,8 @@ ALERT SnmpExporterDownOrMissing
   IF up{job="snmp-exporter"} == 0 OR absent(up{job="snmp-exporter"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The snmp_exporter service is down on {{ $labels.instance }}.",
@@ -273,7 +289,8 @@ ALERT SnmpExporterMissingMetrics
   IF absent(ifHCOutOctets)
   FOR 30m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Expected SNMP metrics are missing from Prometheus!",
@@ -288,7 +305,8 @@ ALERT ScriptExporterDownOrMissing
   IF up{job="script-exporter"} == 0 OR absent(up{job="script-exporter"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The script_exporter service is down on {{ $labels.instance }}.",
@@ -303,7 +321,8 @@ ALERT ScriptExporterMissingMetrics
         OR absent(script_success{service="ndt_queue"})
   FOR 30m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Expected script_exporter metrics are missing from Prometheus!",
@@ -320,7 +339,8 @@ ALERT BlackboxExporterIpv4DownOrMissing
         OR absent(up{job="blackbox-exporter-ipv4"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The blackbox_exporter service is down for IPv4 probes.",
@@ -334,7 +354,8 @@ ALERT BlackboxExporterIpv6DownOrMissing
         OR absent(up{job="blackbox-exporter-ipv6"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The blackbox_exporter service is down or missing for IPv6 probes.",
@@ -364,7 +385,8 @@ ALERT TooManyNdtServersDown
   ) > 0.25
   FOR 30m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Too large a percentage of NDT servers are down.",
@@ -387,7 +409,8 @@ ALERT NdtMetricsMissing
         OR absent(vdlimit_total{experiment="ndt.iupui"})
   FOR 30m
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "A metric for an NDT service is missing.",
@@ -403,7 +426,8 @@ ALERT NeubotMetricsMissing
         OR absent(probe_success{service="neubot_ipv6"})
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "A metric for a Neubot service is missing.",
@@ -419,7 +443,8 @@ ALERT MobiperfMetricsMissing
         OR absent(probe_success{service="mobiperf_ipv6"})
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "A metric for a Mobiperf service is missing.",
@@ -433,7 +458,8 @@ ALERT LameDuckMetricMissingForNode
         UNLESS ON(machine) lame_duck_node{}
   FOR 30m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Some number of nodes are missing lame-duck status metrics.",
@@ -445,7 +471,8 @@ ALERT CoreServices_CollectdMlabDown
   IF collectd_mlab_success{} == 0
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "A collectd-mlab service is down.",
@@ -458,7 +485,8 @@ ALERT CoreServices_CollectdMlabMissing
         UNLESS ON(machine) collectd_mlab_success{}
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "A collectd-mlab service metric is missing.",
@@ -514,7 +542,8 @@ ALERT ParserDailyVolumeTooLow
          ))
   FOR 2h
   LABELS {
-    severity = "page"
+    severity = "page",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "Today's test volume is less than 70% of nominal daily volume.",
@@ -527,7 +556,8 @@ ALERT NagiosExporterDown
   IF up{job="nagios-oam-exporter"} == 0 OR up{job="nagios-exporter"} == 0
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The Nagios exporter instance is down on {{ $labels.instance }}.",
@@ -539,7 +569,8 @@ ALERT NagiosExporterUnavailable
   IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR nagios_livestatus_available{job="nagios-exporter"} == 0
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The Nagios exporter instance is unavailable on {{ $labels.instance }}.",
@@ -551,7 +582,8 @@ ALERT NagiosExporterMissing
   IF absent(up{job="nagios-oam-exporter"}) OR absent(up{job="nagios-exporter"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The Nagios exporter instance is not being monitored.",
@@ -563,7 +595,8 @@ ALERT NodeExporterOnEbDownOrMissing
   IF up{job="eb-node-exporter"} == 0 OR absent(up{job="eb-node-exporter"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The node_exporter instance running on eb.measurementlab.net is down.",
@@ -578,7 +611,8 @@ ALERT GardenerDownOrMissing
   IF up{container="etl-gardener", instance=~".*:9090"} == 0 OR absent(up{container="etl-gardener", instance=~".*:9090"})
   FOR 10m
   LABELS {
-    severity = "ticket"
+    severity = "ticket",
+    repo = "dev-tracker"
   }
   ANNOTATIONS {
     summary = "The ETL Gardener instance is down on {{ $labels.instance }}",

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: github-receiver
-        image: measurementlab/alertmanager-github-receiver:v0.2
+        image: measurementlab/alertmanager-github-receiver:v0.3
         env:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:
@@ -25,7 +25,7 @@ spec:
               name: github-secrets
               key: auth-token
         args: [ "-authtoken=$(GITHUB_AUTH_TOKEN)",
-                "-owner=m-lab",
+                "-org=m-lab",
                 "-repo=dev-tracker" ]
         ports:
         - containerPort: 9393


### PR DESCRIPTION
This change updates the version of the github receiver to enable support for alert routing.

As well, this change adds a `repo=` label to all alert definitions. Initially all repos are set to "dev-tracker" to preserve default behavior. Default behavior should remain unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/238)
<!-- Reviewable:end -->
