### PR TITLE
Add metric_relabel_configs for sidestream exporter labels

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -63,7 +63,7 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
 kubectl create configmap prometheus-federation-config \
     --from-literal=gcloud-project=${PROJECT} \
     --from-file=config/federation/prometheus \
-    --dry-run -o json | kubectl apply -f -
+    --dry-run -o json | kubectl replace -f -
 
 ## Grafana
 kubectl create configmap grafana-config \

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -662,1800 +662,3240 @@ scrape_configs:
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;2
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.syd01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;0
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.syd01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;2
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.syd01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ham01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ham01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ham01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lga02.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lga02.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;2
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lga02.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ams01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ams01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;0
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;2
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;10
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ams01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;9
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;4
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.dfw01.measurement-lab.org;1
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.dfw01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;6
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;8
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.dfw01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.mia01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.mia01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.mia01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.ord01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.ord01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.ord01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.sea01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.sea01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.sea01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.lax01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;7
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;11
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;3
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.lax01.measurement-lab.org;5
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.lax01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab1.atl01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab2.atl01.measurement-lab.org;4
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;11
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;9
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;0
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;7
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;6
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;3
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;5
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;10
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;2
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;8
+        target_label: index
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;1
+        target_label: index
+      - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: drop
+        regex: mlab3.atl01.measurement-lab.org;4
+        target_label: index
       - source_labels: [index]
         action: replace
         regex: 0
@@ -2521,3 +3961,7 @@ scrape_configs:
         regex: (.*)
         target_label: experiment
         replacement: $1
+      - source_labels: [index]
+        action: drop
+        regex: (.*)
+        target_label: index

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -273,312 +273,6 @@ scrape_configs:
         target_label: kubernetes_name
 
 
-  # Scrape config for legacy targets.
-  #
-  # Using an out-of-band process, generated configs can be copied into the
-  # Prometheus container. Prometheus will periodically re-read these files to
-  # load any new targets or remove missing ones.
-  #
-  # The file format is described here:
-  #   https://prometheus.io/docs/operating/configuration/#file_sd_config
-  - job_name: 'legacy-targets'
-    file_sd_configs:
-      - files:
-          # NOTE: The path /legacy-targets does not exist in the default
-          # image. Mount this path as a volume with the docker or kubernetes
-          # configuration.
-          - /legacy-targets/*.json
-          - /legacy-targets/*.yaml
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    metric_relabel_configs:
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab1.lax01.measurement-lab.org;10
-    #    target_label: index
-    #    replacement: ndt
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab2.lax01.measurement-lab.org;10
-    #    target_label: index
-    #    replacement: ndt
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab3.lax01.measurement-lab.org;9
-    #    target_label: index
-    #    replacement: ndt
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab1.lax01.measurement-lab.org;11
-    #    target_label: index
-    #    replacement: samknows
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab2.lax01.measurement-lab.org;11
-    #    target_label: index
-    #    replacement: samknows
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab3.lax01.measurement-lab.org;10
-    #    target_label: index
-    #    replacement: samknows
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab1.lax01.measurement-lab.org;9
-    #    target_label: index
-    #    replacement: neubot
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab2.lax01.measurement-lab.org;9
-    #    target_label: index
-    #    replacement: neubot
-    #  - source_labels: [machine, index]
-    #    action: replace
-    #    regex: mlab3.lax01.measurement-lab.org;8
-    #    target_label: index
-    #    replacement: neubot
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;7
-        target_label: index
-        replacement: unknown-0
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;10
-        target_label: index
-        replacement: ndt
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;0
-        target_label: index
-        replacement: npad
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;8
-        target_label: index
-        replacement: unknown-3
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;6
-        target_label: index
-        replacement: diff
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;3
-        target_label: index
-        replacement: geoloc
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;5
-        target_label: index
-        replacement: ooni
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;11
-        target_label: index
-        replacement: samknows
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;2
-        target_label: index
-        replacement: bismark
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;9
-        target_label: index
-        replacement: neubot
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;1
-        target_label: index
-        replacement: michigan
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;4
-        target_label: index
-        replacement: utility
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;2
-        target_label: index
-        replacement: unknown-0
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;10
-        target_label: index
-        replacement: ndt
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;0
-        target_label: index
-        replacement: npad
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;8
-        target_label: index
-        replacement: unknown-3
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;7
-        target_label: index
-        replacement: diff
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;4
-        target_label: index
-        replacement: geoloc
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;6
-        target_label: index
-        replacement: ooni
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;11
-        target_label: index
-        replacement: samknows
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;3
-        target_label: index
-        replacement: bismark
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;9
-        target_label: index
-        replacement: neubot
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;1
-        target_label: index
-        replacement: michigan
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;5
-        target_label: index
-        replacement: utility
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;11
-        target_label: index
-        replacement: unknown-0
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;9
-        target_label: index
-        replacement: ndt
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;0
-        target_label: index
-        replacement: npad
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;7
-        target_label: index
-        replacement: unknown-3
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;6
-        target_label: index
-        replacement: diff
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;3
-        target_label: index
-        replacement: geoloc
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;5
-        target_label: index
-        replacement: ooni
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;10
-        target_label: index
-        replacement: samknows
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;2
-        target_label: index
-        replacement: bismark
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;8
-        target_label: index
-        replacement: neubot
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;1
-        target_label: index
-        replacement: michigan
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;4
-        target_label: index
-        replacement: utility
-      - source_labels: [index]
-        action: replace
-        regex: 0
-        target_label: index
-        replacement: unknown-0
-      - source_labels: [index]
-        action: replace
-        regex: 1
-        target_label: index
-        replacement: ndt
-      - source_labels: [index]
-        action: replace
-        regex: 2
-        target_label: index
-        replacement: npad
-      - source_labels: [index]
-        action: replace
-        regex: 3
-        target_label: index
-        replacement: unknown-3
-      - source_labels: [index]
-        action: replace
-        regex: 4
-        target_label: index
-        replacement: diff
-      - source_labels: [index]
-        action: replace
-        regex: 5
-        target_label: index
-        replacement: geoloc
-      - source_labels: [index]
-        action: replace
-        regex: 6
-        target_label: index
-        replacement: ooni
-      - source_labels: [index]
-        action: replace
-        regex: 7
-        target_label: index
-        replacement: samknows
-      - source_labels: [index]
-        action: replace
-        regex: 8
-        target_label: index
-        replacement: bismark
-      - source_labels: [index]
-        action: replace
-        regex: 9
-        target_label: index
-        replacement: neubot
-      - source_labels: [index]
-        action: replace
-        regex: 10
-        target_label: index
-        replacement: michigan
-      - source_labels: [index]
-        action: replace
-        regex: 11
-        target_label: index
-        replacement: utility
-
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'
     static_configs:
@@ -942,3 +636,1883 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
+  # Scrape config for legacy targets.
+  #
+  # Using an out-of-band process, generated configs can be copied into the
+  # Prometheus container. Prometheus will periodically re-read these files to
+  # load any new targets or remove missing ones.
+  #
+  # The file format is described here:
+  #   https://prometheus.io/docs/operating/configuration/#file_sd_config
+  - job_name: 'legacy-targets'
+    file_sd_configs:
+      - files:
+          # NOTE: The path /legacy-targets does not exist in the default
+          # image. Mount this path as a volume with the docker or kubernetes
+          # configuration.
+          - /legacy-targets/*.json
+          - /legacy-targets/*.yaml
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    metric_relabel_configs:
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;1
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;2
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;8
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;0
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;10
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;7
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;4
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.syd01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;2
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;0
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;3
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;5
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;11
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;1
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;8
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;7
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.syd01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;2
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;4
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;6
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;7
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;1
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;3
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;9
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;8
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.syd01.measurement-lab.org;5
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;1
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;2
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;9
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;7
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;4
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ham01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;1
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;2
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;9
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;7
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;4
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ham01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;6
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;5
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;1
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;9
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;7
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;3
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;2
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ham01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;8
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;4
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;1
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;2
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;6
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;0
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lga02.measurement-lab.org;3
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lga02.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;8
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;5
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;2
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;3
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;1
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;6
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;0
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lga02.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;1
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;2
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;9
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;7
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;4
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ams01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;1
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;2
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;9
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;7
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;4
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ams01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;4
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;0
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;1
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;2
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;10
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;8
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;9
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;5
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;7
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;3
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ams01.measurement-lab.org;6
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;9
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;7
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;6
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;5
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;2
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;8
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;0
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;4
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;10
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;3
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.dfw01.measurement-lab.org;1
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.dfw01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;2
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;6
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;8
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;3
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;5
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.dfw01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.mia01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.mia01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.mia01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.ord01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.ord01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.ord01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.sea01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;10
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;1
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;8
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;7
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;4
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;6
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;3
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;2
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.sea01.measurement-lab.org;5
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.sea01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;2
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.atl01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.atl01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;0
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;6
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;10
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;8
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;1
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.atl01.measurement-lab.org;4
+        target_label: index
+        replacement: utility.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [index]
+        action: replace
+        regex: 1
+        target_label: index
+        replacement: ndt.iupui
+      - source_labels: [index]
+        action: replace
+        regex: 2
+        target_label: index
+        replacement: npad.iupui
+      - source_labels: [index]
+        action: replace
+        regex: 3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [index]
+        action: replace
+        regex: 4
+        target_label: index
+        replacement: diff.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 5
+        target_label: index
+        replacement: geoloc4.uw
+      - source_labels: [index]
+        action: replace
+        regex: 6
+        target_label: index
+        replacement: ooni.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 7
+        target_label: index
+        replacement: ispmon.samknows
+      - source_labels: [index]
+        action: replace
+        regex: 8
+        target_label: index
+        replacement: bismark.gt
+      - source_labels: [index]
+        action: replace
+        regex: 9
+        target_label: index
+        replacement: neubot.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 10
+        target_label: index
+        replacement: 1.michigan
+      - source_labels: [index]
+        action: replace
+        regex: 11
+        target_label: index
+        replacement: utility.mlab

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -655,6 +655,15 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
+    # Note: these relabel configs translate the sidestream exporter `index`
+    # label from a number to a human readable experiment name. e.g. "1" to
+    # "ndt.iupui". Since some sites have non-standard index order, the majority
+    # of the rules exist to convert legacy network remaped indexes to their
+    # correct name. To make this work the regex matches both the hostname and
+    # the actual index.
+    #
+    # The final set of 12 relabel configs exist to assign experiment names to
+    # all other hostnames that do use standard index order.
     metric_relabel_configs:
       - source_labels: [machine, index]
         action: replace

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -659,3730 +659,1860 @@ scrape_configs:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;1
-        target_label: experiment
-        replacement: unknown-0
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;2
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;8
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;3
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;0
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;10
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;7
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;9
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;4
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.syd01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;2
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;0
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;3
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;5
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;11
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;1
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;8
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;9
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;7
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.syd01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;2
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;4
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;6
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;7
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;1
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;3
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;9
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;8
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.syd01.measurement-lab.org;5
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;1
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;2
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;3
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;9
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;7
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;4
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ham01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;1
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;2
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;3
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;9
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;7
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;4
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ham01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;6
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;1
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;9
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;7
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;3
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;2
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ham01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;8
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;4
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;1
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;2
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;6
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;0
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lga02.measurement-lab.org;3
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lga02.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;8
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;5
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;2
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;3
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;1
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;6
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;0
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lga02.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;1
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;2
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;3
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;9
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;7
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;4
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ams01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;1
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;2
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;3
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;9
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;7
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;4
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ams01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;4
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;0
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;1
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;2
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;10
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;8
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;5
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;7
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;3
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ams01.measurement-lab.org;6
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;9
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;7
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;6
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;5
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;2
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;8
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;0
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;4
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;10
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;3
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.dfw01.measurement-lab.org;1
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.dfw01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;2
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;6
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;8
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;3
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;5
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.dfw01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.mia01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.mia01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.mia01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.ord01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.ord01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.ord01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.sea01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;0
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;1
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;8
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;7
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;4
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;6
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;3
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;9
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;2
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.sea01.measurement-lab.org;5
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.sea01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;8
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;9
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.lax01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;2
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;8
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;7
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;4
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;6
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;11
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;3
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;9
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;5
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab1.atl01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;9
-        target_label: experiment
-        replacement: ndt.iupui
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;0
-        target_label: experiment
-        replacement: npad.iupui
+        replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;7
-        target_label: experiment
-        replacement: unknown-3
+        replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;6
-        target_label: experiment
-        replacement: diff.mlab
+        replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;3
-        target_label: experiment
-        replacement: geoloc4.uw
+        replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;5
-        target_label: experiment
-        replacement: ooni.mlab
+        replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;10
-        target_label: experiment
-        replacement: ispmon.samknows
+        replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;2
-        target_label: experiment
-        replacement: bismark.gt
+        replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;8
-        target_label: experiment
-        replacement: neubot.mlab
+        replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;1
-        target_label: experiment
-        replacement: 1.michigan
+        replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.atl01.measurement-lab.org;4
-        target_label: experiment
-        replacement: utility.mlab
+        replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
         target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.atl01.measurement-lab.org;11
-        target_label: experiment
-        replacement: unknown-0
+        replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
         target_label: index
-        replacement: "" 
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
-        target_label: experiment
+        target_label: index
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;9
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;0
-        target_label: experiment
+        target_label: index
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;0
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;7
-        target_label: experiment
+        target_label: index
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;7
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;6
-        target_label: experiment
+        target_label: index
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;6
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;3
-        target_label: experiment
+        target_label: index
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;3
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;5
-        target_label: experiment
+        target_label: index
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;5
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;10
-        target_label: experiment
+        target_label: index
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;10
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;2
-        target_label: experiment
+        target_label: index
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;2
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;8
-        target_label: experiment
+        target_label: index
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;8
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;1
-        target_label: experiment
+        target_label: index
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.atl01.measurement-lab.org;1
-        target_label: index
-        replacement: "" 
-      - source_labels: [machine, index]
-        action: replace
         regex: mlab3.atl01.measurement-lab.org;4
-        target_label: experiment
+        target_label: index
         replacement: utility.mlab
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.atl01.measurement-lab.org;4
-        target_label: index
-        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 0
-        target_label: experiment
+        target_label: index
         replacement: unknown-0
       - source_labels: [index]
         action: replace
-        regex: 0
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 1
-        target_label: experiment
+        target_label: index
         replacement: ndt.iupui
       - source_labels: [index]
         action: replace
-        regex: 1
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 2
-        target_label: experiment
+        target_label: index
         replacement: npad.iupui
       - source_labels: [index]
         action: replace
-        regex: 2
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 3
-        target_label: experiment
+        target_label: index
         replacement: unknown-3
       - source_labels: [index]
         action: replace
-        regex: 3
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 4
-        target_label: experiment
+        target_label: index
         replacement: diff.mlab
       - source_labels: [index]
         action: replace
-        regex: 4
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 5
-        target_label: experiment
+        target_label: index
         replacement: geoloc4.uw
       - source_labels: [index]
         action: replace
-        regex: 5
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 6
-        target_label: experiment
+        target_label: index
         replacement: ooni.mlab
       - source_labels: [index]
         action: replace
-        regex: 6
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 7
-        target_label: experiment
+        target_label: index
         replacement: ispmon.samknows
       - source_labels: [index]
         action: replace
-        regex: 7
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 8
-        target_label: experiment
+        target_label: index
         replacement: bismark.gt
       - source_labels: [index]
         action: replace
-        regex: 8
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 9
-        target_label: experiment
+        target_label: index
         replacement: neubot.mlab
       - source_labels: [index]
         action: replace
-        regex: 9
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 10
-        target_label: experiment
+        target_label: index
         replacement: 1.michigan
       - source_labels: [index]
         action: replace
-        regex: 10
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
         regex: 11
-        target_label: experiment
+        target_label: index
         replacement: utility.mlab
-      - source_labels: [index]
-        action: replace
-        regex: 11
-        target_label: index
-        replacement: "" 
-      - source_labels: [index]
-        action: replace
-        regex: (.*)
-        target_label: experiment
-        replacement: $1
-      - source_labels: [index]
-        action: replace
-        regex: (.*)
-        target_label: index
-        replacement: "" 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -292,25 +292,87 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-    #'lax01': {1: '7,10,0,8,6,3,5,11,2,9,1,4',
-    #          2: '2,10,0,8,7,4,6,11,3,9,1,5',
-    #          3: '11,9,0,7,6,3,5,10,2,8,1,4'},
     metric_relabel_configs:
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab1.lax01.measurement-lab.org;10
+    #    target_label: index
+    #    replacement: ndt
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab2.lax01.measurement-lab.org;10
+    #    target_label: index
+    #    replacement: ndt
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab3.lax01.measurement-lab.org;9
+    #    target_label: index
+    #    replacement: ndt
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab1.lax01.measurement-lab.org;11
+    #    target_label: index
+    #    replacement: samknows
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab2.lax01.measurement-lab.org;11
+    #    target_label: index
+    #    replacement: samknows
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab3.lax01.measurement-lab.org;10
+    #    target_label: index
+    #    replacement: samknows
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab1.lax01.measurement-lab.org;9
+    #    target_label: index
+    #    replacement: neubot
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab2.lax01.measurement-lab.org;9
+    #    target_label: index
+    #    replacement: neubot
+    #  - source_labels: [machine, index]
+    #    action: replace
+    #    regex: mlab3.lax01.measurement-lab.org;8
+    #    target_label: index
+    #    replacement: neubot
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: index
-        replacement: ndt 
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab2.lax01.measurement-lab.org;10
-        target_label: index
         replacement: ndt
       - source_labels: [machine, index]
         action: replace
-        regex: mlab3.lax01.measurement-lab.org;9
+        regex: mlab1.lax01.measurement-lab.org;0
         target_label: index
-        replacement: ndt
+        replacement: npad
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: diff
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
@@ -318,14 +380,9 @@ scrape_configs:
         replacement: samknows
       - source_labels: [machine, index]
         action: replace
-        regex: mlab2.lax01.measurement-lab.org;11
+        regex: mlab1.lax01.measurement-lab.org;2
         target_label: index
-        replacement: samknows
-      - source_labels: [machine, index]
-        action: replace
-        regex: mlab3.lax01.measurement-lab.org;10
-        target_label: index
-        replacement: samknows
+        replacement: bismark
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
@@ -333,15 +390,194 @@ scrape_configs:
         replacement: neubot
       - source_labels: [machine, index]
         action: replace
+        regex: mlab1.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: utility
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;2
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: ndt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;0
+        target_label: index
+        replacement: npad
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: diff
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: geoloc
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: ooni
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: bismark
+      - source_labels: [machine, index]
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: index
         replacement: neubot
       - source_labels: [machine, index]
         action: replace
+        regex: mlab2.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: utility
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: ndt
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;0
+        target_label: index
+        replacement: npad
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;7
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;6
+        target_label: index
+        replacement: diff
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;3
+        target_label: index
+        replacement: geoloc
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;5
+        target_label: index
+        replacement: ooni
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;2
+        target_label: index
+        replacement: bismark
+      - source_labels: [machine, index]
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: index
         replacement: neubot
-
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;1
+        target_label: index
+        replacement: michigan
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;4
+        target_label: index
+        replacement: utility
+      - source_labels: [index]
+        action: replace
+        regex: 0
+        target_label: index
+        replacement: unknown-0
+      - source_labels: [index]
+        action: replace
+        regex: 1
+        target_label: index
+        replacement: ndt
+      - source_labels: [index]
+        action: replace
+        regex: 2
+        target_label: index
+        replacement: npad
+      - source_labels: [index]
+        action: replace
+        regex: 3
+        target_label: index
+        replacement: unknown-3
+      - source_labels: [index]
+        action: replace
+        regex: 4
+        target_label: index
+        replacement: diff
+      - source_labels: [index]
+        action: replace
+        regex: 5
+        target_label: index
+        replacement: geoloc
+      - source_labels: [index]
+        action: replace
+        regex: 6
+        target_label: index
+        replacement: ooni
+      - source_labels: [index]
+        action: replace
+        regex: 7
+        target_label: index
+        replacement: samknows
+      - source_labels: [index]
+        action: replace
+        regex: 8
+        target_label: index
+        replacement: bismark
+      - source_labels: [index]
+        action: replace
+        regex: 9
+        target_label: index
+        replacement: neubot
+      - source_labels: [index]
+        action: replace
+        regex: 10
+        target_label: index
+        replacement: michigan
+      - source_labels: [index]
+        action: replace
+        regex: 11
+        target_label: index
+        replacement: utility
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -300,37 +300,47 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: index
-        replacement: 1
+        replacement: ndt 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: index
-        replacement: 1
+        replacement: ndt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: index
-        replacement: 1
+        replacement: ndt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: index
-        replacement: 7
+        replacement: samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: index
-        replacement: 7
+        replacement: samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: index
-        replacement: 7
+        replacement: samknows
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: neubot
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: index
-        replacement: 9
+        replacement: neubot
 
 
   # Scrape config for the node_exporter on eb.measurementlab.net.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -659,1860 +659,1860 @@ scrape_configs:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;0
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;7
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;6
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;3
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;5
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;10
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;2
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;8
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;1
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;4
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab
       - source_labels: [index]
         action: replace
         regex: 0
-        target_label: index
+        target_label: experiment
         replacement: unknown-0
       - source_labels: [index]
         action: replace
         regex: 1
-        target_label: index
+        target_label: experiment
         replacement: ndt.iupui
       - source_labels: [index]
         action: replace
         regex: 2
-        target_label: index
+        target_label: experiment
         replacement: npad.iupui
       - source_labels: [index]
         action: replace
         regex: 3
-        target_label: index
+        target_label: experiment
         replacement: unknown-3
       - source_labels: [index]
         action: replace
         regex: 4
-        target_label: index
+        target_label: experiment
         replacement: diff.mlab
       - source_labels: [index]
         action: replace
         regex: 5
-        target_label: index
+        target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [index]
         action: replace
         regex: 6
-        target_label: index
+        target_label: experiment
         replacement: ooni.mlab
       - source_labels: [index]
         action: replace
         regex: 7
-        target_label: index
+        target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [index]
         action: replace
         regex: 8
-        target_label: index
+        target_label: experiment
         replacement: bismark.gt
       - source_labels: [index]
         action: replace
         regex: 9
-        target_label: index
+        target_label: experiment
         replacement: neubot.mlab
       - source_labels: [index]
         action: replace
         regex: 10
-        target_label: index
+        target_label: experiment
         replacement: 1.michigan
       - source_labels: [index]
         action: replace
         regex: 11
-        target_label: index
+        target_label: experiment
         replacement: utility.mlab

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -665,7 +665,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
@@ -675,7 +675,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
@@ -685,7 +685,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
@@ -695,7 +695,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
@@ -705,7 +705,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
@@ -715,7 +715,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
@@ -725,7 +725,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
@@ -735,7 +735,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
@@ -745,7 +745,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
@@ -755,7 +755,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
@@ -765,7 +765,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
@@ -775,7 +775,7 @@ scrape_configs:
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
@@ -785,7 +785,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
@@ -795,7 +795,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
@@ -805,7 +805,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
@@ -815,7 +815,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
@@ -825,7 +825,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
@@ -835,7 +835,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
@@ -845,7 +845,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
@@ -855,7 +855,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
@@ -865,7 +865,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
@@ -875,7 +875,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
@@ -885,7 +885,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
@@ -895,7 +895,7 @@ scrape_configs:
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
@@ -905,7 +905,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
@@ -915,7 +915,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
@@ -925,7 +925,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
@@ -935,7 +935,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
@@ -945,7 +945,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
@@ -955,7 +955,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
@@ -965,7 +965,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
@@ -975,7 +975,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
@@ -985,7 +985,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
@@ -995,7 +995,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
@@ -1005,7 +1005,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
@@ -1015,7 +1015,7 @@ scrape_configs:
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
@@ -1025,7 +1025,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
@@ -1035,7 +1035,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
@@ -1045,7 +1045,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
@@ -1055,7 +1055,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
@@ -1065,7 +1065,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
@@ -1075,7 +1075,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
@@ -1085,7 +1085,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
@@ -1095,7 +1095,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
@@ -1105,7 +1105,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
@@ -1115,7 +1115,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
@@ -1125,7 +1125,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
@@ -1135,7 +1135,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
@@ -1145,7 +1145,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
@@ -1155,7 +1155,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
@@ -1165,7 +1165,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
@@ -1175,7 +1175,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
@@ -1185,7 +1185,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
@@ -1195,7 +1195,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
@@ -1205,7 +1205,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
@@ -1215,7 +1215,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
@@ -1225,7 +1225,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
@@ -1235,7 +1235,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
@@ -1245,7 +1245,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
@@ -1255,7 +1255,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
@@ -1265,7 +1265,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
@@ -1275,7 +1275,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
@@ -1285,7 +1285,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
@@ -1295,7 +1295,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
@@ -1305,7 +1305,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
@@ -1315,7 +1315,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
@@ -1325,7 +1325,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
@@ -1335,7 +1335,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
@@ -1345,7 +1345,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
@@ -1355,7 +1355,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
@@ -1365,7 +1365,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
@@ -1375,7 +1375,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
@@ -1385,7 +1385,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
@@ -1395,7 +1395,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
@@ -1405,7 +1405,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
@@ -1415,7 +1415,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
@@ -1425,7 +1425,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
@@ -1435,7 +1435,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
@@ -1445,7 +1445,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
@@ -1455,7 +1455,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
@@ -1465,7 +1465,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
@@ -1475,7 +1475,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
@@ -1485,7 +1485,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
@@ -1495,7 +1495,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
@@ -1505,7 +1505,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
@@ -1515,7 +1515,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
@@ -1525,7 +1525,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
@@ -1535,7 +1535,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
@@ -1545,7 +1545,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
@@ -1555,7 +1555,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
@@ -1565,7 +1565,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
@@ -1575,7 +1575,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
@@ -1585,7 +1585,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
@@ -1595,7 +1595,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
@@ -1605,7 +1605,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
@@ -1615,7 +1615,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
@@ -1625,7 +1625,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
@@ -1635,7 +1635,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
@@ -1645,7 +1645,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
@@ -1655,7 +1655,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
@@ -1665,7 +1665,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
@@ -1675,7 +1675,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
@@ -1685,7 +1685,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
@@ -1695,7 +1695,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
@@ -1705,7 +1705,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
@@ -1715,7 +1715,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
@@ -1725,7 +1725,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
@@ -1735,7 +1735,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
@@ -1745,7 +1745,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
@@ -1755,7 +1755,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
@@ -1765,7 +1765,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
@@ -1775,7 +1775,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
@@ -1785,7 +1785,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
@@ -1795,7 +1795,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
@@ -1805,7 +1805,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
@@ -1815,7 +1815,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
@@ -1825,7 +1825,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
@@ -1835,7 +1835,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
@@ -1845,7 +1845,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
@@ -1855,7 +1855,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
@@ -1865,7 +1865,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
@@ -1875,7 +1875,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
@@ -1885,7 +1885,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
@@ -1895,7 +1895,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
@@ -1905,7 +1905,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
@@ -1915,7 +1915,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
@@ -1925,7 +1925,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
@@ -1935,7 +1935,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
@@ -1945,7 +1945,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
@@ -1955,7 +1955,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
@@ -1965,7 +1965,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
@@ -1975,7 +1975,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
@@ -1985,7 +1985,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
@@ -1995,7 +1995,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
@@ -2005,7 +2005,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
@@ -2015,7 +2015,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
@@ -2025,7 +2025,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
@@ -2035,7 +2035,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
@@ -2045,7 +2045,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
@@ -2055,7 +2055,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
@@ -2065,7 +2065,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
@@ -2075,7 +2075,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
@@ -2085,7 +2085,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
@@ -2095,7 +2095,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
@@ -2105,7 +2105,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
@@ -2115,7 +2115,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
@@ -2125,7 +2125,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
@@ -2135,7 +2135,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
@@ -2145,7 +2145,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
@@ -2155,7 +2155,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
@@ -2165,7 +2165,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
@@ -2175,7 +2175,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
@@ -2185,7 +2185,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
@@ -2195,7 +2195,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
@@ -2205,7 +2205,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
@@ -2215,7 +2215,7 @@ scrape_configs:
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
@@ -2225,7 +2225,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
@@ -2235,7 +2235,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
@@ -2245,7 +2245,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
@@ -2255,7 +2255,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
@@ -2265,7 +2265,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
@@ -2275,7 +2275,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
@@ -2285,7 +2285,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
@@ -2295,7 +2295,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
@@ -2305,7 +2305,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
@@ -2315,7 +2315,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
@@ -2325,7 +2325,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
@@ -2335,7 +2335,7 @@ scrape_configs:
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
@@ -2345,7 +2345,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
@@ -2355,7 +2355,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
@@ -2365,7 +2365,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
@@ -2375,7 +2375,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
@@ -2385,7 +2385,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
@@ -2395,7 +2395,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
@@ -2405,7 +2405,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
@@ -2415,7 +2415,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
@@ -2425,7 +2425,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
@@ -2435,7 +2435,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
@@ -2445,7 +2445,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
@@ -2455,7 +2455,7 @@ scrape_configs:
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
@@ -2465,7 +2465,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
@@ -2475,7 +2475,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
@@ -2485,7 +2485,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
@@ -2495,7 +2495,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
@@ -2505,7 +2505,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
@@ -2515,7 +2515,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
@@ -2525,7 +2525,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
@@ -2535,7 +2535,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
@@ -2545,7 +2545,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
@@ -2555,7 +2555,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
@@ -2565,7 +2565,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
@@ -2575,7 +2575,7 @@ scrape_configs:
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
@@ -2585,7 +2585,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
@@ -2595,7 +2595,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
@@ -2605,7 +2605,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
@@ -2615,7 +2615,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
@@ -2625,7 +2625,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
@@ -2635,7 +2635,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
@@ -2645,7 +2645,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
@@ -2655,7 +2655,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
@@ -2665,7 +2665,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
@@ -2675,7 +2675,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
@@ -2685,7 +2685,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
@@ -2695,7 +2695,7 @@ scrape_configs:
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
@@ -2705,7 +2705,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
@@ -2715,7 +2715,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
@@ -2725,7 +2725,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
@@ -2735,7 +2735,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
@@ -2745,7 +2745,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
@@ -2755,7 +2755,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
@@ -2765,7 +2765,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
@@ -2775,7 +2775,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
@@ -2785,7 +2785,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
@@ -2795,7 +2795,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
@@ -2805,7 +2805,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
@@ -2815,7 +2815,7 @@ scrape_configs:
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
@@ -2825,7 +2825,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
@@ -2835,7 +2835,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
@@ -2845,7 +2845,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
@@ -2855,7 +2855,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
@@ -2865,7 +2865,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
@@ -2875,7 +2875,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
@@ -2885,7 +2885,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
@@ -2895,7 +2895,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
@@ -2905,7 +2905,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
@@ -2915,7 +2915,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
@@ -2925,7 +2925,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
@@ -2935,7 +2935,7 @@ scrape_configs:
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
@@ -2945,7 +2945,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
@@ -2955,7 +2955,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
@@ -2965,7 +2965,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
@@ -2975,7 +2975,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
@@ -2985,7 +2985,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
@@ -2995,7 +2995,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
@@ -3005,7 +3005,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
@@ -3015,7 +3015,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
@@ -3025,7 +3025,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
@@ -3035,7 +3035,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
@@ -3045,7 +3045,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
@@ -3055,7 +3055,7 @@ scrape_configs:
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
@@ -3065,7 +3065,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
@@ -3075,7 +3075,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
@@ -3085,7 +3085,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
@@ -3095,7 +3095,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
@@ -3105,7 +3105,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
@@ -3115,7 +3115,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
@@ -3125,7 +3125,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
@@ -3135,7 +3135,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
@@ -3145,7 +3145,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
@@ -3155,7 +3155,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
@@ -3165,7 +3165,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
@@ -3175,7 +3175,7 @@ scrape_configs:
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
@@ -3185,7 +3185,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
@@ -3195,7 +3195,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
@@ -3205,7 +3205,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
@@ -3215,7 +3215,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
@@ -3225,7 +3225,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
@@ -3235,7 +3235,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
@@ -3245,7 +3245,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
@@ -3255,7 +3255,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
@@ -3265,7 +3265,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
@@ -3275,7 +3275,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
@@ -3285,7 +3285,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
@@ -3295,7 +3295,7 @@ scrape_configs:
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
@@ -3305,7 +3305,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
@@ -3315,7 +3315,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
@@ -3325,7 +3325,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
@@ -3335,7 +3335,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
@@ -3345,7 +3345,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
@@ -3355,7 +3355,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
@@ -3365,7 +3365,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
@@ -3375,7 +3375,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
@@ -3385,7 +3385,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
@@ -3395,7 +3395,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
@@ -3405,7 +3405,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
@@ -3415,7 +3415,7 @@ scrape_configs:
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
@@ -3425,7 +3425,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
@@ -3435,7 +3435,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
@@ -3445,7 +3445,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
@@ -3455,7 +3455,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
@@ -3465,7 +3465,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
@@ -3475,7 +3475,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
@@ -3485,7 +3485,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
@@ -3495,7 +3495,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
@@ -3505,7 +3505,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
@@ -3515,7 +3515,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
@@ -3525,7 +3525,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
@@ -3535,7 +3535,7 @@ scrape_configs:
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
@@ -3545,7 +3545,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
@@ -3555,7 +3555,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
@@ -3565,7 +3565,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
@@ -3575,7 +3575,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
@@ -3585,7 +3585,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
@@ -3595,7 +3595,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
@@ -3605,7 +3605,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
@@ -3615,7 +3615,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
@@ -3625,7 +3625,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
@@ -3635,7 +3635,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
@@ -3645,7 +3645,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
@@ -3655,7 +3655,7 @@ scrape_configs:
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
@@ -3665,7 +3665,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
@@ -3675,7 +3675,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
@@ -3685,7 +3685,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
@@ -3695,7 +3695,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
@@ -3705,7 +3705,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
@@ -3715,7 +3715,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
@@ -3725,7 +3725,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
@@ -3735,7 +3735,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
@@ -3745,7 +3745,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
@@ -3755,7 +3755,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
@@ -3765,7 +3765,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
@@ -3775,7 +3775,7 @@ scrape_configs:
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
@@ -3785,7 +3785,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
@@ -3795,7 +3795,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
@@ -3805,7 +3805,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
@@ -3815,7 +3815,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
@@ -3825,7 +3825,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
@@ -3835,7 +3835,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
@@ -3845,7 +3845,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
@@ -3855,7 +3855,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
@@ -3865,7 +3865,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
@@ -3875,7 +3875,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
@@ -3885,7 +3885,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
@@ -3895,7 +3895,7 @@ scrape_configs:
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
@@ -3905,7 +3905,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
@@ -3915,7 +3915,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
@@ -3925,7 +3925,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
@@ -3935,7 +3935,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
@@ -3945,7 +3945,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
@@ -3955,7 +3955,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
@@ -3965,7 +3965,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
@@ -3975,7 +3975,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
@@ -3985,7 +3985,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
@@ -3995,7 +3995,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
@@ -4005,7 +4005,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
@@ -4015,7 +4015,7 @@ scrape_configs:
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
@@ -4025,7 +4025,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
@@ -4035,7 +4035,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
@@ -4045,7 +4045,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
@@ -4055,7 +4055,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
@@ -4065,7 +4065,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
@@ -4075,7 +4075,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
@@ -4085,7 +4085,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
@@ -4095,7 +4095,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
@@ -4105,7 +4105,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
@@ -4115,7 +4115,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
@@ -4125,7 +4125,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
@@ -4135,7 +4135,7 @@ scrape_configs:
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
@@ -4145,7 +4145,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
@@ -4155,7 +4155,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;0
@@ -4165,7 +4165,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;7
@@ -4175,7 +4175,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;6
@@ -4185,7 +4185,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;3
@@ -4195,7 +4195,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;5
@@ -4205,7 +4205,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;10
@@ -4215,7 +4215,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;2
@@ -4225,7 +4225,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;8
@@ -4235,7 +4235,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;1
@@ -4245,7 +4245,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;4
@@ -4255,7 +4255,7 @@ scrape_configs:
         action: replace
         regex: mlab3.atl01.measurement-lab.org;4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 0
@@ -4265,7 +4265,7 @@ scrape_configs:
         action: replace
         regex: 0
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 1
@@ -4275,7 +4275,7 @@ scrape_configs:
         action: replace
         regex: 1
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 2
@@ -4285,7 +4285,7 @@ scrape_configs:
         action: replace
         regex: 2
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 3
@@ -4295,7 +4295,7 @@ scrape_configs:
         action: replace
         regex: 3
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 4
@@ -4305,7 +4305,7 @@ scrape_configs:
         action: replace
         regex: 4
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 5
@@ -4315,7 +4315,7 @@ scrape_configs:
         action: replace
         regex: 5
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 6
@@ -4325,7 +4325,7 @@ scrape_configs:
         action: replace
         regex: 6
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 7
@@ -4335,7 +4335,7 @@ scrape_configs:
         action: replace
         regex: 7
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 8
@@ -4345,7 +4345,7 @@ scrape_configs:
         action: replace
         regex: 8
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 9
@@ -4355,7 +4355,7 @@ scrape_configs:
         action: replace
         regex: 9
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 10
@@ -4365,7 +4365,7 @@ scrape_configs:
         action: replace
         regex: 10
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: 11
@@ -4375,7 +4375,7 @@ scrape_configs:
         action: replace
         regex: 11
         target_label: index
-        replacement:
+        replacement: "" 
       - source_labels: [index]
         action: replace
         regex: (.*)
@@ -4385,4 +4385,4 @@ scrape_configs:
         action: replace
         regex: (.*)
         target_label: index
-        replacement:
+        replacement: "" 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -2516,3 +2516,8 @@ scrape_configs:
         regex: 11
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [index]
+        action: replace
+        regex: (.*)
+        target_label: experiment
+        replacement: $1

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -662,3240 +662,3600 @@ scrape_configs:
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.syd01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;1
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.syd01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;2
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;4
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;6
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;1
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;3
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;9
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;8
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.syd01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.syd01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ham01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ham01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;6
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;5
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;1
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;2
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ham01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ham01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lga02.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lga02.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;8
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;5
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;2
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;3
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;1
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;6
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;0
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lga02.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lga02.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ams01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ams01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;4
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;0
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;1
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;10
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;8
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;9
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;5
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;7
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;3
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ams01.measurement-lab.org;6
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ams01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.dfw01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.dfw01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.dfw01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.mia01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.mia01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.mia01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.mia01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.ord01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.ord01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.ord01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.ord01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.sea01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.sea01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.sea01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.sea01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.lax01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.lax01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.lax01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.lax01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab1.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab1.atl01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab2.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab2.atl01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;11
         target_label: experiment
         replacement: unknown-0
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;11
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;9
         target_label: experiment
         replacement: ndt.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;9
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;0
         target_label: experiment
         replacement: npad.iupui
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;0
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;7
         target_label: experiment
         replacement: unknown-3
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;7
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;6
         target_label: experiment
         replacement: diff.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;6
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;3
         target_label: experiment
         replacement: geoloc4.uw
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;3
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;5
         target_label: experiment
         replacement: ooni.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;5
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;10
         target_label: experiment
         replacement: ispmon.samknows
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;10
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;2
         target_label: experiment
         replacement: bismark.gt
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;2
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;8
         target_label: experiment
         replacement: neubot.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;8
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;1
         target_label: experiment
         replacement: 1.michigan
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;1
         target_label: index
+        replacement:
       - source_labels: [machine, index]
         action: replace
         regex: mlab3.atl01.measurement-lab.org;4
         target_label: experiment
         replacement: utility.mlab
       - source_labels: [machine, index]
-        action: drop
+        action: replace
         regex: mlab3.atl01.measurement-lab.org;4
         target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 0
@@ -3903,9 +4263,19 @@ scrape_configs:
         replacement: unknown-0
       - source_labels: [index]
         action: replace
+        regex: 0
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 1
         target_label: experiment
         replacement: ndt.iupui
+      - source_labels: [index]
+        action: replace
+        regex: 1
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 2
@@ -3913,9 +4283,19 @@ scrape_configs:
         replacement: npad.iupui
       - source_labels: [index]
         action: replace
+        regex: 2
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 3
         target_label: experiment
         replacement: unknown-3
+      - source_labels: [index]
+        action: replace
+        regex: 3
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 4
@@ -3923,9 +4303,19 @@ scrape_configs:
         replacement: diff.mlab
       - source_labels: [index]
         action: replace
+        regex: 4
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 5
         target_label: experiment
         replacement: geoloc4.uw
+      - source_labels: [index]
+        action: replace
+        regex: 5
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 6
@@ -3933,9 +4323,19 @@ scrape_configs:
         replacement: ooni.mlab
       - source_labels: [index]
         action: replace
+        regex: 6
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 7
         target_label: experiment
         replacement: ispmon.samknows
+      - source_labels: [index]
+        action: replace
+        regex: 7
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 8
@@ -3943,9 +4343,19 @@ scrape_configs:
         replacement: bismark.gt
       - source_labels: [index]
         action: replace
+        regex: 8
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 9
         target_label: experiment
         replacement: neubot.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 9
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: 10
@@ -3953,15 +4363,26 @@ scrape_configs:
         replacement: 1.michigan
       - source_labels: [index]
         action: replace
+        regex: 10
+        target_label: index
+        replacement:
+      - source_labels: [index]
+        action: replace
         regex: 11
         target_label: experiment
         replacement: utility.mlab
+      - source_labels: [index]
+        action: replace
+        regex: 11
+        target_label: index
+        replacement:
       - source_labels: [index]
         action: replace
         regex: (.*)
         target_label: experiment
         replacement: $1
       - source_labels: [index]
-        action: drop
+        action: replace
         regex: (.*)
         target_label: index
+        replacement:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -292,6 +292,46 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
+    #'lax01': {1: '7,10,0,8,6,3,5,11,2,9,1,4',
+    #          2: '2,10,0,8,7,4,6,11,3,9,1,5',
+    #          3: '11,9,0,7,6,3,5,10,2,8,1,4'},
+    metric_relabel_configs:
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: 1
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: 1
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;9
+        target_label: index
+        replacement: 1
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab1.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: 7
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab2.lax01.measurement-lab.org;11
+        target_label: index
+        replacement: 7
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;10
+        target_label: index
+        replacement: 7
+      - source_labels: [machine, index]
+        action: replace
+        regex: mlab3.lax01.measurement-lab.org;8
+        target_label: index
+        replacement: 9
+
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'


### PR DESCRIPTION
This change adds metric_relabel_config rules to the legacy-targets job so that sidestream metrics convert experiment indexes from the numeric value to human readable values while taking into account the legacy network remapping applied to some machines.

The relabel rules were created using the patch in https://github.com/m-lab/operator/pull/244

The prometheus-federation-config must now be created using `kubectl replace` for the same reason that we use `replace` on the Grafana dashboards -- the size of this file is now large enough to prevent storage backups in the configmap annotation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/278)
<!-- Reviewable:end -->
