### PR TITLE
Update demo site to lga03

### DIFF
--- a/config/federation/vms/legacy-targets/vms_ndt_cloud.json
+++ b/config/federation/vms/legacy-targets/vms_ndt_cloud.json
@@ -10,11 +10,11 @@
     },
     {
         "labels": {
-            "machine": "mlab3.lga02.measurement-lab.org",
+            "machine": "mlab3.lga03.measurement-lab.org",
             "service": "ndt-cloud"
         },
         "targets": [
-            "ndt.iupui.mlab3.lga02.measurement-lab.org:9090"
+            "ndt.iupui.mlab3.lga03.measurement-lab.org:9090"
         ]
     },
     {


### PR DESCRIPTION
It turns out that lga02 is not suitable for the demo due to legacy network remap configuration. We've replaced it with mlab3.lga03.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/286)
<!-- Reviewable:end -->
