### PR TITLE
Add the node-exporter DaemonSet to prometheus cluster

### DIFF
--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+spec:
+  template:
+    metadata:
+      name: node-exporter
+      labels:
+        run: node-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - image: prom/node-exporter
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: scrape
+      hostNetwork: true
+      hostPID: true


### PR DESCRIPTION
This change adds a new DaemonSet for the node-exporter to the prometheus cluster.

With this change it should be possible to get detailed monitoring of whole-node resource utilization. And, with the addition of the `node=` label to pods from https://github.com/m-lab/prometheus-support/pull/248 it should now be possible to discover the history and environment of pod migrations through a k8s cluster over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/250)
<!-- Reviewable:end -->
