### PR TITLE
Increase delay before firing alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -303,7 +303,7 @@ ALERT SnmpExporterMissingMetrics
 # Scraping SNMP metrics from a switch is failing.
 ALERT SnmpScrapingDownAtSite
   IF up{job="snmp-targets", site!~".*t$"} == 0
-  FOR 30m
+  FOR 60m
   LABELS {
     severity = "page",
     repo = "ops-tracker"


### PR DESCRIPTION
This change increases the timeout for the SnmpScrapingDownAtSite alert. It produces too many false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/298)
<!-- Reviewable:end -->
