### PR TITLE
Add bq_ndt_annotation query and alert

### DIFF
--- a/config/federation/bigquery/bq_ndt_annotation.sql
+++ b/config/federation/bigquery/bq_ndt_annotation.sql
@@ -1,0 +1,31 @@
+SELECT
+  SAFE_DIVIDE(COUNTIF(latitude IS NULL OR longitude IS NULL),  COUNT(*)) AS value_percent,
+  COUNT(*) AS value_tests
+FROM (
+SELECT
+    connection_spec.client_geolocation.latitude as latitude,
+    connection_spec.client_geolocation.longitude as longitude
+FROM
+    `measurement-lab.base_tables.ndt`
+
+WHERE
+  -- For faster queries we use _PARTITIONTIME boundaries. And, to
+  -- guarantee the _PARTITIONTIME data is "complete" (all data collected
+  -- and parsed) we should wait 36 hours after start of a given day.
+  -- The following is equivalent to the pseudo code: date(now() - 12h) - 1d
+  _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
+
+GROUP BY
+  log_time,
+  web100_log_entry.connection_spec.remote_ip,
+  web100_log_entry.connection_spec.local_ip,
+  web100_log_entry.connection_spec.remote_port,
+  connection_spec.client_geolocation.latitude,
+  connection_spec.client_geolocation.longitude,
+  web100_log_entry.connection_spec.local_port
+)
+HAVING
+  -- When the test count is zero the safe_divide returns NULL.
+  -- Excluding NULL values from the output will result in the
+  -- metric disappearing from prometheus.
+  value_percent is not NULL

--- a/config/federation/bigquery/bq_ndt_annotation.sql
+++ b/config/federation/bigquery/bq_ndt_annotation.sql
@@ -1,5 +1,5 @@
 SELECT
-  SAFE_DIVIDE(COUNTIF(latitude IS NULL OR longitude IS NULL),  COUNT(*)) AS value_percent,
+  SAFE_DIVIDE(COUNTIF(latitude IS NULL OR longitude IS NULL),  COUNT(*)) AS value_ratio,
   COUNT(*) AS value_tests
 FROM (
 SELECT
@@ -28,4 +28,4 @@ HAVING
   -- When the test count is zero the safe_divide returns NULL.
   -- Excluding NULL values from the output will result in the
   -- metric disappearing from prometheus.
-  value_percent is not NULL
+  value_ratio is not NULL

--- a/config/federation/bigquery/bq_ndt_annotation.sql
+++ b/config/federation/bigquery/bq_ndt_annotation.sql
@@ -1,19 +1,14 @@
 #standardSQL
--- bq_ndt_annotation calculates the ratio of successfully annotated NDT tests
+-- bq_ndt_annotation calculates the number of successfully annotated NDT tests
 -- per day.
 --
 -- This query exports two values:
---   bq_ndt_annotation_ratio -- ratio of successfully annotated NDT tests.
---   bq_ndt_annotation_tests -- number of tests used to calculate ratio.
+--   bq_ndt_annotation_success -- number of successfully annotated NDT tests.
+--   bq_ndt_annotation_total -- total number of tests checked for annotations.
 
 SELECT
-  CASE COUNT(*)
-    -- When the test count is zero the safe_divide returns NULL.
-    -- Since bq_ndt_annotation_ratio is a success metric, zero is appropriate.
-    WHEN = 0 THEN 0
-    ELSE SAFE_DIVIDE(COUNTIF(latitude IS NOT NULL AND longitude IS NOT NULL), COUNT(*))
-  END as value_ratio,
-  COUNT(*) AS value_tests
+  COUNTIF(latitude IS NOT NULL AND longitude IS NOT NULL) AS value_success,
+  COUNT(*) AS value_total
 
 FROM (
   SELECT

--- a/config/federation/bigquery/bq_ndt_annotation.sql
+++ b/config/federation/bigquery/bq_ndt_annotation.sql
@@ -1,31 +1,41 @@
+#standardSQL
+-- bq_ndt_annotation calculates the ratio of successfully annotated NDT tests
+-- per day.
+--
+-- This query exports two values:
+--   bq_ndt_annotation_ratio -- ratio of successfully annotated NDT tests.
+--   bq_ndt_annotation_tests -- number of tests used to calculate ratio.
+
 SELECT
-  SAFE_DIVIDE(COUNTIF(latitude IS NULL OR longitude IS NULL),  COUNT(*)) AS value_ratio,
+  CASE COUNT(*)
+    -- When the test count is zero the safe_divide returns NULL.
+    -- Since bq_ndt_annotation_ratio is a success metric, zero is appropriate.
+    WHEN = 0 THEN 0
+    ELSE SAFE_DIVIDE(COUNTIF(latitude IS NOT NULL AND longitude IS NOT NULL), COUNT(*))
+  END as value_ratio,
   COUNT(*) AS value_tests
+
 FROM (
-SELECT
+  SELECT
     connection_spec.client_geolocation.latitude as latitude,
     connection_spec.client_geolocation.longitude as longitude
-FROM
+
+  FROM
     `measurement-lab.base_tables.ndt`
 
-WHERE
-  -- For faster queries we use _PARTITIONTIME boundaries. And, to
-  -- guarantee the _PARTITIONTIME data is "complete" (all data collected
-  -- and parsed) we should wait 36 hours after start of a given day.
-  -- The following is equivalent to the pseudo code: date(now() - 12h) - 1d
-  _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
+  WHERE
+    -- For faster queries we use _PARTITIONTIME boundaries. And, to
+    -- guarantee the _PARTITIONTIME data is "complete" (all data collected
+    -- and parsed) we should wait 36 hours after start of a given day.
+    -- The following is equivalent to the pseudo code: date(now() - 12h) - 1d
+    _PARTITIONTIME = TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR), DAY), INTERVAL 24 HOUR)
 
-GROUP BY
-  log_time,
-  web100_log_entry.connection_spec.remote_ip,
-  web100_log_entry.connection_spec.local_ip,
-  web100_log_entry.connection_spec.remote_port,
-  connection_spec.client_geolocation.latitude,
-  connection_spec.client_geolocation.longitude,
-  web100_log_entry.connection_spec.local_port
+  GROUP BY
+    log_time,
+    web100_log_entry.connection_spec.remote_ip,
+    web100_log_entry.connection_spec.local_ip,
+    web100_log_entry.connection_spec.remote_port,
+    connection_spec.client_geolocation.latitude,
+    connection_spec.client_geolocation.longitude,
+    web100_log_entry.connection_spec.local_port
 )
-HAVING
-  -- When the test count is zero the safe_divide returns NULL.
-  -- Excluding NULL values from the output will result in the
-  -- metric disappearing from prometheus.
-  value_ratio is not NULL

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -670,3 +670,18 @@ ALERT ETL_AnnotationDownOrMissing
     summary = "An ETL Annotation Server is offline or missing!",
     hints = "The annotator runs in AppEngine. Check logs and recent deployments. The daily and batch parsers may also be affected."
   }
+
+# NDT_AnnotationRatioTooLow fires when the client annotations on NDT
+# tests appears to have too many failures or the bq_ndt_annotation_ratio metric
+# disappears.
+ALERT NDT_AnnotationRatioTooLow
+  IF bq_ndt_annotation_ratio < 0.99 OR absent(bq_ndt_annotation_ratio)
+  FOR 30m
+  LABELS {
+    severity = "ticket",
+    repo = "dev-tracker"
+  }
+  ANNOTATIONS {
+    summary = "Too many NDT tests are missing annotations!",
+    hints = "The annotator runs in AppEngine. Check logs and recent deployments. The daily and batch parsers may also be affected."
+  }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -672,10 +672,10 @@ ALERT ETL_AnnotationDownOrMissing
   }
 
 # NDT_AnnotationRatioTooLow fires when the client annotations on NDT
-# tests appears to have too many failures or the bq_ndt_annotation_ratio metric
-# disappears.
+# tests appears to have too many failures or the bq_ndt_annotation_* metrics
+# disappear.
 ALERT NDT_AnnotationRatioTooLow
-  IF bq_ndt_annotation_ratio < 0.99 OR absent(bq_ndt_annotation_ratio)
+  IF bq_ndt_annotation_success / bq_ndt_annotation_total < 0.99 OR absent(bq_ndt_annotation_success / bq_ndt_annotation_total)
   FOR 30m
   LABELS {
     severity = "ticket",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -20,6 +20,7 @@ spec:
         args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
                 "--type=gauge", "--query=/queries/bq_ipv6_bias.sql",
+                "--type=gauge", "--query=/queries/bq_ndt_annotation.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_worldmap_server.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_geohash_client.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_server.sql" ]


### PR DESCRIPTION
This change adds a new BQ exporter query to measure the percentage of NDT tests successfully  annotated with latitude and longitude.

The typical value for this is around 0.9994. The alert fires when the value is less than 0.99.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/303)
<!-- Reviewable:end -->
