### PR TITLE
Scrape the github receiver

### DIFF
--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -12,8 +12,7 @@ spec:
       labels:
         run: github-receiver
       annotations:
-        # TODO(soltesz): add prometheus metrics to this daemon.
-        prometheus.io/scrape: 'false'
+        prometheus.io/scrape: 'true'
     spec:
       containers:
       - name: github-receiver


### PR DESCRIPTION
An oversight from https://github.com/m-lab/prometheus-support/pull/247 -- the github receiver v0.4 now includes native prometheus metrics, so we want to tell prometheus to scrape this pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/251)
<!-- Reviewable:end -->
