### PR TITLE
Rollback nginx-ingress-controller to v0.17.1.

### DIFF
--- a/k8s/prometheus-federation/deployments/nginx.yml
+++ b/k8s/prometheus-federation/deployments/nginx.yml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: nginx-ingress
       containers:
         - name: nginx
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.17.1
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend


### PR DESCRIPTION
This should alleviate permissions issues with the basic-auth password files due to changes in the upstream nginx-ingress container.