### PR TITLE
Removes scrape jobs for the nagios-exporter, adds new node-exporter scrape jobs.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -589,7 +589,7 @@ ALERT NodeExporterOnEbDownOrMissing
   FOR 10m
   LABELS {
     severity = "ticket",
-    repo = "dev-tracker"
+    repo = "ops-tracker"
   }
   ANNOTATIONS {
     summary = "The node_exporter instance running on eb.measurementlab.net is down.",
@@ -603,7 +603,7 @@ ALERT NodeExporterOnMirrorDownOrMissing
   FOR 10m
   LABELS {
     severity = "ticket",
-    repo = "dev-tracker"
+    repo = "ops-tracker"
   }
   ANNOTATIONS {
     summary = "The node_exporter instance running on mirror.measurementlab.net is down.",
@@ -617,7 +617,7 @@ ALERT NodeExporterOnDnsDownOrMissing
   FOR 10m
   LABELS {
     severity = "ticket",
-    repo = "dev-tracker"
+    repo = "ops-tracker"
   }
   ANNOTATIONS {
     summary = "The node_exporter instance running on dns.measurementlab.net is down.",

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -582,44 +582,6 @@ ALERT ParserDailyVolumeTooLow
     dashboard = "https://grafana.mlab-oti.measurementlab.net/d/PKqnWeNmz/"
   }
 
-# Nagios exporter cannot be scrapped (i.e. is down according to prometheus).
-ALERT NagiosExporterDown
-  IF up{job="nagios-oam-exporter"} == 0 OR up{job="nagios-exporter"} == 0
-  FOR 10m
-  LABELS {
-    severity = "ticket",
-    repo = "dev-tracker"
-  }
-  ANNOTATIONS {
-    summary = "The Nagios exporter instance is down on {{ $labels.instance }}.",
-    hints = "The Nagios exporter instance runs in a Linode VM."
-  }
-
-# Nagios exporter is running but not fully functional.
-ALERT NagiosExporterUnavailable
-  IF nagios_livestatus_available{job="nagios-oam-exporter"} == 0 OR nagios_livestatus_available{job="nagios-exporter"} == 0
-  FOR 10m
-  LABELS {
-    severity = "ticket",
-    repo = "dev-tracker"
-  }
-  ANNOTATIONS {
-    summary = "The Nagios exporter instance is unavailable on {{ $labels.instance }}.",
-    hints = "The Nagios exporter instance runs in a Linode VM."
-  }
-
-# Nagios exporter is not scraped at all.
-ALERT NagiosExporterMissing
-  IF absent(up{job="nagios-oam-exporter"}) OR absent(up{job="nagios-exporter"})
-  FOR 10m
-  LABELS {
-    severity = "ticket",
-    repo = "dev-tracker"
-  }
-  ANNOTATIONS {
-    summary = "The Nagios exporter instance is not being monitored.",
-    hints = "The Nagios exporter instance should run in a Linode VM."
-  }
 
 # The node_exporter running on eb.measurementlab.net is down.
 ALERT NodeExporterOnEbDownOrMissing
@@ -632,6 +594,34 @@ ALERT NodeExporterOnEbDownOrMissing
   ANNOTATIONS {
     summary = "The node_exporter instance running on eb.measurementlab.net is down.",
     hints = "Login to EB to see if it is in fact crashed. If so, look through the logs."
+  }
+
+
+# The node_exporter running on mirror.measurementlab.net is down.
+ALERT NodeExporterOnMirrorDownOrMissing
+  IF up{job="mirror-node-exporter"} == 0 OR absent(up{job="mirror-node-exporter"})
+  FOR 10m
+  LABELS {
+    severity = "ticket",
+    repo = "dev-tracker"
+  }
+  ANNOTATIONS {
+    summary = "The node_exporter instance running on mirror.measurementlab.net is down.",
+    hints = "Login to to see if it is in fact crashed. If so, look through the logs."
+  }
+
+
+# The node_exporter running on dns.measurementlab.net is down.
+ALERT NodeExporterOnDnsDownOrMissing
+  IF up{job="dns-node-exporter"} == 0 OR absent(up{job="dns-node-exporter"})
+  FOR 10m
+  LABELS {
+    severity = "ticket",
+    repo = "dev-tracker"
+  }
+  ANNOTATIONS {
+    summary = "The node_exporter instance running on dns.measurementlab.net is down.",
+    hints = "Login to to see if it is in fact crashed. If so, look through the logs."
   }
 
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -293,26 +293,22 @@ scrape_configs:
         refresh_interval: 5m
 
 
-  # Scrape config for the nagios exporter.
-  #
-  # The nagios exporter generates its own labels.
-  - job_name: 'nagios-exporter'
-    static_configs:
-      - targets: ['nagios.measurementlab.net:9267']
-
-
-  # Scrape config for the nagios-oam exporter.
-  #
-  # The nagios exporter generates its own labels.
-  - job_name: 'nagios-oam-exporter'
-    static_configs:
-      - targets: ['nagios-oam.measurementlab.net:9267']
-
-
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'
     static_configs:
       - targets: ['eb.measurementlab.net:9100']
+
+
+  # Scrape config for the node_exporter on mirror.measurementlab.net.
+  - job_name: 'mirror-node-exporter'
+    static_configs:
+      - targets: ['mirror.measurementlab.net:9100']
+
+
+  # Scrape config for the node_exporter on dns.measurementlab.net.
+  - job_name: 'dns-node-exporter'
+    static_configs:
+      - targets: ['dns.measurementlab.net:9100']
 
 
   # Scrape config for federation.


### PR DESCRIPTION
We don't rely on Nagios for much any longer (only ReBot still uses it for anything and that is minimal), so we don't need to be scraping the nagios-exporter on either eb.measurementlab.net or nagios-oam.measurementlab.net. 

Additionally, we don't even need to be running the nagios-oam VM any longer. All it does is monitor eb.measurementlab.net, mirror.measurementlab.net and dns.measuremenlab.net, and very basically. EB was already running Prometheus node_exporter and being scraped. I have installed node_exporter on both  DNS and MIRROR as well. This PR adds scrape jobs for those node_exporters.

This PR also adds alerts for those new node_exporter scrape jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/274)
<!-- Reviewable:end -->
