### PR TITLE
Adds a new BBE probe, and alert, for the k8s nginx ingress load balancer

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -61,7 +61,6 @@ export AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
-    -e 's|{{HTTP_AUTH}}|'${AUTH}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -61,6 +61,7 @@ export AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
+    -e 's|{{HTTP_AUTH}}|'${AUTH}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -502,6 +502,16 @@ groups:
         repository to configure collectd-mlab. Login to the node and run the check
         script manually to see what the specific error is (/usr/lib/nagios/plugins/check_collectd_mlab.py).
       summary: A collectd-mlab service metric is missing.
+# The nginx ingress load balancer is down.
+  - alert: NginxLoadBalancerDown
+    expr: up{service="nodeexporter"} == 0
+    for: 30m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      hints: Did the nginx k8s deployment or nginx-lb k8s service fail?
+      summary: The nginx ingress load balancer is down.
 # TODO:
 #   Replace this with two other alerts:
 #    1.  Alert if hourly test volume on servers drops relative to same hour on recent days.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -459,10 +459,10 @@ scrape_configs:
   # Probes the services running behind the nginx load balancer. This makes sure
   # that the services are running, as well as the load balancer itself.
   - job_name: 'nginx-loadbalancer-services'
-    metrics-path: /probe
+    metrics_path: /probe
     params:
       module: [http_2xx]
-    static-configs:
+    static_configs:
       targets:
         - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -456,6 +456,31 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
+  # Probes the services running behind the nginx load balancer. This makes sure
+  # that the services are running, as well as the load balancer itself.
+  - job_name: 'nginx-loadbalancer-services'
+    metrics-path: /probe
+    params:
+      module: [http_2xx]
+    static-configs:
+      targets:
+        - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
+        - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
+        - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - source_labels: [__param_module]
+        target_label: module
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the blackbox exporter
+      # address.
+      - target_label: __address__
+        replacement: blackbox-service.default.svc.cluster.local:9115
+
+
   # Scrape config for the snmp_exporter. There is one snmp_exporter service
   # running in a Docker container on a GCE VM in each GCP project.
   #

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -463,7 +463,7 @@ scrape_configs:
     params:
       module: [http_2xx]
     static_configs:
-      targets:
+      - targets:
         - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -456,22 +456,22 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
-  # Probes the services running behind the nginx load balancer. This makes sure
-  # that the services are running, as well as the load balancer itself.
-  - job_name: 'nginx-loadbalancer-services'
+  # Probes the nginx load balancer to be sure that it's listening on port 443.
+  # There are a number of services running behind the load balancer, but below
+  # we've arbitrarily chosen one particular ones, since the names all point to
+  # the load balancer's IP.
+  - job_name: 'nginx-loadbalancer'
     metrics_path: /probe
     params:
-      module: [http_2xx]
+      module: [tcp_v4_online]
     static_configs:
       - targets:
-        - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
-        - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
-        - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net
+        - prometheus.{{PROJECT}}.measurementlab.net:443
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
-        regex: .+@(.+)
+        regex: (.+):443
         target_label: instance
         replacement: ${1}
       - source_labels: [__param_module]

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -471,7 +471,9 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
+        regex: .+@(.+)
         target_label: instance
+        replacement: ${1}
       - source_labels: [__param_module]
         target_label: module
       # Since __address__ is the target that prometheus will contact,


### PR DESCRIPTION
If the nginx ingress load balancer is not listening on port 443, then an operator needs to know about it. This PR adds a new scrape job which probes port 443 on host prometheus.{project}.measurementlab.net, which points to the IP address of the load balancer.  It also adds a new alert, which should trigger if the load balancer is down for more than 30m.

This should resolve issue #314.

Alternate strategy considered: monitor HTTP 200 replies from all services running behind the load balancer. This won't work without a lot of back-bending due to the HTTP Basic Auth implemented on most of the services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/323)
<!-- Reviewable:end -->
