### PR TITLE
Changes the configmap-reload container to use the internal service URL.

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -35,12 +35,3 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     -f k8s/${CLUSTER}/${PROJECT}.yml > ${CFG}
 kubectl apply -f ${CFG}
 
-
-# Get the public IP for the prometheus service.
-#PUBLIC_IP=$( kubectl get services \
-#  -o jsonpath='{.items[?(@.metadata.name=="prometheus-public-service")].status.loadBalancer.ingress[0].ip}' )
-#if [[ -n "${PUBLIC_IP}" ]] ; then
-#  # Reload configurations. If the deployment configuration has changed then this
-#  # request may fail because the container has already shutdown.
-#  curl -X POST http://${PUBLIC_IP}:9090/-/reload || :
-#fi

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -233,7 +233,8 @@ spec:
       # stable version.
       - image: jimmidyson/configmap-reload:v0.2.2
         name: configmap-reload
-        args: ["-webhook-url", "$(PROM_RELOAD_URL)", "-volume-dir", "/prometheus-config"]
+        args: ["-webhook-url", "http://prometheus-public-service.default.svc.cluster.local:9090/-/reload",
+               "-volume-dir", "/prometheus-config"]
         env:
         - name: PROM_RELOAD_URL
           valueFrom:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -233,7 +233,7 @@ spec:
       # stable version.
       - image: jimmidyson/configmap-reload:v0.2.2
         name: configmap-reload
-        args: ["-webhook-url", "http://prometheus-public-service.default.svc.cluster.local:9090/-/reload",
+        args: ["-webhook-url", "http://prometheus-service.default.svc.cluster.local:9090/-/reload",
                "-volume-dir", "/prometheus-config"]
         env:
         - name: PROM_RELOAD_URL


### PR DESCRIPTION
Previously it was using the public URL, and for reasons that we don't understand yet was receiving a 504 Gateway Timeout error. Apparently using the internal service URL gets around this issue.

It also removes some obsolete commented-out code that previously reloaded Prom through the public URL. This isn't necessary now that we have the configmap-reload sidecar container, which does this automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/328)
<!-- Reviewable:end -->
