### PR TITLE
Removes gmx_machine_maintenance condition from LameDuckMetricMissingForNode alert.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -491,7 +491,7 @@ ALERT MobiperfMetricsMissing
 # Some number of nodes don't have a lame-duck status.
 ALERT LameDuckMetricMissingForNode
   IF up{service="nodeexporter"} == 1
-        UNLESS ON(machine) (lame_duck_node == 1 OR gmx_machine_maintenance == 1)
+        UNLESS ON(machine) lame_duck_node
   FOR 30m
   LABELS {
     severity = "ticket",


### PR DESCRIPTION
It doesn't really belong there. And the change I made in a previous PR setting the condition to `lame_duck_node == 1` was wrong too, since the purpose was to return not just ones where it was 1, but all instances where it was set at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/311)
<!-- Reviewable:end -->
