### PR TITLE
Add configmap-reload to Prometheus deployment.

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -103,9 +103,9 @@ kubectl create secret generic prometheus-auth \
 AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 export ALERTMANAGER_URL=https://$AUTH@alertmanager.${PROJECT}.measurementlab.net
 # Pass appropriate URL to configmap-reload
-export CONFIGMAP_RELOAD_URL=https://$AUTH@prometheus.${PROJECT}.measurementlab.net/-/reload
-kubectl create configmap configmap-reload \
-    "--from-literal=configmap_reload_url=${CONFIGMAP_RELOAD_URL}" \
+export PROM_RELOAD_URL=https://$AUTH@prometheus.${PROJECT}.measurementlab.net/-/reload
+kubectl create configmap configmap-reload-urls \
+    "--from-literal=prometheus_reload_url=${PROM_RELOAD_URL}" \
     --dry-run -o json | kubectl apply -f -
 set -x
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -102,6 +102,11 @@ kubectl create secret generic prometheus-auth \
     --dry-run -o json | kubectl apply -f -
 AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 export ALERTMANAGER_URL=https://$AUTH@alertmanager.${PROJECT}.measurementlab.net
+# Pass appropriate URL to configmap-reload
+export CONFIGMAP_RELOAD_URL=https://$AUTH@prometheus.${PROJECT}.measurementlab.net/-/reload
+kubectl create configmap configmap-reload \
+    "--from-literal=configmap_reload_url=${CONFIGMAP_RELOAD_URL}" \
+    --dry-run -o json | kubectl apply -f -
 set -x
 
 

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -189,6 +189,29 @@ spec:
         - mountPath: /targets
           name: prometheus-storage
 
+      # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
+      # stable version.
+      - image: jimmidyson/configmap-reload:v0.2.2
+        name: configmap-reload
+        args: ["-webhook-url", "$(CONFIGMAP_RELOAD_URL)", "-volume-dir", "/prometheus-config"]
+        env:
+        - name: CONFIGMAP_RELOAD_URL
+          valueFrom:
+            configMapKeyRef:
+              name: configmap-reload
+              key: configmap_reload_url
+        resources:
+          requests:
+            memory: "400Mi"
+            cpu: "200m"
+          limits:
+            memory: "400Mi"
+            cpu: "200m"
+        volumeMounts:
+        # Mount the prometheus config volume so we can watch it for changes.
+        - mountPath: /prometheus-config
+          name: prometheus-config
+
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.
       volumes:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -195,13 +195,13 @@ spec:
       # stable version.
       - image: jimmidyson/configmap-reload:v0.2.2
         name: configmap-reload
-        args: ["-webhook-url", "$(CONFIGMAP_RELOAD_URL)", "-volume-dir", "/prometheus-config"]
+        args: ["-webhook-url", "$(PROM_RELOAD_URL)", "-volume-dir", "/prometheus-config"]
         env:
-        - name: CONFIGMAP_RELOAD_URL
+        - name: PROM_RELOAD_URL
           valueFrom:
             configMapKeyRef:
-              name: configmap-reload
-              key: configmap_reload_url
+              name: configmap-reload-urls
+              key: prometheus_reload_url
         resources:
           requests:
             memory: "400Mi"


### PR DESCRIPTION
I recreated this branch and pull request in order to clean it up after getting a little too much cruft in my private development fork. This adds the configmap-reload service to the Prometheus deployment, and integrates the feedback from https://github.com/m-lab/prometheus-support/pull/228.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/264)
<!-- Reviewable:end -->
