### PR TITLE
Adds two new alerts: vdlimit_* metrics and SNMP scraping

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -310,7 +310,8 @@ ALERT SnmpScrapingDownAtSite
   }
   ANNOTATIONS {
     summary = "Prometheus is unable to scrape SNMP metrics from a switch.",
-    hints = "Maybe the switch is down? Is the snmp_exporter using the right community string? Look in switch-details.json in the m-lab/switch-config repo. Is the IP of the snmp_exporter VM in GCE whitelisted on the switch?"
+    hints = "Maybe the switch is down? Is the snmp_exporter using the right community string? Look in switch-details.json in the m-lab/switch-config repo. Is the IP of the snmp_exporter VM in GCE whitelisted on the switch?",
+    dashboard = "https://grafana.mlab-oti.measurementlab.net/dashboard/file/Ops_SwitchOverview.json?orgId=1&var-site_name={{ $labels.site }}"
   }
 
 # Prometheus is unable to get data from the script_exporter service.
@@ -492,7 +493,8 @@ ALERT VdlimitMetricsMissingForNode
   }
   ANNOTATIONS {
     summary = "Some vdlimit_* metrics are missing.",
-    hints = "Check /var/spool/node_exporter/ on the node to see if the file vdlimit.prom is missing. The file is created by /etc/cron.d/prom_vdlimit_metrics.cron."
+    hints = "Check /var/spool/node_exporter/ on the node to see if the file vdlimit.prom is missing. The file is created by /etc/cron.d/prom_vdlimit_metrics.cron.",
+    dashboard = "https://grafana.mlab-oti.measurementlab.net/dashboard/file/Ops_PlatformOverview.json?orgId=1"
   }
 
 # A collectd-mlab service has a problem and is down.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -309,7 +309,7 @@ ALERT SnmpScrapingDownAtSite
     repo = "ops-tracker"
   }
   ANNOTATIONS {
-    summary = "Prometheus is unable to scrape SNMP metrics from a switch."
+    summary = "Prometheus is unable to scrape SNMP metrics from a switch.",
     hints = "Maybe the switch is down? Is the snmp_exporter using the right community string? Look in switch-details.json in the m-lab/switch-config repo. Is the IP of the snmp_exporter VM in GCE whitelisted on the switch?"
   }
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -300,6 +300,19 @@ ALERT SnmpExporterMissingMetrics
     dashboard = "http://status.mlab-oti.measurementlab.net:3000/dashboard/db/switch-metrics"
   }
 
+# Scraping SNMP metrics from a switch is failing.
+ALERT SnmpScrapingDownAtSite
+  IF up{job="snmp-targets", site!~".*t$"} == 0
+  FOR 30m
+  LABELS {
+    severity = "page",
+    repo = "ops-tracker"
+  }
+  ANNOTATIONS {
+    summary = "Prometheus is unable to scrape SNMP metrics from a switch."
+    hints = "Maybe the switch is down? Is the snmp_exporter using the right community string? Look in switch-details.json in the m-lab/switch-config repo. Is the IP of the snmp_exporter VM in GCE whitelisted on the switch?"
+  }
+
 # Prometheus is unable to get data from the script_exporter service.
 ALERT ScriptExporterDownOrMissing
   IF up{job="script-exporter"} == 0 OR absent(up{job="script-exporter"})
@@ -464,6 +477,22 @@ ALERT LameDuckMetricMissingForNode
   ANNOTATIONS {
     summary = "Some number of nodes are missing lame-duck status metrics.",
     hints = "Check /var/spool/node_exporter/ on the node to see if the file lame_duck.prom is missing. If it is, use the mlabops Ansible lame-duck.yaml playbook to restore it."
+  }
+
+# vdlimit_used and/or vdlimit_free metrics are completely missing for a node.
+# There are other vdlimit_* metrics, but we care especially about these because
+# mlab-ns uses them to query Prometheus for node status.
+ALERT VdlimitMetricsMissingForNode
+  IF up{service="nodeexporter"} == 1
+        UNLESS ON(machine) (vdlimit_used AND vdlimit_total)
+  FOR 30m
+  LABELS {
+    severity = "ticket",
+    repo = "ops-tracker"
+  }
+  ANNOTATIONS {
+    summary = "Some vdlimit_* metrics are missing.",
+    hints = "Check /var/spool/node_exporter/ on the node to see if the file vdlimit.prom is missing. The file is created by /etc/cron.d/prom_vdlimit_metrics.cron."
   }
 
 # A collectd-mlab service has a problem and is down.


### PR DESCRIPTION
* mlab-ns relies on three specific metrics from the node_exporter instance running on each node: `vdlimit_used`, `vdlimit_total`, `lame_duck_experiment`. There is already an alert for `lame_duck_experiment`. This PR adds an alert for both of the vdlimit_* metrics.

* If SNMP scraping of a switch is failing, we will now get an alert. Currently, we only get an alert if snmp_exporter is down or if an entire metric is missing from all switches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/239)
<!-- Reviewable:end -->
