### PR TITLE
Adds a new deployment, service and ingress for GMX.

### DIFF
--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -23,7 +23,7 @@ spec:
         run: gmx-server
     spec:
       containers:
-        - image: measurementlab/github-maintenance-exporter:v0.1
+      - image: measurementlab/github-maintenance-exporter:v0.1
         name: gmx-server
         env:
         - name: GITHUB_WEBHOOK_SECRET
@@ -32,7 +32,7 @@ spec:
               name: gmx-webhook-secret
               key: gmx-webhook-secret
         ports:
-          - containerPort: 9999
+        - containerPort: 9999
         resources:
           requests:
             memory: "500Mi"

--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -31,6 +31,7 @@ spec:
             secretKeyRef:
               name: gmx-webhook-secret
               key: gmx-webhook-secret
+        imagePullPolicy: Always
         ports:
         - containerPort: 9999
         resources:

--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gmx-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      # Used to match pre-existing pods that may be affected during updates.
+      run: gmx-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  # Pod template.
+  template:
+    metadata:
+      labels:
+        # Note: run=gmx-server should match a service config with a
+        # public IP and port so that it is publically accessible.
+        run: gmx-server
+    spec:
+      containers:
+        - image: measurementlab/github-maintenance-exporter:v0.1
+        name: gmx-server
+        env:
+        - name: GITHUB_WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: gmx-webhook-secret
+              key: gmx-webhook-secret
+        ports:
+          - containerPort: 9999
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "200m"
+        volumeMounts:
+        - mountPath: /var/lib/gmx
+          name: gmx-storage
+      # Disks created manually, can be named here explicitly using
+      # gcePersistentDisk instead of the persistentVolumeClaim.
+      volumes:
+      - name: gmx-storage
+        persistentVolumeClaim:
+          claimName: auto-gmx-disk0

--- a/k8s/prometheus-federation/persistentvolumes/persistent-volumes.yml
+++ b/k8s/prometheus-federation/persistentvolumes/persistent-volumes.yml
@@ -36,3 +36,16 @@ spec:
   resources:
     requests:
       storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: auto-gmx-disk0
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "slow"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/prometheus-federation/services/gmx-tls-service.yml
+++ b/k8s/prometheus-federation/services/gmx-tls-service.yml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  name: gmx-tls-service
+  namespace: default
+spec:
+  ports:
+  - port: 9999
+    protocol: TCP
+    targetPort: 9999
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: gmx-server
+  sessionAffinity: None
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gmx-tls
+  namespace: default
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - gmx.{{GCLOUD_PROJECT}}.measurementlab.net
+    secretName: gmx-tls
+  rules:
+  - host: gmx.{{GCLOUD_PROJECT}}.measurementlab.net
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: gmx-tls-service
+          servicePort: 9999
+


### PR DESCRIPTION
This PR adds a new deployment for the [GitHub Maintenance Exporter](https://github.com/m-lab/github-maintenance-exporter). It also adds a corresponding service and ingress such that GitHub webhooks use our nginx load balancer and TLS.