### PR TITLE
Adds a new SwitchDownAtSite alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -134,6 +134,28 @@ ALERT ScraperCollectorMissingFromScraperSync
     description = "",
   }
 
+
+# SwitchSLO
+#
+# A switch at a site has been down for too long and we need to contact the site
+# host or transit provider to investigate. If SNMP scraping *and* pings are both
+# failing for a certain period, then this is probaby a reasonable stand-in as an
+# "up"/"aliveness" check.
+ALERT SwitchDownAtSite
+  IF up{job="snmp-targets", site!~".*t$"} == 0
+        AND ON(site) probe_success{instance=~"s1.*", module="icmp"} == 0
+  FOR 24h
+  LABELS {
+    severity = "ticket",
+    repo = "ops-tracker"
+  }
+  ANNOTATIONS {
+    summary = "The switch at a site has been unreachable for too long.",
+    hints = "The issue could be with the switch itself, or with the transit provider.",
+    dashboard = "https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{ $labels.site }}"
+  }
+
+
 ##
 ## Inventory.
 ##
@@ -303,7 +325,8 @@ ALERT SnmpExporterMissingMetrics
 # Scraping SNMP metrics from a switch is failing.
 ALERT SnmpScrapingDownAtSite
   IF up{job="snmp-targets", site!~".*t$"} == 0
-  FOR 2h
+        AND ON(site) probe_success{instance=~"s1.*", module="icmp"} == 1
+  FOR 6h
   LABELS {
     severity = "page",
     repo = "ops-tracker"


### PR DESCRIPTION
Also modifies `SnmpScrapingDownAtSite` to only fire when the switch is pingable, and only when the condition exists for 6+ hours.

Currently, we get way too many `SnmpScrapingDownAtSite` alerts for transient issues that resolve themselves in the course of an hour or two. With these changes, if a switch isn't pingable (and likely down) then there is no need to fire an alert about not being able to scrape SNMP metrics. Likewise, if both SNMP scraping is down and the switch isn't pingable for 24h, then we likely need to intervene with the site host or the transit provider. 