### PR TITLE
Add ad-hoc monitoring of demo machines

### DIFF
--- a/config/federation/vms/legacy-targets/vms_ndt_cloud.json
+++ b/config/federation/vms/legacy-targets/vms_ndt_cloud.json
@@ -7,5 +7,23 @@
         "targets": [
             "ndt.iupui.mlab1.tyo02.measurement-lab.org:9090"
         ]
+    },
+    {
+        "labels": {
+            "machine": "mlab3.lga02.measurement-lab.org",
+            "service": "ndt-cloud"
+        },
+        "targets": [
+            "ndt.iupui.mlab3.lga02.measurement-lab.org:9090"
+        ]
+    },
+    {
+        "labels": {
+            "machine": "mlab3.lax02.measurement-lab.org",
+            "service": "ndt-cloud"
+        },
+        "targets": [
+            "ndt.iupui.mlab3.lax02.measurement-lab.org:9090"
+        ]
     }
 ]


### PR DESCRIPTION
Right now we only have ad-hoc monitoring of the ndt-cloud prometheus metrics.

Ultimately, NDT-cloud instances will be auto discovered using prometheus service discovery. However, until we advance the networking to the prometheus instance running on the k8s platform cluster, we will rely on external and static target configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/285)
<!-- Reviewable:end -->
