### PR TITLE
Update kube-state-metrics service

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -128,9 +128,10 @@ scrape_configs:
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
 
-  # Kube state metrics is special. We do not want to rely on pod-auto discovery
-  # because of the kubernetes-pods relabel rules create labels that conflict
-  # with the labels that kube-state-metrics adds to many of its metrics.
+  # kube-state-metrics reports status about k8s objects (pods, nodes,
+  # deployments, etc). We cannot rely on service-discovery because the metric
+  # labels used by kube-state-metrics conflict with the labels added by
+  # service-discovery. Instead, we define a static target using the ksm service.
   - job_name: 'kube-state-metrics'
     static_configs:
       - targets:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -128,6 +128,14 @@ scrape_configs:
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
 
+  # Kube state metrics is special. We do not want to rely on pod-auto discovery
+  # because of the kubernetes-pods relabel rules create labels that conflict
+  # with the labels that kube-state-metrics adds to many of its metrics.
+  - job_name: 'kube-state-metrics'
+    static_configs:
+      - targets:
+        - kube-state-metrics-service.default.svc.cluster.local:8080
+
   # Scrape config for kubernetes pods.
   #
   # Kubernetes pods are scraped when they have an annotation:

--- a/k8s/prometheus-federation/deployments/kube-state-metrics.yml
+++ b/k8s/prometheus-federation/deployments/kube-state-metrics.yml
@@ -7,15 +7,19 @@ spec:
   template:
     metadata:
       labels:
-        application: kube-state-metrics
-        version: "v0.5.0"
+        run: kube-state-metrics
       annotations:
-        prometheus.io/scrape: 'true'
+        prometheus.io/scrape: 'false'
     spec:
       nodeSelector:
         prometheus-node: 'true'
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v0.5.0
+        # image: gcr.io/google_containers/kube-state-metrics:v0.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.3.1
+        args: [
+          "--collectors=deployments,nodes,pods,services",
+          "--port=8080",
+        ]
         ports:
         - containerPort: 8080

--- a/k8s/prometheus-federation/deployments/kube-state-metrics.yml
+++ b/k8s/prometheus-federation/deployments/kube-state-metrics.yml
@@ -9,6 +9,7 @@ spec:
       labels:
         run: kube-state-metrics
       annotations:
+        # Note: Do not enable service-discovery scraping.
         prometheus.io/scrape: 'false'
     spec:
       nodeSelector:

--- a/k8s/prometheus-federation/services/kube-state-metrics-service.yml
+++ b/k8s/prometheus-federation/services/kube-state-metrics-service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    # Note: Do not enable service-discovery scraping. Use static configs.
     prometheus.io/scrape: 'false'
   name: kube-state-metrics-service
   namespace: default

--- a/k8s/prometheus-federation/services/kube-state-metrics-service.yml
+++ b/k8s/prometheus-federation/services/kube-state-metrics-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  name: kube-state-metrics-service
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: kube-state-metrics
+  sessionAffinity: None
+  type: ClusterIP

--- a/k8s/prometheus-federation/services/kube-state-metrics-service.yml
+++ b/k8s/prometheus-federation/services/kube-state-metrics-service.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/scrape: 'true'
+    prometheus.io/scrape: 'false'
   name: kube-state-metrics-service
   namespace: default
 spec:


### PR DESCRIPTION
This PR updates the kube-state-metrics deployment to the latest version. As well, we define a static config target for the kube-state-metrics-service. We use a service definition to create a cluster-local DNS name. And, we disable service-discovery for the pod as well as the service because kube-state-metric adds labels to metrics that conflict with the labels added automatically by service discovery, e.g. "pod=", "node=", etc.

With this change we will be able to monitor the deployment status of various services, as well as alert on error states such as OOM. https://github.com/m-lab/prometheus-support/issues/213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/252)
<!-- Reviewable:end -->
