### PR TITLE
SNMP inhibit rule + additional script-exporter inhibit rule

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -72,7 +72,7 @@ inhibit_rules:
 # Various other checks rely on the script-exporter being up. If the
 # script-exporter is not up, then don't alert on those dependencies.
 - source_match:
-    alertname: 'ScriptExporterDownOrMissing'
+    - alertname: 'ScriptExporterDownOrMissing'
   target_match:
     - alertname: 'ScriptExporterMissingMetrics'
     - alertname: 'TooManyNdtServersDown'
@@ -81,7 +81,7 @@ inhibit_rules:
 # Don't alert on missing SNMP metrics or SNMP scraping being broken if the
 # snmp-exporter is down.
 - source_match:
-    alertname: 'SnmpExporterDownOrMissing'
+    - alertname: 'SnmpExporterDownOrMissing'
   target_match:
     - alertname: 'SnmpExporterMissingMetrics'
     - alertname: 'SnmpScrapingDownAtSite'

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -69,13 +69,22 @@ inhibit_rules:
   # Apply inhibition if the group is the same.
   equal: ['instance', 'service']
 
-# NDT health checks depend on the script-exporter. If the script-exporter is
-# down, then all NDT health checks will report as down too. Don't alert on NDT
-# when the script-exporter is down.
+# Various other checks rely on the script-exporter being up. If the
+# script-exporter is not up, then don't alert on those dependencies.
 - source_match:
     alertname: 'ScriptExporterDownOrMissing'
   target_match:
-    alertname: 'TooManyNdtServersDown'
+    - alertname: 'ScriptExporterMissingMetrics'
+    - alertname: 'TooManyNdtServersDown'
+  equal: []
+
+# Don't alert on missing SNMP metrics or SNMP scraping being broken if the
+# snmp-exporter is down.
+- source_match:
+    alertname: 'SnmpExporterDownOrMissing'
+  target_match:
+    - alertname: 'SnmpExporterMissingMetrics'
+    - alertname: 'SnmpScrapingDownAtSite'
   equal: []
 
 receivers:

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -72,19 +72,19 @@ inhibit_rules:
 # Various other checks rely on the script-exporter being up. If the
 # script-exporter is not up, then don't alert on those dependencies.
 - source_match:
-    - alertname: 'ScriptExporterDownOrMissing'
+  - alertname: 'ScriptExporterDownOrMissing'
   target_match:
-    - alertname: 'ScriptExporterMissingMetrics'
-    - alertname: 'TooManyNdtServersDown'
+  - alertname: 'ScriptExporterMissingMetrics'
+  - alertname: 'TooManyNdtServersDown'
   equal: []
 
 # Don't alert on missing SNMP metrics or SNMP scraping being broken if the
 # snmp-exporter is down.
 - source_match:
-    - alertname: 'SnmpExporterDownOrMissing'
+  - alertname: 'SnmpExporterDownOrMissing'
   target_match:
-    - alertname: 'SnmpExporterMissingMetrics'
-    - alertname: 'SnmpScrapingDownAtSite'
+  - alertname: 'SnmpExporterMissingMetrics'
+  - alertname: 'SnmpScrapingDownAtSite'
   equal: []
 
 receivers:


### PR DESCRIPTION
If the script-exporter is down, then there is no point in alerting on missing script-exporter metrics, nor on things that rely on the script-exporter.  Same with the snmp-exporter. My syntax here is based on my reading of the [AlertManager documentation](https://prometheus.io/docs/alerting/configuration/#inhibit_rule).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/269)
<!-- Reviewable:end -->
