### PR TITLE
Add monitoring targets for ndt-cloud VMs

### DIFF
--- a/config/federation/vms/legacy-targets/vms_ndt_cloud.json
+++ b/config/federation/vms/legacy-targets/vms_ndt_cloud.json
@@ -1,0 +1,11 @@
+[
+    {
+        "labels": {
+            "machine": "mlab1.tyo02.measurement-lab.org",
+            "service": "ndt-cloud"
+        },
+        "targets": [
+            "ndt.iupui.mlab1.tyo02.measurement-lab.org:9090"
+        ]
+    }
+]


### PR DESCRIPTION
For now we will use explicit monitoring configs for the TYO & demo VMs.

This PR adds a new legacy-targets vms_ndt_cloud.json file for ndt-cloud targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/280)
<!-- Reviewable:end -->
