### PR TITLE
Upgrade Grafana to v5.1.4 + adds GCP discovery for switch ping  BBE probes.

### DIFF
--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -22,9 +22,17 @@ spec:
         # public IP and port so that it is publically accessible.
         run: grafana-server
     spec:
-      securityContext:
-        # http://docs.grafana.org/installation/docker/#user-id-changes
-        runAsUser: 104
+      # http://docs.grafana.org/installation/docker/#user-id-changes
+      # TODO (kinkade): Remove this initContainers section once it has been
+      # deployed once and permissions have been changed. It won't be needed
+      # again once the perms are changed once.
+      initContainers:
+      - name: reset-perms
+        image: busybox
+        command: ['chown', '-R', '472', '/work-dir']
+        volumeMounts:
+        - mountPath: /work-dir
+          name: grafana-storage
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -22,6 +22,8 @@ spec:
         # public IP and port so that it is publically accessible.
         run: grafana-server
     spec:
+      securityContext:
+        runAsUser: 104
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:5.0.4
+      - image: grafana/grafana:5.1.4
         name: grafana-server
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -23,6 +23,7 @@ spec:
         run: grafana-server
     spec:
       securityContext:
+        # http://docs.grafana.org/installation/docker/#user-id-changes
         runAsUser: 104
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -29,7 +29,7 @@ spec:
       initContainers:
       - name: reset-perms
         image: busybox
-        command: ['chown', '-R', '472', '/work-dir']
+        command: ['chown', '-R', '472:472', '/work-dir']
         volumeMounts:
         - mountPath: /work-dir
           name: grafana-storage

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -175,6 +175,8 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/neubot.json",
                 "--http-target=/targets/blackbox-targets-ipv6/neubot_ipv6.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets-ipv6/neubot_ipv6.json",
+                "--http-target=/targets/blackbox-targets/switches_ping.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/switches_ping.json",
                 "--project={{GCLOUD_PROJECT}}"]
         resources:
           requests:


### PR DESCRIPTION
This PR upgrades Grafana to v5.1.4. Because the [default Grafana Docker images now specify a UID of 472 (instead of 104)](http://docs.grafana.org/installation/docker/#user-id-changes) the permissions of existing files in GKE persistent storage are wrong, meaning that you can either figure out how to change the permissions all those files, or you can simply run the container as UID 104. This PR takes the latter approach, since it seemed much easier, but does mean that we will be carrying forward some non-default configuration baggage for the Grafana container.

This PR also adds a new set of Prom targets to the `gcp-discovery-service` config: `switches_ping.json`. These new targets are use the `icmp` module of blackbox_exporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/262)
<!-- Reviewable:end -->
