### PR TITLE
Sets the Ops_SwitchOverview dashboard to UTC instead of localtime.

### DIFF
--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -1501,7 +1501,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Ops: Switch Overview",
   "version": 32
 }


### PR DESCRIPTION
Resolves https://github.com/m-lab/ops-tracker/issues/325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/242)
<!-- Reviewable:end -->
