### PR TITLE
Updates dashboards to use label_values(site) instead of broken hostname value.

### DIFF
--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -16,8 +16,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 44,
-  "iteration": 1531520114158,
+  "id": 194,
+  "iteration": 1538498829575,
   "links": [],
   "panels": [
     {
@@ -399,6 +399,7 @@
       ],
       "targets": [
         {
+          "$$hashKey": "object:380",
           "expr": "sum_over_time(probe_success{service=\"ssh806\"}[10m]) < 5 AND changes(probe_success{service=\"ssh806\"}[1w]) > 0",
           "format": "time_series",
           "instant": true,
@@ -2142,9 +2143,8 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "acc",
-          "value": "acc"
+          "text": "acc02",
+          "value": "acc02"
         },
         "datasource": "$datasource",
         "hide": 0,
@@ -2153,9 +2153,9 @@
         "multi": false,
         "name": "site",
         "options": [],
-        "query": "label_values(hostname)",
+        "query": "label_values(site)",
         "refresh": 1,
-        "regex": ".*([a-z]{3}).*.measurement-lab.org",
+        "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -2197,5 +2197,5 @@
   "timezone": "utc",
   "title": "Ops: Platform Overview",
   "uid": "JAq7W6Nmk",
-  "version": 3
+  "version": 55
 }

--- a/config/federation/grafana/dashboards/Ops_PodOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PodOverview.json
@@ -16,8 +16,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 45,
-  "iteration": 1531932319644,
+  "id": 196,
+  "iteration": 1538509283034,
   "links": [],
   "panels": [
     {
@@ -1085,7 +1085,7 @@
       "id": 165,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 95,
       "scopedVars": {
         "node": {
@@ -1150,7 +1150,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1241,7 +1241,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1332,7 +1332,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 6,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1423,7 +1423,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 31,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1514,7 +1514,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 46,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1571,7 +1571,7 @@
       "id": 171,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 4,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1654,7 +1654,7 @@
       "id": 172,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 2,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1737,7 +1737,7 @@
       "id": 173,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 63,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1825,7 +1825,7 @@
       "id": 174,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 64,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1908,7 +1908,7 @@
       "id": 175,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 5,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1989,7 +1989,7 @@
       "id": 176,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 95,
       "scopedVars": {
         "node": {
@@ -2054,7 +2054,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2145,7 +2145,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2236,7 +2236,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 6,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2327,7 +2327,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 31,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2418,7 +2418,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 46,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2475,7 +2475,7 @@
       "id": 182,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 4,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2558,7 +2558,7 @@
       "id": 183,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 2,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2641,7 +2641,7 @@
       "id": 184,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 63,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2729,7 +2729,7 @@
       "id": 185,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 64,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2812,7 +2812,7 @@
       "id": 186,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 5,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2893,7 +2893,7 @@
       "id": 187,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 95,
       "scopedVars": {
         "node": {
@@ -2958,7 +2958,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3049,7 +3049,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3140,7 +3140,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 6,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3231,7 +3231,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 31,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3322,7 +3322,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 46,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3379,7 +3379,7 @@
       "id": 193,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 4,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3462,7 +3462,7 @@
       "id": 194,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 2,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3545,7 +3545,7 @@
       "id": 195,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 63,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3633,7 +3633,7 @@
       "id": 196,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 64,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3716,7 +3716,7 @@
       "id": 197,
       "links": [],
       "pageSize": null,
-      "repeatIteration": 1531932319644,
+      "repeatIteration": 1538509283034,
       "repeatPanelId": 5,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3809,7 +3809,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "acc02",
           "value": "acc02"
         },
@@ -3820,9 +3819,9 @@
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": "label_values(hostname)",
+        "query": "label_values(site)",
         "refresh": 1,
-        "regex": ".*([a-z]{3}[0-9t]{2}).*.measurement-lab.org",
+        "regex": "",
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -3906,5 +3905,5 @@
   "timezone": "",
   "title": "Ops: Pod Overview",
   "uid": "1Q3nWeNik",
-  "version": 3
+  "version": 53
 }

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -16,8 +16,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 46,
-  "iteration": 1531520182355,
+  "id": 197,
+  "iteration": 1538509387868,
   "links": [],
   "panels": [
     {
@@ -826,20 +826,33 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "lax03",
-          "value": "lax03"
+          "text": "acc02",
+          "value": "acc02"
         },
-        "datasource": "Prometheus",
+        "datasource": "$datasource",
         "hide": 0,
         "includeAll": false,
         "label": "Site",
         "multi": false,
         "name": "site_name",
         "options": [],
-        "query": "label_values(up{job=\"snmp-targets\"}, site)",
+        "query": "label_values(site)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -883,5 +896,5 @@
   "timezone": "utc",
   "title": "Ops: Switch Overview",
   "uid": "SuqnZ6Hiz",
-  "version": 3
+  "version": 54
 }


### PR DESCRIPTION
I'm not sure what happened along the way, but apparently `label_values(hostname)` stopped working at some point, breaking the variables in several Ops dashboards. This PR replaces that with `label_values(site)`, which is more efficient anyway, since it will return the site name (e.g., abc01) without having to apply a regex to it to get the value we want.

While I was at it, I noticed that the OpsSwitchOverview dashboard had no datasource select box, which is a standard now, so I added it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/326)
<!-- Reviewable:end -->
