### PR TITLE
Fixes two smallish bugs in two Ops dashboards

### DIFF
--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -1408,7 +1408,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(node_load15{machine!=\".*mlab4.*\"})",
+              "expr": "max(node_load15{machine!=\".*mlab4.*\", service=\"nodeexporter\"})",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1418,7 +1418,7 @@
               "step": 300
             },
             {
-              "expr": "quantile(0.99, node_load15{machine!=\".*mlab4.*\"})",
+              "expr": "quantile(0.99, node_load15{machine!=\".*mlab4.*\", service=\"nodeexporter\"})",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1428,7 +1428,7 @@
               "step": 300
             },
             {
-              "expr": "quantile(0.90, node_load15{machine!=\".*mlab4.*\"})",
+              "expr": "quantile(0.90, node_load15{machine!=\".*mlab4.*\", service=\"nodeexporter\"})",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1438,7 +1438,7 @@
               "step": 300
             },
             {
-              "expr": "quantile(0.50, node_load15{machine!=\".*mlab4.*\"})",
+              "expr": "quantile(0.50, node_load15{machine!=\".*mlab4.*\", service=\"nodeexporter\"})",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1520,7 +1520,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(2, node_load15{machine!=\".*mlab4.*\"})",
+              "expr": "topk(2, node_load15{machine!=\".*mlab4.*\", service=\"nodeexporter\"})",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1602,7 +1602,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_load15{instance=~\".*$site.*\"}",
+              "expr": "node_load15{instance=~\".*$site.*\", service=\"nodeexporter\"}",
               "format": "time_series",
               "interval": "60s",
               "intervalFactor": 1,
@@ -1961,9 +1961,8 @@
       {
         "current": {
           "selected": false,
-          "tags": [],
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "label": "Data source",

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -1460,7 +1460,7 @@
             "value": "yyz02"
           }
         ],
-        "query": "label_values(ifHCInOctets, site)",
+        "query": "label_values(up{job=\"snmp-targets\"}, site)",
         "refresh": 0,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
* [Fixes a bug in the Ops_PlatformOverview dashboard](https://github.com/m-lab/ops-tracker/issues/373) where the Load15 panels were getting metrics from node_exporters other than the ones running on platform nodes, skewing results.

* Fixes a bug in the Ops_SwitchOverview dashboard where a switch that was missing SNMP metrics would not show up in the Site selectbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/240)
<!-- Reviewable:end -->
