### PR TITLE
Sandbox initcontainer improvements

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -30,7 +30,7 @@ spec:
       initContainers:
       - name: reset-perms
         image: busybox
-        command: ['chown', '-R', '65534:65534', '/work-dir']
+        command: ['chown', '-R', '65534:65534', '/work-dir/*-targets']
         volumeMounts:
         - mountPath: /work-dir
           name: prometheus-storage

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -30,7 +30,7 @@ spec:
       initContainers:
       - name: reset-perms
         image: busybox
-        command: ['chown', '-R', '65534:65534', '/work-dir/*-targets']
+        command: ['ls', '-lah', '/work-dir']
         volumeMounts:
         - mountPath: /work-dir
           name: prometheus-storage

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -30,7 +30,8 @@ spec:
       initContainers:
       - name: reset-perms
         image: busybox
-        command: ['ls', '-lah', '/work-dir']
+        command: ['/bin/sh']
+        args: ['-c', 'chown -R 65534:65534 /work-dir/*-targets*']
         volumeMounts:
         - mountPath: /work-dir
           name: prometheus-storage


### PR DESCRIPTION
This modifies the reset-perms initcontainer to only run `chmod` on the targets, and not on the data directory, in order to cut down on execution time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/327)
<!-- Reviewable:end -->
