### PR TITLE
Add prometheus VMs configuration & auto deployment

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -188,6 +188,7 @@ pushd config/federation/vms
   ls */*.json | grep vms 2> /dev/null \
     | while read file ; do
 	    echo $file
+		cat $file | python -m json.tool || exit 1
 	    kubectl cp $file ${pod}:/${file}
       done
 popd

--- a/config/federation/vms/blackbox-targets-ipv6/vms_ndt_raw_ipv6.json
+++ b/config/federation/vms/blackbox-targets-ipv6/vms_ndt_raw_ipv6.json
@@ -34,5 +34,65 @@
         "targets": [
             "ndt.iupui.mlab1v6.tyo03.measurement-lab.org:3001"
         ]
-    }
+    },
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.chs0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.iad0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lax0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.lax0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.oma0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.oma0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.pdx0c.measurement-lab.org:3010"
+        ]
+    } 
 ]

--- a/config/federation/vms/blackbox-targets-ipv6/vms_ndt_raw_ipv6.json
+++ b/config/federation/vms/blackbox-targets-ipv6/vms_ndt_raw_ipv6.json
@@ -1,0 +1,38 @@
+[
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo01.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.tyo01.measurement-lab.org:3001"
+        ]
+    }, 
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo02.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.tyo02.measurement-lab.org:3001"
+        ]
+    }, 
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo03.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_raw_ipv6", 
+            "module": "tcp_v6_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.tyo03.measurement-lab.org:3001"
+        ]
+    }
+]

--- a/config/federation/vms/blackbox-targets-ipv6/vms_ndt_ssl_ipv6.json
+++ b/config/federation/vms/blackbox-targets-ipv6/vms_ndt_ssl_ipv6.json
@@ -1,0 +1,38 @@
+[
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo01.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1v6-tyo01.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo02.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1v6-tyo02.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "experiment": "ndt.iupui", 
+            "machine": "mlab1.tyo03.measurement-lab.org", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1v6-tyo03.measurement-lab.org:3010"
+        ]
+    }
+]

--- a/config/federation/vms/blackbox-targets-ipv6/vms_ndt_ssl_ipv6.json
+++ b/config/federation/vms/blackbox-targets-ipv6/vms_ndt_ssl_ipv6.json
@@ -34,5 +34,65 @@
         "targets": [
             "ndt-iupui-mlab1v6-tyo03.measurement-lab.org:3010"
         ]
-    }
+    },
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.chs0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.iad0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lax0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.lax0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.oma0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.oma0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "__blackbox_port": "7115", 
+            "service": "ndt_ssl_ipv6", 
+            "module": "tcp_v6_tls_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1v6.pdx0c.measurement-lab.org:3010"
+        ]
+    } 
 ]

--- a/config/federation/vms/blackbox-targets/vms_ndt_raw.json
+++ b/config/federation/vms/blackbox-targets/vms_ndt_raw.json
@@ -1,0 +1,35 @@
+[
+    {
+        "labels": {
+            "machine": "mlab1.tyo01.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.tyo01.measurement-lab.org:3001"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo02.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.tyo02.measurement-lab.org:3001"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo03.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.tyo03.measurement-lab.org:3001"
+        ]
+    }
+]

--- a/config/federation/vms/blackbox-targets/vms_ndt_raw.json
+++ b/config/federation/vms/blackbox-targets/vms_ndt_raw.json
@@ -31,5 +31,60 @@
         "targets": [
             "ndt.iupui.mlab1.tyo03.measurement-lab.org:3001"
         ]
-    }
+    },
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.chs0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.iad0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lax0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.lax0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.oma0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.oma0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_raw", 
+            "module": "tcp_v4_online"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.pdx0c.measurement-lab.org:3010"
+        ]
+    } 
 ]

--- a/config/federation/vms/blackbox-targets/vms_ndt_ssl.json
+++ b/config/federation/vms/blackbox-targets/vms_ndt_ssl.json
@@ -31,5 +31,60 @@
         "targets": [
             "ndt-iupui-mlab1-tyo03.measurement-lab.org:3010"
         ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-chs0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-iad0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lax0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-lax0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.oma0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-oma0c.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-pdx0c.measurement-lab.org:3010"
+        ]
     }
 ]

--- a/config/federation/vms/blackbox-targets/vms_ndt_ssl.json
+++ b/config/federation/vms/blackbox-targets/vms_ndt_ssl.json
@@ -1,0 +1,35 @@
+[
+    {
+        "labels": {
+            "machine": "mlab1.tyo01.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-tyo01.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo02.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-tyo02.measurement-lab.org:3010"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo03.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_ssl", 
+            "module": "tcp_v4_tls_online"
+        }, 
+        "targets": [
+            "ndt-iupui-mlab1-tyo03.measurement-lab.org:3010"
+        ]
+    }
+]

--- a/config/federation/vms/legacy-targets/vms_nodeexporter.json
+++ b/config/federation/vms/legacy-targets/vms_nodeexporter.json
@@ -1,0 +1,29 @@
+[
+    {
+        "labels": {
+            "machine": "mlab1.tyo01.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.tyo01.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo02.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.tyo02.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.tyo03.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.tyo03.measurement-lab.org:9100"
+        ]
+    }
+]

--- a/config/federation/vms/legacy-targets/vms_nodeexporter.json
+++ b/config/federation/vms/legacy-targets/vms_nodeexporter.json
@@ -25,5 +25,50 @@
         "targets": [
             "mlab1.tyo03.measurement-lab.org:9100"
         ]
-    }
+    },
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.chs0c.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0c.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.iad0c.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lax0c.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.lax0c.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.oma0c.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.oma0c.measurement-lab.org:9100"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
+            "service": "nodeexporter"
+        }, 
+        "targets": [
+            "mlab1.pdx0c.measurement-lab.org:9100"
+        ]
+    } 
 ]

--- a/config/federation/vms/script-targets/vms_ndt_e2e.json
+++ b/config/federation/vms/script-targets/vms_ndt_e2e.json
@@ -1,162 +1,82 @@
 [
     {
         "labels": {
-            "machine": "mlab4.lga0t.measurement-lab.org", 
+            "machine": "mlab1.tyo01.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab4.lga0t.measurement-lab.org"
+            "ndt.iupui.mlab1.tyo01.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab3.lga0t.measurement-lab.org", 
+            "machine": "mlab1.tyo02.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab3.lga0t.measurement-lab.org"
+            "ndt.iupui.mlab1.tyo02.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab2.lga0t.measurement-lab.org", 
+            "machine": "mlab1.tyo03.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab2.lga0t.measurement-lab.org"
+            "ndt.iupui.mlab1.tyo03.measurement-lab.org"
+        ]
+    },
+    {
+        "labels": {
+            "machine": "mlab1.chs0c.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.chs0c.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab1.lga0t.measurement-lab.org", 
+            "machine": "mlab1.iad0c.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab1.lga0t.measurement-lab.org"
+            "ndt.iupui.mlab1.iad0c.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab4.lga1t.measurement-lab.org", 
+            "machine": "mlab1.lax0c.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab4.lga1t.measurement-lab.org"
+            "ndt.iupui.mlab1.lax0c.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab1.lga1t.measurement-lab.org", 
+            "machine": "mlab1.oma0c.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab1.lga1t.measurement-lab.org"
+            "ndt.iupui.mlab1.oma0c.measurement-lab.org"
         ]
     }, 
     {
         "labels": {
-            "machine": "mlab2.lga1t.measurement-lab.org", 
+            "machine": "mlab1.pdx0c.measurement-lab.org", 
             "experiment": "ndt.iupui", 
             "service": "ndt_e2e"
         }, 
         "targets": [
-            "ndt.iupui.mlab2.lga1t.measurement-lab.org"
+            "ndt.iupui.mlab1.pdx0c.measurement-lab.org"
         ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab3.lga1t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab3.lga1t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab2.iad0t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab2.iad0t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab1.iad0t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab1.iad0t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab4.iad0t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab4.iad0t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab3.iad0t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab3.iad0t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab2.iad1t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab2.iad1t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab3.iad1t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab3.iad1t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab4.iad1t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab4.iad1t.measurement-lab.org"
-        ]
-    }, 
-    {
-        "labels": {
-            "machine": "mlab1.iad1t.measurement-lab.org", 
-            "experiment": "ndt.iupui", 
-            "service": "ndt_e2e"
-        }, 
-        "targets": [
-            "ndt.iupui.mlab1.iad1t.measurement-lab.org"
-        ]
-    }
+    } 
 ]

--- a/config/federation/vms/script-targets/vms_ndt_e2e.json
+++ b/config/federation/vms/script-targets/vms_ndt_e2e.json
@@ -1,0 +1,162 @@
+[
+    {
+        "labels": {
+            "machine": "mlab4.lga0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab4.lga0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab3.lga0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab3.lga0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab2.lga0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab2.lga0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lga0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.lga0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab4.lga1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab4.lga1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.lga1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.lga1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab2.lga1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab2.lga1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab3.lga1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab3.lga1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab2.iad0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab2.iad0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.iad0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab4.iad0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab4.iad0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab3.iad0t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab3.iad0t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab2.iad1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab2.iad1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab3.iad1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab3.iad1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab4.iad1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab4.iad1t.measurement-lab.org"
+        ]
+    }, 
+    {
+        "labels": {
+            "machine": "mlab1.iad1t.measurement-lab.org", 
+            "experiment": "ndt.iupui", 
+            "service": "ndt_e2e"
+        }, 
+        "targets": [
+            "ndt.iupui.mlab1.iad1t.measurement-lab.org"
+        ]
+    }
+]


### PR DESCRIPTION
Until we have a better strategy for generating VM monitoring configuration, we want to make changes from reviewed files.

This change adds the manual VM configuration files to the `config/federation/vms` directory and automatically copies these files to the prometheus pod during deployment.

This configuration implies that all projects will monitor the VMs.