### PR TITLE
Sandbox prometheus 2.x dataprocessing upgrade

### DIFF
--- a/k8s/data-processing-cluster/deployments/prometheus.yml
+++ b/k8s/data-processing-cluster/deployments/prometheus.yml
@@ -47,18 +47,13 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.
-      - image: prom/prometheus:v1.8.2
+      - image: prom/prometheus:v2.3.2
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: prometheus
         # Use 10x the default values for all index cache flags:
-        args: ["-config.file=/etc/prometheus/prometheus.yml",
-               "-storage.local.path=/prometheus",
-               "-storage.local.index-cache-size.fingerprint-to-metric=104857600",
-               "-storage.local.index-cache-size.fingerprint-to-timerange=52428800",
-               "-storage.local.index-cache-size.label-name-to-label-values=104857600",
-               "-storage.local.index-cache-size.label-pair-to-fingerprints=20971520"]
+        args: ["-config.file=/etc/prometheus/prometheus.yml"]
         ports:
           - containerPort: 9090
         resources:
@@ -70,9 +65,9 @@ spec:
             cpu: "1500m"
         volumeMounts:
         # /prometheus stores all metric data. Declared as VOLUME in base image.
-        - mountPath: /prometheus
+        - mountPath: /data
           name: prometheus-storage
-          subPath: prometheus-data
+          subPath: prometheus-data2
         # /legacy-targets should contain legacy target configuration files.
         - mountPath: /legacy-targets
           name: prometheus-storage

--- a/k8s/data-processing-cluster/deployments/prometheus.yml
+++ b/k8s/data-processing-cluster/deployments/prometheus.yml
@@ -53,7 +53,7 @@ spec:
         # value results in a configuration error.
         name: prometheus
         # Use 10x the default values for all index cache flags:
-        args: ["-config.file=/etc/prometheus/prometheus.yml"]
+        args: ["--config.file=/etc/prometheus/prometheus.yml"]
         ports:
           - containerPort: 9090
         resources:


### PR DESCRIPTION
This pull request updates the Prometheus instance on the dataprocessing cluster from v1.8.2 to v2.3.2. It also revises the command-line arguments to Prometheus to bring them in line with changes to the new version (including the removal of most storage-related options) and mounts a new directory in the prometheus-storage volume to the new default location for the time-series database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/304)
<!-- Reviewable:end -->
