### PR TITLE
Adds BBE checks, and alerts, for core services running behind our nginx load balancer.

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -64,6 +64,12 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 
+# Evaluate the Prometheus blackbox_exporter configuration template.
+sed -e 's|{{PROM_AUTH_USER}}|'${PROM_AUTH_USER}'|g' \
+    -e 's|{{PROM_AUTH_PATH}}|'${PROM_AUTH_PASS}'|g' \
+    config/federation/blackbox/config.yml.template > \
+    config/federation/blackbox/config.yml
+
 # Apply the above configmap.
 kubectl create configmap prometheus-federation-config \
     --from-literal=gcloud-project=${PROJECT} \

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -61,7 +61,6 @@ export AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
-    -e 's|{{HTTP_AUTH}}|'${AUTH}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -74,7 +74,7 @@ sed -e 's|{{PROM_AUTH_USER}}|'${!PROM_AUTH_USER}'|g' \
 ## Apply the above configmap for Blackbox exporter.
 kubectl create configmap blackbox-config \
     --from-file=config/federation/blackbox \
-    --dry-run -o json | kubectl apply -f -
+    --dry-run -o json | kubectl replace -f -
 
 ## Grafana
 kubectl create configmap grafana-config \

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -65,8 +65,8 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     config/federation/prometheus/prometheus.yml
 
 # Evaluate the Prometheus blackbox_exporter configuration template.
-sed -e 's|{{PROM_AUTH_USER}}|'${PROM_AUTH_USER}'|g' \
-    -e 's|{{PROM_AUTH_PATH}}|'${PROM_AUTH_PASS}'|g' \
+sed -e 's|{{PROM_AUTH_USER}}|'${!PROM_AUTH_USER}'|g' \
+    -e 's|{{PROM_AUTH_PASS}}|'${!PROM_AUTH_PASS}'|g' \
     config/federation/blackbox/config.yml.template > \
     config/federation/blackbox/config.yml
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -59,7 +59,7 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 
-# Apply the above configmap for Prometheus
+# Apply the above configmap for Prometheus.
 kubectl create configmap prometheus-federation-config \
     --from-literal=gcloud-project=${PROJECT} \
     --from-file=config/federation/prometheus \
@@ -76,7 +76,7 @@ kubectl create configmap blackbox-config \
     --from-file=config/federation/blackbox \
     --dry-run -o json | kubectl replace -f -
 
-## Grafana
+## Grafana.
 kubectl create configmap grafana-config \
     --from-file=config/federation/grafana \
     --dry-run -o json | kubectl apply -f -

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -61,6 +61,7 @@ export AUTH="${!PROM_AUTH_USER}:${!PROM_AUTH_PASS}"
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
+    -e 's|{{HTTP_AUTH}}|'${AUTH}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/config/federation/blackbox/config.yml.template
+++ b/config/federation/blackbox/config.yml.template
@@ -125,3 +125,15 @@ modules:
     timeout: 9s
     http:
       method: "GET"
+
+  # target=<http[s]://host:port>
+  #
+  # Works with http or https targets.
+  nginx_lb_svcs_online:
+    prober: http
+    timeout: 9s
+    http:
+      method: "GET"
+      basic_auth:
+        username: {{PROM_AUTH_USER}}
+        password: {{PROM_AUTH_PASS}}

--- a/config/federation/blackbox/config.yml.template
+++ b/config/federation/blackbox/config.yml.template
@@ -129,7 +129,7 @@ modules:
   # target=<http[s]://host:port>
   #
   # Works with http or https targets.
-  nginx_lb_svcs_online:
+  nginx_proxy_svcs_online:
     prober: http
     timeout: 9s
     http:

--- a/config/federation/grafana/grafana.ini
+++ b/config/federation/grafana/grafana.ini
@@ -249,7 +249,7 @@ api_url = https://www.googleapis.com/oauth2/v1/userinfo
 
 #################################### Basic Auth ##########################
 [auth.basic]
-;enabled = true
+enabled = false
 
 #################################### Auth LDAP ##########################
 [auth.ldap]

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -502,6 +502,16 @@ groups:
         repository to configure collectd-mlab. Login to the node and run the check
         script manually to see what the specific error is (/usr/lib/nagios/plugins/check_collectd_mlab.py).
       summary: A collectd-mlab service metric is missing.
+# The nginx ingress load balancer is down.
+  - alert: NginxLoadBalancerDown
+    expr: up{service="nodeexporter"} == 0
+    for: 30m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      hints: Did the nginx k8s deployment or nginx-lb k8s service fail?
+      summary: The nginx ingress load balancer is down.
 # TODO:
 #   Replace this with two other alerts:
 #    1.  Alert if hourly test volume on servers drops relative to same hour on recent days.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -502,9 +502,9 @@ groups:
         repository to configure collectd-mlab. Login to the node and run the check
         script manually to see what the specific error is (/usr/lib/nagios/plugins/check_collectd_mlab.py).
       summary: A collectd-mlab service metric is missing.
-# One or more of the backend services handled by the nginx loadbalancer is down.
-  - alert: CoreServices_NginxLoadBalancedServiceDown
-    expr: probe_success{job="nginx-loadbalanced-services"} == 0
+# One or more of the backend services handled by the nginx proxy is down.
+  - alert: Prometheus_NginxProxiedServiceDown
+    expr: probe_success{job="nginx-proxied-services"} == 0
     for: 30m
     labels:
       repo: ops-tracker
@@ -512,8 +512,7 @@ groups:
     annotations:
       hints: Did the nginx k8s deployment or nginx-lb k8s service fail? Did the
         backend service or deployment fail in some way?
-      summary: One or more of the backend services handled by the nginx
-        loadbalancer is down.
+      summary: One or more of the backend services handled by the nginx proxy is down.
 # TODO:
 #   Replace this with two other alerts:
 #    1.  Alert if hourly test volume on servers drops relative to same hour on recent days.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -502,16 +502,18 @@ groups:
         repository to configure collectd-mlab. Login to the node and run the check
         script manually to see what the specific error is (/usr/lib/nagios/plugins/check_collectd_mlab.py).
       summary: A collectd-mlab service metric is missing.
-# The nginx ingress load balancer is down.
-  - alert: NginxLoadBalancerDown
-    expr: up{job="nginx-loadbalancer-services"} == 0
+# One or more of the backend services handled by the nginx loadbalancer is down.
+  - alert: CoreServices_NginxLoadBalancedServiceDown
+    expr: probe_success{job="nginx-loadbalanced-services"} == 0
     for: 30m
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      hints: Did the nginx k8s deployment or nginx-lb k8s service fail?
-      summary: The nginx ingress load balancer is down.
+      hints: Did the nginx k8s deployment or nginx-lb k8s service fail? Did the
+        backend service or deployment fail in some way?
+      summary: One or more of the backend services handled by the nginx
+        loadbalancer is down.
 # TODO:
 #   Replace this with two other alerts:
 #    1.  Alert if hourly test volume on servers drops relative to same hour on recent days.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -504,7 +504,7 @@ groups:
       summary: A collectd-mlab service metric is missing.
 # The nginx ingress load balancer is down.
   - alert: NginxLoadBalancerDown
-    expr: up{service="nodeexporter"} == 0
+    expr: up{job="nginx-loadbalancer-services"} == 0
     for: 30m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -482,7 +482,7 @@ scrape_configs:
         - https://gmx.{{PROJECT}}.measurementlab.net
         - https://grafana.{{PROJECT}}.measurementlab.net
         - https://prometheus.{{PROJECT}}.measurementlab.net
-        labels:
+      - labels:
         - module: nginx_lb_svcs_online
     relabel_configs:
       - source_labels: [__address__]

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -482,8 +482,8 @@ scrape_configs:
         - https://gmx.{{PROJECT}}.measurementlab.net
         - https://grafana.{{PROJECT}}.measurementlab.net
         - https://prometheus.{{PROJECT}}.measurementlab.net
-      - labels:
-        - module: nginx_lb_svcs_online
+        labels:
+          module: nginx_lb_svcs_online
     relabel_configs:
       - source_labels: [__address__]
         regex: (.*)

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -468,11 +468,8 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
-  # Probes the nginx load balancer to be sure that it's listening on port 443.
-  # There are a number of services running behind the load balancer, but below
-  # we've arbitrarily chosen one particular ones, since the names all point to
-  # the load balancer's IP.
-  - job_name: 'nginx-loadbalancer-services'
+  # Probes the backend services being loadbalanced by nginx.
+  - job_name: 'nginx-loadbalanced-services'
     metrics_path: /probe
     params:
       module: [nginx_lb_svcs_online]
@@ -480,8 +477,8 @@ scrape_configs:
       - targets:
         - https://alertmanager.{{PROJECT}}.measurementlab.net
         - https://gmx.{{PROJECT}}.measurementlab.net
-        - https://grafana.{{PROJECT}}.measurementlab.net
-        - https://prometheus.{{PROJECT}}.measurementlab.net
+        - https://grafana.{{PROJECT}}.measurementlab.net/login
+        - https://prometheus.{{PROJECT}}.measurementlab.net/graph
         labels:
           module: nginx_lb_svcs_online
     relabel_configs:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -468,22 +468,22 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
-  # Probes the services running behind the nginx load balancer. This makes sure
-  # that the services are running, as well as the load balancer itself.
-  - job_name: 'nginx-loadbalancer-services'
+  # Probes the nginx load balancer to be sure that it's listening on port 443.
+  # There are a number of services running behind the load balancer, but below
+  # we've arbitrarily chosen one particular ones, since the names all point to
+  # the load balancer's IP.
+  - job_name: 'nginx-loadbalancer'
     metrics_path: /probe
     params:
-      module: [http_2xx]
+      module: [tcp_v4_online]
     static_configs:
       - targets:
-        - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
-        - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
-        - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net
+        - prometheus.{{PROJECT}}.measurementlab.net:443
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
-        regex: .+@(.+)
+        regex: (.+):443
         target_label: instance
         replacement: ${1}
       - source_labels: [__param_module]

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -484,13 +484,17 @@ scrape_configs:
         - https://prometheus.{{PROJECT}}.measurementlab.net
     relabel_configs:
       - source_labels: [__address__]
+        regex: (.*)
         target_label: __param_target
+        replacement: ${1}
+      - source_labels: [module]
+        regex: (.*)
+        target_label: __param_module
+        replacement: ${1}
       - source_labels: [__param_target]
-        regex: (.+):443
+        regex: (.*)
         target_label: instance
         replacement: ${1}
-      - source_labels: [__param_module]
-        target_label: module
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the blackbox exporter
       # address.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -478,10 +478,10 @@ scrape_configs:
       module: [nginx_lb_svcs_online]
     static_configs:
       - targets:
-        - https://alertmanager.{{PROJECT}}.measurementlab.net/#/alerts
-        - https://gmx.{{PROJECT}}.measurementlab.net/
-        - https://grafana.{{PROJECT}}.measurementlab.net/
-        - https://prometheus.{{PROJECT}}.measurementlab.net/graph
+        - https://alertmanager.{{PROJECT}}.measurementlab.net
+        - https://gmx.{{PROJECT}}.measurementlab.net
+        - https://grafana.{{PROJECT}}.measurementlab.net
+        - https://prometheus.{{PROJECT}}.measurementlab.net
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -483,7 +483,9 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
+        regex: .+@(.+)
         target_label: instance
+        replacement: ${1}
       - source_labels: [__param_module]
         target_label: module
       # Since __address__ is the target that prometheus will contact,

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -468,11 +468,11 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
-  # Probes the backend services being loadbalanced by nginx.
-  - job_name: 'nginx-loadbalanced-services'
+  # Probes the backend services being proxied by nginx.
+  - job_name: 'nginx-proxied-services'
     metrics_path: /probe
     params:
-      module: [nginx_lb_svcs_online]
+      module: [nginx_proxy_svcs_online]
     static_configs:
       - targets:
         - https://alertmanager.{{PROJECT}}.measurementlab.net
@@ -480,20 +480,29 @@ scrape_configs:
         - https://grafana.{{PROJECT}}.measurementlab.net/login
         - https://prometheus.{{PROJECT}}.measurementlab.net/graph
         labels:
-          module: nginx_lb_svcs_online
+          module: nginx_proxy_svcs_online
     relabel_configs:
+      # The default __address__ value is a target host from the config file.
+      # Here, we set (i.e. "replace") a request parameter "target" equal to the
+      # host value.
       - source_labels: [__address__]
         regex: (.*)
         target_label: __param_target
         replacement: ${1}
+      # Use the "module" label defined in the input file as the module name for
+      # the blackbox exporter request.
       - source_labels: [module]
         regex: (.*)
         target_label: __param_module
         replacement: ${1}
+      # Isolate the hostname from the URL, which will give us an good
+      # representation of the service.
       - source_labels: [__param_target]
         regex: https://([a-z]+).*
         target_label: service
         replacement: ${1}
+      # Use the target parameter defined above and use it to define the
+      # "instance" label.
       - source_labels: [__param_target]
         regex: (.*)
         target_label: instance

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -475,7 +475,7 @@ scrape_configs:
     params:
       module: [http_2xx]
     static_configs:
-      targets:
+      - targets:
         - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -482,6 +482,8 @@ scrape_configs:
         - https://gmx.{{PROJECT}}.measurementlab.net
         - https://grafana.{{PROJECT}}.measurementlab.net
         - https://prometheus.{{PROJECT}}.measurementlab.net
+        labels:
+        - module: nginx_lb_svcs_online
     relabel_configs:
       - source_labels: [__address__]
         regex: (.*)
@@ -490,6 +492,10 @@ scrape_configs:
       - source_labels: [module]
         regex: (.*)
         target_label: __param_module
+        replacement: ${1}
+      - source_labels: [__param_target]
+        regex: https://(.*)\..*
+        target_label: service
         replacement: ${1}
       - source_labels: [__param_target]
         regex: (.*)

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -478,10 +478,10 @@ scrape_configs:
       module: [nginx_lb_svcs_online]
     static_configs:
       - targets:
-        - https://alertmanager.{{PROJECT}}.measurementlab.net:443
-        - https://gmx.{{PROJECT}}.measurementlab.net:443
-        - https://grafana.{{PROJECT}}.measurementlab.net:443
-        - https://prometheus.{{PROJECT}}.measurementlab.net:443
+        - https://alertmanager.{{PROJECT}}.measurementlab.net:443/#/alerts
+        - https://gmx.{{PROJECT}}.measurementlab.net:443/
+        - https://grafana.{{PROJECT}}.measurementlab.net:443/
+        - https://prometheus.{{PROJECT}}.measurementlab.net:443/graph
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -495,7 +495,7 @@ scrape_configs:
         regex: (.*)
         target_label: __param_module
         replacement: ${1}
-      # Isolate the hostname from the URL, which will give us an good
+      # Isolate the hostname from the URL, which will give us a good
       # representation of the service.
       - source_labels: [__param_target]
         regex: https://([a-z]+).*

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -494,7 +494,7 @@ scrape_configs:
         target_label: __param_module
         replacement: ${1}
       - source_labels: [__param_target]
-        regex: https://(.*)\..*
+        regex: https://([a-z]+).*
         target_label: service
         replacement: ${1}
       - source_labels: [__param_target]

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -468,6 +468,31 @@ scrape_configs:
         replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
 
 
+  # Probes the services running behind the nginx load balancer. This makes sure
+  # that the services are running, as well as the load balancer itself.
+  - job_name: 'nginx-loadbalancer-services'
+    metrics-path: /probe
+    params:
+      module: [http_2xx]
+    static-configs:
+      targets:
+        - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
+        - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net
+        - https://{{HTTP_AUTH}}@prometheus.{{PROJECT}}.measurementlab.net
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - source_labels: [__param_module]
+        target_label: module
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the blackbox exporter
+      # address.
+      - target_label: __address__
+        replacement: blackbox-service.default.svc.cluster.local:9115
+
+
   # Scrape config for the snmp_exporter. There is one snmp_exporter service
   # running in a Docker container on a GCE VM in each GCP project.
   #

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -478,10 +478,10 @@ scrape_configs:
       module: [nginx_lb_svcs_online]
     static_configs:
       - targets:
-        - https://alertmanager.{{PROJECT}}.measurementlab.net:443/#/alerts
-        - https://gmx.{{PROJECT}}.measurementlab.net:443/
-        - https://grafana.{{PROJECT}}.measurementlab.net:443/
-        - https://prometheus.{{PROJECT}}.measurementlab.net:443/graph
+        - https://alertmanager.{{PROJECT}}.measurementlab.net/#/alerts
+        - https://gmx.{{PROJECT}}.measurementlab.net/
+        - https://grafana.{{PROJECT}}.measurementlab.net/
+        - https://prometheus.{{PROJECT}}.measurementlab.net/graph
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -471,10 +471,10 @@ scrape_configs:
   # Probes the services running behind the nginx load balancer. This makes sure
   # that the services are running, as well as the load balancer itself.
   - job_name: 'nginx-loadbalancer-services'
-    metrics-path: /probe
+    metrics_path: /probe
     params:
       module: [http_2xx]
-    static-configs:
+    static_configs:
       targets:
         - https://{{HTTP_AUTH}}@alertmanager.{{PROJECT}}.measurementlab.net
         - https://{{HTTP_AUTH}}@grafana.{{PROJECT}}.measurementlab.net

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -472,13 +472,16 @@ scrape_configs:
   # There are a number of services running behind the load balancer, but below
   # we've arbitrarily chosen one particular ones, since the names all point to
   # the load balancer's IP.
-  - job_name: 'nginx-loadbalancer'
+  - job_name: 'nginx-loadbalancer-services'
     metrics_path: /probe
     params:
-      module: [tcp_v4_online]
+      module: [nginx_lb_svcs_online]
     static_configs:
       - targets:
-        - prometheus.{{PROJECT}}.measurementlab.net:443
+        - https://alertmanager.{{PROJECT}}.measurementlab.net:443
+        - https://gmx.{{PROJECT}}.measurementlab.net:443
+        - https://grafana.{{PROJECT}}.measurementlab.net:443
+        - https://prometheus.{{PROJECT}}.measurementlab.net:443
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
This PR adds basic HTTP Prometheus blackbox_exporter checks for the services running in the prometheus-federation k8s cluster. It also adds an alert for when one of them goes down for more than 30m.

*Note*: I disabled HTTP Basic Auth for Grafana so that probes would work to `/login` without receiving a 401 reply. I don't think we are using Basic Auth for anything in Grafana, but mention this change here just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/329)
<!-- Reviewable:end -->
