### PR TITLE
Update self-monitoring dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Prometheus_SelfMonitoring.json
+++ b/config/federation/grafana/dashboards/Prometheus_SelfMonitoring.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:4369",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": false,
@@ -13,10 +12,10 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1530141039384,
+  "iteration": 1534534488961,
   "links": [],
   "panels": [
     {
@@ -40,7 +39,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -122,8 +121,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "id": 3,
@@ -164,6 +163,7 @@
       "targets": [
         {
           "expr": "max(prometheus_local_storage_memory_series)",
+          "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Count",
@@ -185,87 +185,92 @@
       "valueName": "avg"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "rgba(50, 172, 45, 0.97)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(245, 54, 54, 0.9)"
-      ],
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "$datasource",
-      "decimals": null,
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
+      "fill": 1,
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 12,
+        "x": 12,
         "y": 0
       },
-      "id": 5,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
+      "id": 30,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": false,
+        "total": false,
+        "values": true
       },
-      "tableColumn": "",
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
-          "expr": "max(prometheus_local_storage_indexing_queue_length)",
+          "expr": "prometheus_local_storage_indexing_queue_length",
+          "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
-          "step": 1800
+          "step": 240
         }
       ],
-      "thresholds": "500,4000",
-      "title": "Internal Storage Queue Length",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Local Storage Indexing Queue Length",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
         {
-          "op": "=",
-          "text": "Empty",
-          "value": "0"
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
         }
       ],
-      "valueName": "current"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1243,7 +1248,7 @@
         "x": 0,
         "y": 25
       },
-      "id": 15,
+      "id": 29,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -1256,7 +1261,7 @@
         "values": true
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
@@ -1269,45 +1274,22 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(scrape_duration_seconds)",
-          "interval": "60s",
+          "expr": "prometheus_local_storage_indexing_batch_duration_seconds",
+          "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "MAX",
-          "refId": "D",
-          "step": 120
-        },
-        {
-          "expr": "quantile(0.99, scrape_duration_seconds)",
-          "interval": "60s",
-          "intervalFactor": 2,
-          "legendFormat": "99th",
-          "refId": "C",
-          "step": 120
-        },
-        {
-          "expr": "quantile(0.95, scrape_duration_seconds)",
-          "interval": "60s",
-          "intervalFactor": 2,
-          "legendFormat": "95th",
+          "legendFormat": "{{quantile}}",
           "refId": "A",
-          "step": 120
-        },
-        {
-          "expr": "quantile(0.5, scrape_duration_seconds)",
-          "interval": "60s",
-          "intervalFactor": 2,
-          "legendFormat": "50th",
-          "refId": "B",
-          "step": 120
+          "step": 240
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Prometheus Collection Durations",
+      "title": "Storage Indexing Batch Duration",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1320,9 +1302,9 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "s",
           "label": null,
-          "logBase": 10,
+          "logBase": 1,
           "max": null,
           "min": null,
           "show": true
@@ -1354,7 +1336,7 @@
         "x": 8,
         "y": 25
       },
-      "id": 14,
+      "id": 31,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -1380,43 +1362,22 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(up)",
+          "expr": "prometheus_engine_query_duration_seconds{quantile=\"0.9\"}",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "All Targets",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{slice}} - {{quantile}}",
           "refId": "A",
           "step": 240
-        },
-        {
-          "expr": "count(up == 1)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "All Up Targets",
-          "refId": "B",
-          "step": 240
-        },
-        {
-          "expr": "count(up == 1) - count(up{job=\"blackbox-targets\"} == 1) ",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "All - Up",
-          "refId": "C"
-        },
-        {
-          "expr": "count(up{job=\"blackbox-targets\"} == 1) ",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Blackbox Up",
-          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Targets",
+      "title": "Prometheus Engine Query Duration",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1429,11 +1390,11 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -1547,19 +1508,21 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 32
       },
-      "id": 6,
+      "id": 15,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -1575,19 +1538,151 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "prometheus_local_storage_memory_series",
-          "format": "time_series",
-          "interval": "",
+          "expr": "max(scrape_duration_seconds)",
+          "interval": "60s",
           "intervalFactor": 2,
-          "legendFormat": "{{cluster}}",
+          "legendFormat": "MAX",
+          "refId": "D",
+          "step": 120
+        },
+        {
+          "expr": "quantile(0.99, scrape_duration_seconds)",
+          "interval": "60s",
+          "intervalFactor": 2,
+          "legendFormat": "99th",
+          "refId": "C",
+          "step": 120
+        },
+        {
+          "expr": "quantile(0.95, scrape_duration_seconds)",
+          "interval": "60s",
+          "intervalFactor": 2,
+          "legendFormat": "95th",
           "refId": "A",
-          "step": 240
+          "step": 120
+        },
+        {
+          "expr": "quantile(0.5, scrape_duration_seconds)",
+          "interval": "60s",
+          "intervalFactor": 2,
+          "legendFormat": "50th",
+          "refId": "B",
+          "step": 120
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "prometheus_local_storage_memory_series",
+      "title": "Prometheus Collection Durations",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 10,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 32
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count(up)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "All Targets",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "expr": "count(up == 1)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "All Up Targets",
+          "refId": "B",
+          "step": 240
+        },
+        {
+          "expr": "count(up == 1) - count(up{job=\"blackbox-targets\"} == 1) ",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "All - Up",
+          "refId": "C"
+        },
+        {
+          "expr": "count(up{job=\"blackbox-targets\"} == 1) ",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Blackbox Up",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Targets",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1633,8 +1728,8 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 32
       },
       "id": 22,
@@ -1730,8 +1825,8 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 32
       },
       "id": 9,
@@ -2058,5 +2153,5 @@
   "timezone": "utc",
   "title": "Prometheus: Self-monitoring",
   "uid": "sVklmeHik",
-  "version": 12
+  "version": 9
 }


### PR DESCRIPTION
This adds new panels to display metrics for:

prometheus_engine_query_duration_seconds
prometheus_local_storage_indexing_queue_length
prometheus_local_storage_indexing_batch_duration_seconds

And removes the panel for prometheus_local_storage_memory_series

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/296)
<!-- Reviewable:end -->
