### PR TITLE
Optimize queries for ParserDailyVolumeTooLow

### DIFF
--- a/config/federation/grafana/dashboards/Alert_ParserDailyVolumeTooLow.json
+++ b/config/federation/grafana/dashboards/Alert_ParserDailyVolumeTooLow.json
@@ -30,109 +30,6 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by(service) (rate(etl_test_count{service!~\".*batch.*\"}[12h]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{service}}",
-          "refId": "A"
-        },
-        {
-          "expr": "0.20 * quantile by(service) (0.50,\n         sum by(service) (rate(etl_test_count[12h] offset 1d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 3d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 5d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 7d))    \n          )",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "20% of {{service}}",
-          "refId": "B"
-        },
-        {
-          "expr": "sum by(service) (rate(etl_test_count{service!~\".*batch.*\"}[12h])) < (0.20 * quantile by(service) (0.50,\n         sum by(service) (rate(etl_test_count[12h] offset 1d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 3d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 5d))\n            OR\n         sum by(service) (rate(etl_test_count[12h] offset 7d))\n         ) > 1)",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 2,
-          "legendFormat": "LT {{service}}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "ParserDailyVolumeTooLow",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 2,
-          "format": "short",
-          "label": "Tests/sec parsed by different components",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "description": "Compares the current volume of data to 20% of the historical numbers in the past few days.",
-      "fill": 1,
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
         "y": 8
       },
       "id": 2,
@@ -159,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(service) (increase(etl_test_count{service!~\".*batch.*\"}[24h]))",
+          "expr": "candidate_service:etl_test_count:increase24h",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -167,7 +64,7 @@
           "refId": "A"
         },
         {
-          "expr": "0.7 * quantile by(service)(0.50,\n         label_replace(sum by(service) (increase(etl_test_count{service!~\".*batch.*\"}[24h] offset 1d)),\"delay\",\"1d\",\"\",\".*\" ) OR\n         label_replace(sum by(service) (increase(etl_test_count{service!~\".*batch.*\"}[24h] offset 3d)),\"delay\",\"3d\",\"\",\".*\" ) OR\n         label_replace(sum by(service) (increase(etl_test_count{service!~\".*batch.*\"}[24h] offset 5d)),\"delay\",\"5d\",\"\",\".*\" ) OR\n         label_replace(sum by(service) (increase(etl_test_count{service!~\".*batch.*\"}[24h] offset 7d)),\"delay\",\"7d\",\"\",\".*\" ) OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\")\n         )",
+          "expr": "0.7 * quantile by(service)(0.50,\n         label_replace(candidate_service:etl_test_count:increase24h offset 1d)),\"delay\",\"1d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 3d)),\"delay\",\"3d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 5d)),\"delay\",\"5d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 7d)),\"delay\",\"7d\",\"\",\".*\" ) OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\")\n         )",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -534,7 +534,7 @@ ALERT CoreServices_CollectdMlabMissing
 # of conservative constant value avoid false alarms when there is little valid history.
 # On occasion, processing may fall behind a bit.  The "FOR 2h" waits 2h before triggering
 # an actual alert, so the pipeline may fall behind for up to 2 hours without alerting.
-# However, if the pipeline falls several hours behind, and stays behind for more than 
+# However, if the pipeline falls several hours behind, and stays behind for more than
 # 2 hours, the alert will fire.
 #
 # In normal operation, we expect the 50th quantile to split mid-way between the two smallest
@@ -556,12 +556,12 @@ ALERT CoreServices_CollectdMlabMissing
 # For each pipeline service, the quantile computation then aggregates across the 6 vectors in
 # the delay dimension.
 ALERT ParserDailyVolumeTooLow
-  IF sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h]))
+  IF candidate_service:etl_test_count:increase24h
       < (0.7 * quantile by(service)(0.50,
-         label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h] offset 1d)),"delay","1d","",".*" ) OR
-         label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h] offset 3d)),"delay","3d","",".*" ) OR
-         label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h] offset 5d)),"delay","5d","",".*" ) OR
-         label_replace(sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h] offset 7d)),"delay","7d","",".*" ) OR
+         label_replace(candidate_service:etl_test_count:increase24h offset 1d)),"delay","1d","",".*" ) OR
+         label_replace(candidate_service:etl_test_count:increase24h offset 3d)),"delay","3d","",".*" ) OR
+         label_replace(candidate_service:etl_test_count:increase24h offset 5d)),"delay","5d","",".*" ) OR
+         label_replace(candidate_service:etl_test_count:increase24h offset 7d)),"delay","7d","",".*" ) OR
          label_replace(label_replace(vector(0),"delay","c1","",".*" ), "service", "etl-disco-parser",      "", ".*") OR
          label_replace(label_replace(vector(0),"delay","c2","",".*" ), "service", "etl-disco-parser",      "", ".*") OR
          label_replace(label_replace(vector(0),"delay","c1","",".*" ), "service", "etl-ndt-parser",        "", ".*") OR

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -204,3 +204,12 @@ candidate_machine:node_disk_io_time_ratio:gt_50_pct =
 
 candidate_ndt:vdlimit_used_12h_prediction:gt_50gb =
     ndt:vdlimit_used:predict_linear3h_12h > bool 50000000
+
+
+## Parser volume checks.
+#
+# This rule optimizes the alert query used for ParserDailyVolumeTooLow. Rather
+# than calculate multi-day values continuously, this rule will maintain a history
+# of the precalculated value needed by the rule.
+candidate_service:etl_test_count:increase24h =
+    sum by(service) (increase(etl_test_count{service!~".*batch.*", status="ok"}[24h]))


### PR DESCRIPTION
While there are multiple factors contributing to the performance of prometheus server, one factor that we can control is the efficiency of regular queries using recording rules that pre-calculate the majority of the data needed.

This change adds a new recording rule to continuously calculate the candidate_service:etl_test_count:increase24h value used by the ParserDailyVolumeTooLow alert rule.

The expectation is that this change will reduce the load on the prometheus server.

Because the recording rule is new, this means the alert will not be valid for about a week after the rule is deployed. Since everyone is on vacation anyway, I think this a fine time to do so. Until then, we can silence the ParserDailyVolumeTooLow alert.