### PR TITLE
Adds a gmx_machine_state{}==1 condition to a number of alerts.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -51,8 +51,7 @@ ALERT CoreServices_SidestreamIsNotRunning
   IF sum_over_time(up{service="sidestream"}[10m]) == 0
         AND ON(machine)
      sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
-        UNLESS ON(machine) lame_duck_node == 1 OR
-               ON(machine) gmx_machine_state{} == 1
+        UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
   FOR 10m
   LABELS {
     severity = "page",
@@ -85,8 +84,7 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (56 * 60 * 60)
         AND ON(machine)
      (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
-        UNLESS ON(machine) lame_duck_node == 1 OR
-               ON(machine) gmx_machine_state{} == 1
+        UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
   FOR 2h
   LABELS {
     severity = "page",
@@ -144,7 +142,7 @@ ALERT ScraperCollectorMissingFromScraperSync
 ALERT SwitchDownAtSite
   IF up{job="snmp-targets", site!~".*t$"} == 0
     AND ON(site) probe_success{instance=~"s1.*", module="icmp"} == 0
-      UNLESS ON(site) gmx_site_state{} == 1
+      UNLESS ON(site) gmx_site_maintenance == 1
   FOR 24h
   LABELS {
     severity = "ticket",
@@ -406,8 +404,7 @@ ALERT TooManyNdtServersDown
   IF count_scalar(
     probe_success{service="ndt_raw"} AND ON(machine)
       up{service="nodeexporter"} == 1
-        UNLESS ON(machine) lame_duck_node{} == 1 OR
-               ON(machine) gmx_machine_state{} == 1
+        UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
     UNLESS ON(machine) (
       probe_success{service="ndt_raw"} == 1 AND ON(machine)
       probe_success{service="ndt_ssl"} == 1 AND ON(machine)
@@ -420,8 +417,7 @@ ALERT TooManyNdtServersDown
   count(
     probe_success{service="ndt_raw"} AND ON(machine)
     up{service="nodeexporter"} == 1
-      UNLESS ON(machine) lame_duck_node{} == 1 OR
-             ON(machine) gmx_machine_state{} == 1
+      UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
   ) > 0.25
   FOR 30m
   LABELS {
@@ -495,8 +491,7 @@ ALERT MobiperfMetricsMissing
 # Some number of nodes don't have a lame-duck status.
 ALERT LameDuckMetricMissingForNode
   IF up{service="nodeexporter"} == 1
-        UNLESS ON(machine) lame_duck_node{} OR
-               ON(machine) gmx_machine_state{} == 1
+        UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
   FOR 30m
   LABELS {
     severity = "ticket",
@@ -527,7 +522,7 @@ ALERT VdlimitMetricsMissingForNode
 # A collectd-mlab service has a problem and is down.
 ALERT CoreServices_CollectdMlabDown
   IF collectd_mlab_success{} == 0
-    UNLESS ON(machine) gmx_machine_state{} == 1
+    UNLESS ON(machine) gmx_machine_maintenance == 1
   FOR 10m
   LABELS {
     severity = "ticket",

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -51,8 +51,8 @@ ALERT CoreServices_SidestreamIsNotRunning
   IF sum_over_time(up{service="sidestream"}[10m]) == 0
         AND ON(machine)
      sum_over_time(probe_success{service="ssh806"}[20m]) / 20 >= 0.90
-        UNLESS ON(machine)
-     lame_duck_node == 1
+        UNLESS ON(machine) lame_duck_node == 1 OR
+               ON(machine) gmx_machine_state{} == 1
   FOR 10m
   LABELS {
     severity = "page",
@@ -85,8 +85,8 @@ ALERT ScraperMostRecentArchivedFileTimeIsTooOld
   IF (time() - (scraper_maxrawfiletimearchived{container="scraper-sync"} != 0)) > (56 * 60 * 60)
         AND ON(machine)
      (time() - process_start_time_seconds{service="sidestream"}) > (30 * 60 * 60)
-        UNLESS ON(machine)
-     lame_duck_node == 1
+        UNLESS ON(machine) lame_duck_node == 1 OR
+               ON(machine) gmx_machine_state{} == 1
   FOR 2h
   LABELS {
     severity = "page",
@@ -404,8 +404,9 @@ ALERT BlackboxExporterIpv6DownOrMissing
 ALERT TooManyNdtServersDown
   IF count_scalar(
     probe_success{service="ndt_raw"} AND ON(machine)
-      up{service="nodeexporter"} == 1 UNLESS ON(machine)
-      lame_duck_node{} == 1
+      up{service="nodeexporter"} == 1
+        UNLESS ON(machine) lame_duck_node{} == 1 OR
+               ON(machine) gmx_machine_state{} == 1
     UNLESS ON(machine) (
       probe_success{service="ndt_raw"} == 1 AND ON(machine)
       probe_success{service="ndt_ssl"} == 1 AND ON(machine)
@@ -417,8 +418,9 @@ ALERT TooManyNdtServersDown
   /
   count(
     probe_success{service="ndt_raw"} AND ON(machine)
-    up{service="nodeexporter"} == 1 UNLESS ON(machine)
-    lame_duck_node{} == 1
+    up{service="nodeexporter"} == 1
+      UNLESS ON(machine) lame_duck_node{} == 1 OR
+             ON(machine) gmx_machine_state{} == 1
   ) > 0.25
   FOR 30m
   LABELS {
@@ -492,7 +494,8 @@ ALERT MobiperfMetricsMissing
 # Some number of nodes don't have a lame-duck status.
 ALERT LameDuckMetricMissingForNode
   IF up{service="nodeexporter"} == 1
-        UNLESS ON(machine) lame_duck_node{}
+        UNLESS ON(machine) lame_duck_node{} OR
+               ON(machine) gmx_machine_state{} == 1
   FOR 30m
   LABELS {
     severity = "ticket",

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -143,7 +143,8 @@ ALERT ScraperCollectorMissingFromScraperSync
 # "up"/"aliveness" check.
 ALERT SwitchDownAtSite
   IF up{job="snmp-targets", site!~".*t$"} == 0
-        AND ON(site) probe_success{instance=~"s1.*", module="icmp"} == 0
+    AND ON(site) probe_success{instance=~"s1.*", module="icmp"} == 0
+      UNLESS ON(site) gmx_site_state{} == 1
   FOR 24h
   LABELS {
     severity = "ticket",
@@ -526,6 +527,7 @@ ALERT VdlimitMetricsMissingForNode
 # A collectd-mlab service has a problem and is down.
 ALERT CoreServices_CollectdMlabDown
   IF collectd_mlab_success{} == 0
+    UNLESS ON(machine) gmx_machine_state{} == 1
   FOR 10m
   LABELS {
     severity = "ticket",


### PR DESCRIPTION
Now that the GMX is working, this PR adds machine and site state metrics as conditions to a number of alerts. Specifically, the condition was added to any alert that already had a `lame_duck_node` condition. It was also added to two other alerts where it would be useful: `SwitchDownAtSite` and `CoreServices_CollectdMlabDown`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/307)
<!-- Reviewable:end -->
