### PR TITLE
Add static config for sending alerts from Prometheus to Alertmanager.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -17,6 +17,18 @@ rule_files:
   - /etc/prometheus/rules.yml
   - /etc/prometheus/alerts.yml
 
+# Alerting configurations.
+#
+# Prometheus v2.0 and above support autodiscovery of alertmanager instances,
+# but we're statically configuring it here to be on the safe side. We could
+# add a more complex autodiscovery configuration here in the future if
+# needed.
+alerting:
+  alertmanagers:
+    - static_configs:
+      - targets:
+        - alertmanager-service.default.svc.cluster.local:9093
+
 # Scrape configurations.
 #
 # Each job name defines monitoring targets (or a method for discovering


### PR DESCRIPTION
Yeah, looks like the auto-discovery won't just work on its own. I added a parameter to send the alerts to the internal cluster address of the alertmanager instance, an approach which seems to work just fine on sandbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/322)
<!-- Reviewable:end -->
