### PR TITLE
Fixes Ops_PlatformOverview dashboard and adds Ops_PodOverview

### DIFF
--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -515,6 +515,93 @@
     },
     {
       "collapse": false,
+      "height": 224,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fill": 1,
+          "id": 37,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m]))",
+              "format": "time_series",
+              "intervalFactor": 10,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "NDT global test rate (up + down)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
       "height": 326,
       "panels": [
         {
@@ -880,10 +967,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, nagios_check_disk_boot_perf_data_used / nagios_check_disk_boot_perf_data_total)",
+              "expr": "topk(10, (node_filesystem_size{device=\"/dev/mapper/planetlab-root\"} - node_filesystem_free{device=\"/dev/mapper/planetlab-root\"}) / node_filesystem_size{device=\"/dev/mapper/planetlab-root\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{hostname}}",
+              "legendFormat": "{{machine}}",
               "refId": "A",
               "step": 600
             }
@@ -1960,7 +2047,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "default",
           "value": "default"
         },
@@ -2286,7 +2373,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {

--- a/config/federation/grafana/dashboards/Ops_PodOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PodOverview.json
@@ -1,0 +1,4092 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 183,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": 233,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 18,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"} -\n    node_filesystem_free{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"})\n/ node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70,90",
+          "title": "Root fs",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "deckbytes",
+          "gauge": {
+            "maxValue": 1000000000,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 6,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "__name__",
+          "targets": [
+            {
+              "expr": "vdlimit_used{experiment=\"ndt.iupui\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70000000,90000000",
+          "title": "NDT disk",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 7,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "node_load15{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "Load15",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 31,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_process_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "680,700",
+          "title": "Total procs",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 46,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_packet_socket_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "50,60",
+          "title": "Pkt sockets",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 4,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=\"ssh806\", machine=~\"$node.$pod.*\", module=\"ssh_v4_online\"}, \"service_name\", \"ssh806\", \"service\", \".*\")\n  OR label_replace(collectd_mlab_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"collectd_mlab\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_node_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_node\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_readonly_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_readonly\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_swap_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_swap\", \"service\", \".*\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 2,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"} OR script_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "NDT status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 63,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"neubot.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Neubot status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 64,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "link": false,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=~\"mobiperf.*\", machine=~\"$node.*$pod.*\"}, \"tcp_port\", \"$1\", \"instance\", \".*:(.*)\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}} ({{tcp_port}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Mobiperf status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 5,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab1",
+              "value": "mlab1"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Experiment",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=\"rsyncd\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{experiment}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Rsync status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": "node",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "$node",
+      "titleSize": "h3"
+    },
+    {
+      "collapse": false,
+      "height": 233,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 65,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"} -\n    node_filesystem_free{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"})\n/ node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70,90",
+          "title": "Root fs",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "deckbytes",
+          "gauge": {
+            "maxValue": 1000000000,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 66,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "__name__",
+          "targets": [
+            {
+              "expr": "vdlimit_used{experiment=\"ndt.iupui\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70000000,90000000",
+          "title": "NDT disk",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 67,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "node_load15{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "Load15",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 68,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_process_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "680,700",
+          "title": "Total procs",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 69,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_packet_socket_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "50,60",
+          "title": "Pkt sockets",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 70,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=\"ssh806\", machine=~\"$node.$pod.*\", module=\"ssh_v4_online\"}, \"service_name\", \"ssh806\", \"service\", \".*\")\n  OR label_replace(collectd_mlab_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"collectd_mlab\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_node_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_node\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_readonly_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_readonly\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_swap_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_swap\", \"service\", \".*\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 71,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"} OR script_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "NDT status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 72,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"neubot.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Neubot status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 73,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "link": false,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=~\"mobiperf.*\", machine=~\"$node.*$pod.*\"}, \"tcp_port\", \"$1\", \"instance\", \".*:(.*)\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}} ({{tcp_port}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Mobiperf status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 74,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab2",
+              "value": "mlab2"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Experiment",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=\"rsyncd\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{experiment}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Rsync status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": 1529079928245,
+      "repeatRowId": 1,
+      "showTitle": true,
+      "title": "$node",
+      "titleSize": "h3"
+    },
+    {
+      "collapse": false,
+      "height": 233,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 75,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"} -\n    node_filesystem_free{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"})\n/ node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70,90",
+          "title": "Root fs",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "deckbytes",
+          "gauge": {
+            "maxValue": 1000000000,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 76,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "__name__",
+          "targets": [
+            {
+              "expr": "vdlimit_used{experiment=\"ndt.iupui\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70000000,90000000",
+          "title": "NDT disk",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 77,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "node_load15{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "Load15",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 78,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_process_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "680,700",
+          "title": "Total procs",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 79,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_packet_socket_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "50,60",
+          "title": "Pkt sockets",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 80,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=\"ssh806\", machine=~\"$node.$pod.*\", module=\"ssh_v4_online\"}, \"service_name\", \"ssh806\", \"service\", \".*\")\n  OR label_replace(collectd_mlab_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"collectd_mlab\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_node_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_node\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_readonly_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_readonly\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_swap_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_swap\", \"service\", \".*\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 81,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"} OR script_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "NDT status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 82,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"neubot.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Neubot status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 83,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "link": false,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=~\"mobiperf.*\", machine=~\"$node.*$pod.*\"}, \"tcp_port\", \"$1\", \"instance\", \".*:(.*)\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}} ({{tcp_port}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Mobiperf status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 84,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab3",
+              "value": "mlab3"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Experiment",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=\"rsyncd\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{experiment}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Rsync status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": 1529079928245,
+      "repeatRowId": 1,
+      "showTitle": true,
+      "title": "$node",
+      "titleSize": "h3"
+    },
+    {
+      "collapse": false,
+      "height": 233,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 85,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"} -\n    node_filesystem_free{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"})\n/ node_filesystem_size{device=\"/dev/mapper/planetlab-root\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70,90",
+          "title": "Root fs",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "deckbytes",
+          "gauge": {
+            "maxValue": 1000000000,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 86,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "__name__",
+          "targets": [
+            {
+              "expr": "vdlimit_used{experiment=\"ndt.iupui\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "70000000,90000000",
+          "title": "NDT disk",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 87,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "node_load15{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "Load15",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 88,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_process_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "680,700",
+          "title": "Total procs",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$datasource",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 89,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "mlab_host_packet_socket_count{machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "50,60",
+          "title": "Pkt sockets",
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 90,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=\"ssh806\", machine=~\"$node.$pod.*\", module=\"ssh_v4_online\"}, \"service_name\", \"ssh806\", \"service\", \".*\")\n  OR label_replace(collectd_mlab_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"collectd_mlab\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_node_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_node\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_readonly_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_readonly\", \"service\", \".*\")\n  OR label_replace(mlab_host_check_swap_success{machine=~\"$node.$pod.*\"}, \"service_name\", \"check_swap\", \"service\", \".*\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 91,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"} OR script_success{service=~\"ndt.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "NDT status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 92,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 1,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "Value",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=~\"neubot.*\", machine=~\"$node.*$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Neubot status",
+          "transform": "timeseries_to_rows",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 93,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "link": false,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "label_replace(probe_success{service=~\"mobiperf.*\", machine=~\"$node.*$pod.*\"}, \"tcp_port\", \"$1\", \"instance\", \".*:(.*)\")",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{service}} ({{tcp_port}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Mobiperf status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "$datasource",
+          "fontSize": "80%",
+          "id": 94,
+          "links": [],
+          "pageSize": null,
+          "scopedVars": {
+            "node": {
+              "selected": false,
+              "text": "mlab4",
+              "value": "mlab4"
+            }
+          },
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Experiment",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": null,
+              "pattern": "/Metric/",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "alias": "Status",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "#299c46",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": null,
+              "pattern": "/Current/",
+              "thresholds": [
+                "1",
+                "2"
+              ],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "probe_success{service=\"rsyncd\", machine=~\"$node.$pod.*\"}",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{experiment}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Rsync status",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": 1529079928245,
+      "repeatRowId": 1,
+      "showTitle": true,
+      "title": "$node",
+      "titleSize": "h3"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "mlab-oti prometheus",
+          "value": "mlab-oti prometheus"
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "acc02",
+          "value": "acc02"
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [
+          {
+            "selected": true,
+            "text": "acc02",
+            "value": "acc02"
+          },
+          {
+            "selected": false,
+            "text": "akl01",
+            "value": "akl01"
+          },
+          {
+            "selected": false,
+            "text": "ams01",
+            "value": "ams01"
+          },
+          {
+            "selected": false,
+            "text": "ams02",
+            "value": "ams02"
+          },
+          {
+            "selected": false,
+            "text": "ams03",
+            "value": "ams03"
+          },
+          {
+            "selected": false,
+            "text": "ams04",
+            "value": "ams04"
+          },
+          {
+            "selected": false,
+            "text": "ams05",
+            "value": "ams05"
+          },
+          {
+            "selected": false,
+            "text": "ams06",
+            "value": "ams06"
+          },
+          {
+            "selected": false,
+            "text": "ams07",
+            "value": "ams07"
+          },
+          {
+            "selected": false,
+            "text": "arn02",
+            "value": "arn02"
+          },
+          {
+            "selected": false,
+            "text": "arn03",
+            "value": "arn03"
+          },
+          {
+            "selected": false,
+            "text": "arn04",
+            "value": "arn04"
+          },
+          {
+            "selected": false,
+            "text": "arn05",
+            "value": "arn05"
+          },
+          {
+            "selected": false,
+            "text": "ath03",
+            "value": "ath03"
+          },
+          {
+            "selected": false,
+            "text": "atl01",
+            "value": "atl01"
+          },
+          {
+            "selected": false,
+            "text": "atl02",
+            "value": "atl02"
+          },
+          {
+            "selected": false,
+            "text": "atl03",
+            "value": "atl03"
+          },
+          {
+            "selected": false,
+            "text": "atl04",
+            "value": "atl04"
+          },
+          {
+            "selected": false,
+            "text": "atl05",
+            "value": "atl05"
+          },
+          {
+            "selected": false,
+            "text": "atl06",
+            "value": "atl06"
+          },
+          {
+            "selected": false,
+            "text": "bcn01",
+            "value": "bcn01"
+          },
+          {
+            "selected": false,
+            "text": "beg01",
+            "value": "beg01"
+          },
+          {
+            "selected": false,
+            "text": "bkk01",
+            "value": "bkk01"
+          },
+          {
+            "selected": false,
+            "text": "bog01",
+            "value": "bog01"
+          },
+          {
+            "selected": false,
+            "text": "bom01",
+            "value": "bom01"
+          },
+          {
+            "selected": false,
+            "text": "bom02",
+            "value": "bom02"
+          },
+          {
+            "selected": false,
+            "text": "bru01",
+            "value": "bru01"
+          },
+          {
+            "selected": false,
+            "text": "bru02",
+            "value": "bru02"
+          },
+          {
+            "selected": false,
+            "text": "bru03",
+            "value": "bru03"
+          },
+          {
+            "selected": false,
+            "text": "bru04",
+            "value": "bru04"
+          },
+          {
+            "selected": false,
+            "text": "den01",
+            "value": "den01"
+          },
+          {
+            "selected": false,
+            "text": "den02",
+            "value": "den02"
+          },
+          {
+            "selected": false,
+            "text": "den03",
+            "value": "den03"
+          },
+          {
+            "selected": false,
+            "text": "den04",
+            "value": "den04"
+          },
+          {
+            "selected": false,
+            "text": "dfw01",
+            "value": "dfw01"
+          },
+          {
+            "selected": false,
+            "text": "dfw02",
+            "value": "dfw02"
+          },
+          {
+            "selected": false,
+            "text": "dfw03",
+            "value": "dfw03"
+          },
+          {
+            "selected": false,
+            "text": "dfw04",
+            "value": "dfw04"
+          },
+          {
+            "selected": false,
+            "text": "dfw05",
+            "value": "dfw05"
+          },
+          {
+            "selected": false,
+            "text": "dfw06",
+            "value": "dfw06"
+          },
+          {
+            "selected": false,
+            "text": "dub01",
+            "value": "dub01"
+          },
+          {
+            "selected": false,
+            "text": "fln01",
+            "value": "fln01"
+          },
+          {
+            "selected": false,
+            "text": "fra01",
+            "value": "fra01"
+          },
+          {
+            "selected": false,
+            "text": "fra02",
+            "value": "fra02"
+          },
+          {
+            "selected": false,
+            "text": "fra03",
+            "value": "fra03"
+          },
+          {
+            "selected": false,
+            "text": "fra04",
+            "value": "fra04"
+          },
+          {
+            "selected": false,
+            "text": "ham01",
+            "value": "ham01"
+          },
+          {
+            "selected": false,
+            "text": "hnd01",
+            "value": "hnd01"
+          },
+          {
+            "selected": false,
+            "text": "hnd02",
+            "value": "hnd02"
+          },
+          {
+            "selected": false,
+            "text": "iad01",
+            "value": "iad01"
+          },
+          {
+            "selected": false,
+            "text": "iad02",
+            "value": "iad02"
+          },
+          {
+            "selected": false,
+            "text": "iad03",
+            "value": "iad03"
+          },
+          {
+            "selected": false,
+            "text": "iad04",
+            "value": "iad04"
+          },
+          {
+            "selected": false,
+            "text": "iad05",
+            "value": "iad05"
+          },
+          {
+            "selected": false,
+            "text": "iad0t",
+            "value": "iad0t"
+          },
+          {
+            "selected": false,
+            "text": "iad1t",
+            "value": "iad1t"
+          },
+          {
+            "selected": false,
+            "text": "jnb01",
+            "value": "jnb01"
+          },
+          {
+            "selected": false,
+            "text": "lax01",
+            "value": "lax01"
+          },
+          {
+            "selected": false,
+            "text": "lax02",
+            "value": "lax02"
+          },
+          {
+            "selected": false,
+            "text": "lax03",
+            "value": "lax03"
+          },
+          {
+            "selected": false,
+            "text": "lax04",
+            "value": "lax04"
+          },
+          {
+            "selected": false,
+            "text": "lax05",
+            "value": "lax05"
+          },
+          {
+            "selected": false,
+            "text": "lba01",
+            "value": "lba01"
+          },
+          {
+            "selected": false,
+            "text": "lca01",
+            "value": "lca01"
+          },
+          {
+            "selected": false,
+            "text": "lga02",
+            "value": "lga02"
+          },
+          {
+            "selected": false,
+            "text": "lga03",
+            "value": "lga03"
+          },
+          {
+            "selected": false,
+            "text": "lga04",
+            "value": "lga04"
+          },
+          {
+            "selected": false,
+            "text": "lga05",
+            "value": "lga05"
+          },
+          {
+            "selected": false,
+            "text": "lga06",
+            "value": "lga06"
+          },
+          {
+            "selected": false,
+            "text": "lga07",
+            "value": "lga07"
+          },
+          {
+            "selected": false,
+            "text": "lga0t",
+            "value": "lga0t"
+          },
+          {
+            "selected": false,
+            "text": "lga1t",
+            "value": "lga1t"
+          },
+          {
+            "selected": false,
+            "text": "lhr02",
+            "value": "lhr02"
+          },
+          {
+            "selected": false,
+            "text": "lhr03",
+            "value": "lhr03"
+          },
+          {
+            "selected": false,
+            "text": "lhr04",
+            "value": "lhr04"
+          },
+          {
+            "selected": false,
+            "text": "lhr05",
+            "value": "lhr05"
+          },
+          {
+            "selected": false,
+            "text": "lis01",
+            "value": "lis01"
+          },
+          {
+            "selected": false,
+            "text": "lis02",
+            "value": "lis02"
+          },
+          {
+            "selected": false,
+            "text": "lju01",
+            "value": "lju01"
+          },
+          {
+            "selected": false,
+            "text": "los01",
+            "value": "los01"
+          },
+          {
+            "selected": false,
+            "text": "mad02",
+            "value": "mad02"
+          },
+          {
+            "selected": false,
+            "text": "mad03",
+            "value": "mad03"
+          },
+          {
+            "selected": false,
+            "text": "mad04",
+            "value": "mad04"
+          },
+          {
+            "selected": false,
+            "text": "mia01",
+            "value": "mia01"
+          },
+          {
+            "selected": false,
+            "text": "mia02",
+            "value": "mia02"
+          },
+          {
+            "selected": false,
+            "text": "mia03",
+            "value": "mia03"
+          },
+          {
+            "selected": false,
+            "text": "mia04",
+            "value": "mia04"
+          },
+          {
+            "selected": false,
+            "text": "mia05",
+            "value": "mia05"
+          },
+          {
+            "selected": false,
+            "text": "mil02",
+            "value": "mil02"
+          },
+          {
+            "selected": false,
+            "text": "mil03",
+            "value": "mil03"
+          },
+          {
+            "selected": false,
+            "text": "mil04",
+            "value": "mil04"
+          },
+          {
+            "selected": false,
+            "text": "mil05",
+            "value": "mil05"
+          },
+          {
+            "selected": false,
+            "text": "mnl01",
+            "value": "mnl01"
+          },
+          {
+            "selected": false,
+            "text": "mpm01",
+            "value": "mpm01"
+          },
+          {
+            "selected": false,
+            "text": "nbo01",
+            "value": "nbo01"
+          },
+          {
+            "selected": false,
+            "text": "nuq02",
+            "value": "nuq02"
+          },
+          {
+            "selected": false,
+            "text": "nuq03",
+            "value": "nuq03"
+          },
+          {
+            "selected": false,
+            "text": "nuq04",
+            "value": "nuq04"
+          },
+          {
+            "selected": false,
+            "text": "nuq05",
+            "value": "nuq05"
+          },
+          {
+            "selected": false,
+            "text": "nuq06",
+            "value": "nuq06"
+          },
+          {
+            "selected": false,
+            "text": "ord01",
+            "value": "ord01"
+          },
+          {
+            "selected": false,
+            "text": "ord02",
+            "value": "ord02"
+          },
+          {
+            "selected": false,
+            "text": "ord03",
+            "value": "ord03"
+          },
+          {
+            "selected": false,
+            "text": "ord04",
+            "value": "ord04"
+          },
+          {
+            "selected": false,
+            "text": "ord05",
+            "value": "ord05"
+          },
+          {
+            "selected": false,
+            "text": "par02",
+            "value": "par02"
+          },
+          {
+            "selected": false,
+            "text": "par03",
+            "value": "par03"
+          },
+          {
+            "selected": false,
+            "text": "par04",
+            "value": "par04"
+          },
+          {
+            "selected": false,
+            "text": "par05",
+            "value": "par05"
+          },
+          {
+            "selected": false,
+            "text": "prg02",
+            "value": "prg02"
+          },
+          {
+            "selected": false,
+            "text": "prg03",
+            "value": "prg03"
+          },
+          {
+            "selected": false,
+            "text": "prg04",
+            "value": "prg04"
+          },
+          {
+            "selected": false,
+            "text": "prg05",
+            "value": "prg05"
+          },
+          {
+            "selected": false,
+            "text": "sea01",
+            "value": "sea01"
+          },
+          {
+            "selected": false,
+            "text": "sea02",
+            "value": "sea02"
+          },
+          {
+            "selected": false,
+            "text": "sea03",
+            "value": "sea03"
+          },
+          {
+            "selected": false,
+            "text": "sea04",
+            "value": "sea04"
+          },
+          {
+            "selected": false,
+            "text": "sea05",
+            "value": "sea05"
+          },
+          {
+            "selected": false,
+            "text": "sea06",
+            "value": "sea06"
+          },
+          {
+            "selected": false,
+            "text": "sin01",
+            "value": "sin01"
+          },
+          {
+            "selected": false,
+            "text": "sjc01",
+            "value": "sjc01"
+          },
+          {
+            "selected": false,
+            "text": "svg01",
+            "value": "svg01"
+          },
+          {
+            "selected": false,
+            "text": "syd01",
+            "value": "syd01"
+          },
+          {
+            "selected": false,
+            "text": "syd02",
+            "value": "syd02"
+          },
+          {
+            "selected": false,
+            "text": "tnr01",
+            "value": "tnr01"
+          },
+          {
+            "selected": false,
+            "text": "tpe01",
+            "value": "tpe01"
+          },
+          {
+            "selected": false,
+            "text": "trn01",
+            "value": "trn01"
+          },
+          {
+            "selected": false,
+            "text": "tun01",
+            "value": "tun01"
+          },
+          {
+            "selected": false,
+            "text": "tyo01",
+            "value": "tyo01"
+          },
+          {
+            "selected": false,
+            "text": "tyo02",
+            "value": "tyo02"
+          },
+          {
+            "selected": false,
+            "text": "tyo03",
+            "value": "tyo03"
+          },
+          {
+            "selected": false,
+            "text": "vie01",
+            "value": "vie01"
+          },
+          {
+            "selected": false,
+            "text": "wlg02",
+            "value": "wlg02"
+          },
+          {
+            "selected": false,
+            "text": "yqm01",
+            "value": "yqm01"
+          },
+          {
+            "selected": false,
+            "text": "yul02",
+            "value": "yul02"
+          },
+          {
+            "selected": false,
+            "text": "yvr01",
+            "value": "yvr01"
+          },
+          {
+            "selected": false,
+            "text": "ywg01",
+            "value": "ywg01"
+          },
+          {
+            "selected": false,
+            "text": "yyc02",
+            "value": "yyc02"
+          },
+          {
+            "selected": false,
+            "text": "yyz02",
+            "value": "yyz02"
+          }
+        ],
+        "query": "label_values(hostname)",
+        "refresh": 0,
+        "regex": ".*([a-z]{3}[0-9t]{2}).*.measurement-lab.org",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "mlab1",
+            "value": "mlab1"
+          },
+          {
+            "selected": false,
+            "text": "mlab2",
+            "value": "mlab2"
+          },
+          {
+            "selected": false,
+            "text": "mlab3",
+            "value": "mlab3"
+          },
+          {
+            "selected": false,
+            "text": "mlab4",
+            "value": "mlab4"
+          }
+        ],
+        "query": "mlab1,mlab2,mlab3,mlab4",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Ops: Pod Overview",
+  "version": 107
+}


### PR DESCRIPTION
[Ops_PlatformOverview](https://grafana.mlab-sandbox.measurementlab.net/dashboard/file/Ops_PlatformOverview.json?orgId=1):
* The NDT root filesystem panels was still using nagios_exporter metrics. This PR switches that panel to start using node_exporter metrics.
* I've added a new panel for NDT global test rates. I've set the resolution to 1/10 to speed it up, and it's purpose is just to give the operator a rough idea of major traffic events.

[Ops_PodOverview](https://grafana.mlab-sandbox.measurementlab.net/dashboard/file/Ops_PodOverview.json?orgId=1&var-datasource=mlab-oti%20prometheus&var-pod=ams01&var-node=All):
* This is a new JSON dashboard that has been in development for some months. At a glance, it lets an operator know what is up and down through color coding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/257)
<!-- Reviewable:end -->
