### PR TITLE
Configures Prom to communicate with the script-exporter using its internal DNS name.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -555,8 +555,8 @@ scrape_configs:
   - job_name: 'script-exporter'
     static_configs:
       - targets:
-        - script-exporter.{{PROJECT}}.measurementlab.net:9172
-        - script-exporter.{{PROJECT}}.measurementlab.net:9100
+        - script-exporter.c.{{PROJECT}}.internal:9172
+        - script-exporter.c.{{PROJECT}}.internal:9100
 
 
   # script_exporter configurations. The scrape_timeout is set very high because
@@ -596,7 +596,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: script-exporter.{{PROJECT}}.measurementlab.net:9172
+        replacement: script-exporter.c.{{PROJECT}}.internal:9172
 
 
   # Scrape config for pushgateway.


### PR DESCRIPTION
Scrape metrics from the script-exporter VM using its internal VPC domain name. This PR depends on this PR:

https://github.com/m-lab/prometheus-script-exporter/pull/15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/254)
<!-- Reviewable:end -->
