### PR TITLE
Configures Prom to communicate with the snmp-exporter using its internal DNS name.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -490,8 +490,8 @@ scrape_configs:
   - job_name: 'snmp-exporter'
     static_configs:
       - targets:
-        - snmp-exporter.{{PROJECT}}.measurementlab.net:9116
-        - snmp-exporter.{{PROJECT}}.measurementlab.net:9100
+        - snmp-exporter.c.{{PROJECT}}.internal:9116
+        - snmp-exporter.c.{{PROJECT}}.internal:9100
 
 
   # SNMP configurations.
@@ -530,7 +530,7 @@ scrape_configs:
       - source_labels: [__exporter_project]
         regex: (.*)
         target_label: __address__
-        replacement: snmp-exporter.${1}.measurementlab.net:9116
+        replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
 
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -524,11 +524,11 @@ scrape_configs:
         target_label: __param_module
         replacement: ${1}
 
-      # The "__exporter_project" label will contain a shortened GCP project
-      # name. We use this to construct the domain name of the GCE instance
-      # running the snmp_exporer in that project.
-      - source_labels: [__exporter_project]
-        regex: (.*)
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the script_exporter
+      # address.
+      - source_labels: []
+        regex: .*
         target_label: __address__
         replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
 


### PR DESCRIPTION
Scrape metrics from the snmp-exporter VM using its internal VPC domain name. This PR depends on this PR:

https://github.com/m-lab/prometheus-snmp-exporter/pull/11

Noteworthy: this also changes one of the label rewrite rules for the snmp-targets job. The old rule was created before we had templated promtheus.yaml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/255)
<!-- Reviewable:end -->
