### PR TITLE
Add stackdriver exporter for mlab-ns

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -44,6 +44,11 @@ kubectl create configmap blackbox-config \
     --from-file=config/federation/blackbox \
     --dry-run -o json | kubectl apply -f -
 
+## Credentials for accessing Stackdriver monitoring for mlab-ns.
+kubectl create secret generic mlabns-credentials \
+    "--from-literal=mlabns.json=${SERVICE_ACCOUNT_mlab_ns}" \
+    --dry-run -o json | kubectl apply -f -
+
 ## Prometheus
 
 # Evaluate the configuration template.

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mlabns-stackdriver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: mlabns-stackdriver
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        prometheus-node: 'true'
+      containers:
+      - name: stackdriver
+        image: frodenas/stackdriver-exporter:v0.5.1
+        args: [
+          # Metrics are available with some delay, so look 2 minutes in the past.
+          "--monitoring.metrics-offset=2m",
+          # Prometheus scrapes every minute, so look at a 1 minute window.
+          "--monitoring.metrics-interval=1m",
+          "--google.project-id=mlab-ns",
+          # Metrics are gauges, representing counts over the sampled interval.
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies",
+        ]
+        ports:
+        - containerPort: 9255
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/mlabns.json
+        volumeMounts:
+        - name: credentials
+          mountPath: /etc/credentials
+          readOnly: true
+      volumes:
+      - name: credentials
+        secret:
+          secretName: mlabns-credentials


### PR DESCRIPTION
This change adds a new deployment specifically for collecting metrics about mlab-ns.

Because mlab-ns is in a separate project from the rest of the prometheus stack we must create a k8s secret used by the stackdriver exporter to authenticate with the mlab-ns project.

The list of `--monitoring.metrics-type-prefixes` is not exhaustive, but represent the ones that look useful and whose values could represent significant shifts due to usage spikes or drops, or internal bugs.

```
logging.googleapis.com/log_entry_count
appengine.googleapis.com/system/network/sent_bytes_count
appengine.googleapis.com/system/instance_count
appengine.googleapis.com/system/cpu/usage
appengine.googleapis.com/memcache/operation_count
appengine.googleapis.com/http/server/response_count
appengine.googleapis.com/http/server/response_latencies
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/253)
<!-- Reviewable:end -->
