### PR TITLE
Update deployment relabel rule to distinguish DaemonSet & ReplicaSet

### DIFF
--- a/config/cluster/prometheus/prometheus.yml
+++ b/config/cluster/prometheus/prometheus.yml
@@ -179,27 +179,25 @@ scrape_configs:
         replacement: $1
         target_label: cluster
 
-      # Identify the deployment name of a pod or daemon set. This requires two
-      # steps. Two steps are necessary to handle both daemon set pod names and
-      # deployment pod names correctly. And, because, evidently, a combined
-      # regex doesn't work as expected.
+      # Identify the deployment name for replica set or daemon set.  Pods
+      # created by deployments or daemon sets are processed here. The
+      # following two rules recognize these two cases.
       #
-      # Step 1: unconditionally remove the last field of a pod or daemonset.
-      #   e.g. prometheus-server-3165440997-ppf9w
+      # 1: For DaemonSet, remove the last 5-digit pod name hash.
       #   e.g. node-exporter-ltxgz
-      - source_labels: [__meta_kubernetes_pod_name]
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)(-[^-]{5})
+        regex: DaemonSet;(.*)(-[^-]{5})
         replacement: $1
         target_label: deployment
 
-      # Step 2: Remove the trailing pod_template_hash if present.
+      # 2: For ReplicaSet, remove the last 10-digit + 5-digit pod name hash.
       # In the case of a daemon set that does not have the trailing hash, the
       # regex will not match and deployment remains unchanged.
-      #   e.g. prometheus-server-3165440997
-      - source_labels: [deployment]
+      #   e.g. prometheus-server-3165440997-ppf9w
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)(-[0-9]+)
+        regex: ReplicaSet;(.*)(-[^-]+)(-[^-]{5})
         replacement: $1
         target_label: deployment
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -195,27 +195,25 @@ scrape_configs:
         replacement: $1
         target_label: cluster
 
-      # Identify the deployment name of a pod or daemon set. This requires two
-      # steps. Two steps are necessary to handle both daemon set pod names and
-      # deployment pod names correctly. And, because, evidently, a combined
-      # regex doesn't work as expected.
+      # Identify the deployment name for replica set or daemon set.  Pods
+      # created by deployments or daemon sets are processed here. The
+      # following two rules recognize these two cases.
       #
-      # Step 1: unconditionally remove the last field of a pod or daemonset.
-      #   e.g. prometheus-server-3165440997-ppf9w
+      # 1: For DaemonSet, remove the last 5-digit pod name hash.
       #   e.g. node-exporter-ltxgz
-      - source_labels: [__meta_kubernetes_pod_name]
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)(-[^-]{5})
+        regex: DaemonSet;(.*)(-[^-]{5})
         replacement: $1
         target_label: deployment
 
-      # Step 2: Remove the trailing pod_template_hash if present.
+      # 2: For ReplicaSet, remove the last 10-digit + 5-digit pod name hash.
       # In the case of a daemon set that does not have the trailing hash, the
       # regex will not match and deployment remains unchanged.
-      #   e.g. prometheus-server-3165fc0997
-      - source_labels: [deployment]
+      #   e.g. prometheus-server-3165440997-ppf9w
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
         action: replace
-        regex: (.*)(-[0-9a-f]+)
+        regex: ReplicaSet;(.*)(-[^-]+)(-[^-]{5})
         replacement: $1
         target_label: deployment
 


### PR DESCRIPTION
With the 1.x series, prometheus provided no hints about whether the pod was part of a DaemonSet or ReplicaSet. The 2.x series does.

This change uses this feature to provide more reliable relabel rules for extracting the deployment name for all pods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/320)
<!-- Reviewable:end -->
