### PR TITLE
Moves all resources into the default namespace in the prometheus-federation cluster.

### DIFF
--- a/k8s/prometheus-federation/deployments/kube-lego.yml
+++ b/k8s/prometheus-federation/deployments/kube-lego.yml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-lego
-  namespace: kube-lego
+  namespace: default
 spec:
   replicas: 1
   template:

--- a/k8s/prometheus-federation/deployments/nginx.yml
+++ b/k8s/prometheus-federation/deployments/nginx.yml
@@ -28,21 +28,17 @@ spec:
       serviceAccountName: nginx-ingress
       containers:
         - name: nginx
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.12.0
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0
           args:
             - /nginx-ingress-controller
-            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-            - --configmap=$(POD_NAMESPACE)/nginx
-            - --publish-service=$(POD_NAMESPACE)/nginx-lb
+            - --default-backend-service=default-http-backend
+            - --configmap=nginx
+            - --publish-service=nginx-lb
           env:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           ports:
           - name: http
             containerPort: 80

--- a/k8s/prometheus-federation/deployments/nginx.yml
+++ b/k8s/prometheus-federation/deployments/nginx.yml
@@ -31,14 +31,18 @@ spec:
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0
           args:
             - /nginx-ingress-controller
-            - --default-backend-service=default-http-backend
-            - --configmap=nginx
-            - --publish-service=nginx-lb
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/nginx
+            - --publish-service=$(POD_NAMESPACE)/nginx-lb
           env:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
           - name: http
             containerPort: 80

--- a/k8s/prometheus-federation/deployments/nginx.yml
+++ b/k8s/prometheus-federation/deployments/nginx.yml
@@ -10,14 +10,14 @@ data:
   server-name-hash-bucket-size: "256"
 kind: ConfigMap
 metadata:
-  namespace: nginx-ingress
+  namespace: default
   name: nginx
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx
-  namespace: nginx-ingress
+  namespace: default
 spec:
   replicas: 1
   template:
@@ -67,7 +67,7 @@ metadata:
   name: default-http-backend
   labels:
     app: default-http-backend
-  namespace: nginx-ingress
+  namespace: default
 spec:
   replicas: 1
   template:

--- a/k8s/prometheus-federation/roles/rbac-external-dns.yml
+++ b/k8s/prometheus-federation/roles/rbac-external-dns.yml
@@ -1,9 +1,3 @@
-# Create a namespace for external-dns and its attendant services.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: external-dns
----
 # A ClusterRole allowing external-dns to watch for new services and ingresses
 # with domains to add to the zone.
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -33,7 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: external-dns
-  namespace: external-dns
+  namespace: default
 ---
 # Binding the external-dns ClusterRole to the ServiceAccount above.
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -47,4 +41,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
-  namespace: external-dns
+  namespace: default

--- a/k8s/prometheus-federation/roles/rbac-kube-lego.yml
+++ b/k8s/prometheus-federation/roles/rbac-kube-lego.yml
@@ -1,9 +1,3 @@
-# Create a namespace for kube-lego and its attendant services.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kube-lego
----
 # ClusterRole for kube-lego, which watches for properly annotated services and 
 # automatically generates TLS certificates for them via LetsEncrypt, then 
 # configures an ingress for them with those certificates.
@@ -55,7 +49,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-lego
-  namespace: kube-lego
+  namespace: default
 ---
 # Bind the kube-lego ServiceAccount to the ClusterRole above.
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -69,4 +63,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kube-lego
-    namespace: kube-lego
+    namespace: default

--- a/k8s/prometheus-federation/roles/rbac-nginx.yml
+++ b/k8s/prometheus-federation/roles/rbac-nginx.yml
@@ -1,15 +1,9 @@
-# Create a namespace for nginx-ingress and its attendant services.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: nginx-ingress
----
 # A ServiceAccount under which nginx-ingress runs.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nginx-ingress
-  namespace: nginx-ingress
+  namespace: default
 ---
 # ClusterRole for nginx-ingress, which creates an instance of nginx which acts 
 # as an Ingress that forwards different vhosts and paths to different Service 
@@ -73,7 +67,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: nginx-ingress-role
-  namespace: nginx-ingress
+  namespace: default
 rules:
 - apiGroups:
   - ""
@@ -115,7 +109,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
-  namespace: nginx-ingress
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -123,7 +117,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nginx-ingress
-  namespace: nginx-ingress
+  namespace: default
 ---
 # Bind the nginx-ingress ServiceAccount to the ClusterRole above.
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -137,4 +131,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nginx-ingress
-  namespace: nginx-ingress
+  namespace: default

--- a/k8s/prometheus-federation/services/nginx.yml
+++ b/k8s/prometheus-federation/services/nginx.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: default-http-backend
-  namespace: nginx-ingress
+  namespace: default
 spec:
   ports:
   - port: 80
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-lb
-  namespace: nginx-ingress
+  namespace: default
   labels:
     app: nginx-lb
 spec:


### PR DESCRIPTION
The prometheus-federation cluster doesn't currently have enough resources to make it worth fragmenting the namespace, and having it fragmented at this point makes working with it a bit more tedious.

The impetus behind making this change is that the external-dns deployment is in the default namespace while the rbac role for it is in the external-dns namespace, causing the deployment to fail because of a permission issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/312)
<!-- Reviewable:end -->
