### PR TITLE
Upgrade Grafana to work-around k8s 1.10 incompatibility

### DIFF
--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:4.6.3
+      - image: grafana/grafana:5.0.4
         name: grafana-server
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD


### PR DESCRIPTION
With k8s version 1.10, there is an incompatibility between how k8s mounts configmaps and what Grafana expects from its configuration directory.

k8s 1.10 mounts all configmaps read-only, and Grafana tries to `chown` all files in its config directory. Versions of Grafana later than or equal to 5.0.4 should support this behavior.
