### PR TITLE
Updates comment for newly renamed repos {script, snmp}-exporter-support

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -324,7 +324,7 @@ ALERT ScriptExporterDownOrMissing
   }
   ANNOTATIONS {
     summary = "The script_exporter service is down on {{ $labels.instance }}.",
-    hints = "The script_exporter service runs in a Docker container on a GCE VM named 'script-exporter' in each M-Lab GCP project. For deployment details and troubleshooting, you can usually figure out the issue by looking through the Travis-CI build logs: https://travis-ci.org/m-lab/prometheus-script-exporter. You can also look for hints in the dashboard for the GCE instance, or by SSHing to the instance itself."
+    hints = "The script_exporter service runs in a Docker container on a GCE VM named 'script-exporter' in each M-Lab GCP project. For deployment details and troubleshooting, you can usually figure out the issue by looking through the Travis-CI build logs: https://travis-ci.org/m-lab/script-exporter-support. You can also look for hints in the dashboard for the GCE instance, or by SSHing to the instance itself."
   }
 
 # Some script_exporter metrics are missing from Prometheus. These should always

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -279,7 +279,7 @@ ALERT SnmpExporterDownOrMissing
   }
   ANNOTATIONS {
     summary = "The snmp_exporter service is down on {{ $labels.instance }}.",
-    hints = "The snmp_exporter service runs in a Docker container on a GCE VM named 'snmp-exporter' in each M-Lab GCP project. Look at the Travis-CI builds/deploys for m-lab/prometheus-snmp-exporter, or SSH to the VM and poke around."
+    hints = "The snmp_exporter service runs in a Docker container on a GCE VM named 'snmp-exporter' in each M-Lab GCP project. Look at the Travis-CI builds/deploys for m-lab/snmp-exporter-support, or SSH to the VM and poke around."
   }
 
 # Some SNMP metrics are missing from Prometheus. These should always be present.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -552,7 +552,7 @@ scrape_configs:
     relabel_configs:
       # The value of the source label named "service" must match the name of a
       # configured script in the script_exporter configuration. See this file:
-      # https://github.com/m-lab/prometheus-script-exporter/blob/master/script_exporter.yml
+      # https://github.com/m-lab/script-exporter-support/blob/master/script_exporter.yml
       - source_labels: [service]
         regex: (.*)
         target_label: __param_name


### PR DESCRIPTION
The repos changed names:

prometheus-snmp-exporter -> snmp-exporter-support
prometheus-script-exporter -> script-exporter-support