### PR TITLE
Add configmap-reload sidecar for data-processing-cluster prometheus instance

### DIFF
--- a/k8s/data-processing-cluster/deployments/prometheus.yml
+++ b/k8s/data-processing-cluster/deployments/prometheus.yml
@@ -55,6 +55,7 @@ spec:
         # Note: Set retention time to 60 days. (default retention is 15d).
         args: ["--config.file=/etc/prometheus/prometheus.yml",
                "--storage.tsdb.retention=1440h",
+               "--storage.tsdb.path=/data",
                "--web.enable-lifecycle"]
         ports:
           - containerPort: 9090

--- a/k8s/data-processing-cluster/deployments/prometheus.yml
+++ b/k8s/data-processing-cluster/deployments/prometheus.yml
@@ -86,11 +86,11 @@ spec:
                "-volume-dir", "/prometheus-config"]
         resources:
           requests:
-            memory: "400Mi"
-            cpu: "200m"
+            memory: "100Mi"
+            cpu: "50m"
           limits:
-            memory: "400Mi"
-            cpu: "200m"
+            memory: "100Mi"
+            cpu: "50m"
         volumeMounts:
         # Mount the prometheus config volume so we can watch it for changes.
         - mountPath: /prometheus-config

--- a/k8s/data-processing-cluster/deployments/prometheus.yml
+++ b/k8s/data-processing-cluster/deployments/prometheus.yml
@@ -47,13 +47,15 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.
-      - image: prom/prometheus:v2.3.2
+      - image: prom/prometheus:v2.4.2
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.
         name: prometheus
-        # Use 10x the default values for all index cache flags:
-        args: ["--config.file=/etc/prometheus/prometheus.yml"]
+        # Note: Set retention time to 60 days. (default retention is 15d).
+        args: ["--config.file=/etc/prometheus/prometheus.yml",
+               "--storage.tsdb.retention=1440h",
+               "--web.enable-lifecycle"]
         ports:
           - containerPort: 9090
         resources:
@@ -74,6 +76,24 @@ spec:
           subPath: legacy-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
+          name: prometheus-config
+
+      # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
+      # stable version.
+      - image: jimmidyson/configmap-reload:v0.2.2
+        name: configmap-reload
+        args: ["-webhook-url", "http://prometheus-public-service.default.svc.cluster.local:9090/-/reload",
+               "-volume-dir", "/prometheus-config"]
+        resources:
+          requests:
+            memory: "400Mi"
+            cpu: "200m"
+          limits:
+            memory: "400Mi"
+            cpu: "200m"
+        volumeMounts:
+        # Mount the prometheus config volume so we can watch it for changes.
+        - mountPath: /prometheus-config
           name: prometheus-config
 
       # Run a node-exporter as part of the prometheus-server pod so that it has


### PR DESCRIPTION
Evidently the last PR to update the DPC prometheus config was never reloaded. This change adds the reload-config sidecar to the DPC prometheus instance so that this doesn't happen again.

As well, the change includes a longer default retention time and enables the "lifecycle" option, required for the "/-/reload" operation to be enabled.

Finally, this change specifies the data path to the locally data volume so that data is persisted across restarts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/324)
<!-- Reviewable:end -->
