### PR TITLE
Add SLO panel to Gardener, use increase for hourly and daily

### DIFF
--- a/config/federation/grafana/dashboards/Pipeline_Gardener.json
+++ b/config/federation/grafana/dashboards/Pipeline_Gardener.json
@@ -17,7 +17,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 216,
-  "iteration": 1539623588073,
+  "iteration": 1539623588087,
   "links": [],
   "panels": [
     {
@@ -634,7 +634,7 @@
       "targets": [
         {
           "$$hashKey": "object:156",
-          "expr": "increase(gardener_started_total{deployment=~\"$deployment\"}[1h])",
+          "expr": "sum by(deployment) (increase(gardener_started_total{deployment=~\"$deployment\"}[1h]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -643,7 +643,7 @@
         },
         {
           "$$hashKey": "object:157",
-          "expr": "-increase(gardener_completed_total{deployment=~\"$deployment\"}[1h])",
+          "expr": "sum by(deployment) (-increase(gardener_completed_total{deployment=~\"$deployment\"}[1h]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -756,7 +756,7 @@
       "targets": [
         {
           "$$hashKey": "object:157",
-          "expr": "increase(gardener_completed_total{deployment=~\"$deployment\"}[24h])",
+          "expr": "sum by(deployment) (increase(gardener_completed_total{deployment=~\"$deployment\"}[24h]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -799,7 +799,7 @@
           "label": "Tasks / Day",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -866,7 +866,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {

--- a/config/federation/grafana/dashboards/Pipeline_Gardener.json
+++ b/config/federation/grafana/dashboards/Pipeline_Gardener.json
@@ -2,6 +2,7 @@
   "annotations": {
     "list": [
       {
+        "$$hashKey": "object:85",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": false,
@@ -15,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 55,
-  "iteration": 1539288566988,
+  "id": 216,
+  "iteration": 1539623588073,
   "links": [],
   "panels": [
     {
@@ -632,15 +633,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "# NOTE: `deriv` is for gauges; `rate` is for counters.",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "legendFormat": "Completed {{deployment}}",
-          "refId": "C"
-        },
-        {
-          "expr": "rate(gardener_started_total{deployment=~\"$deployment\"}[3h])*3600",
+          "$$hashKey": "object:156",
+          "expr": "increase(gardener_started_total{deployment=~\"$deployment\"}[1h])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -648,7 +642,8 @@
           "refId": "A"
         },
         {
-          "expr": "-rate(gardener_completed_total{deployment=~\"$deployment\"}[3h])*3600",
+          "$$hashKey": "object:157",
+          "expr": "-increase(gardener_completed_total{deployment=~\"$deployment\"}[1h])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -659,7 +654,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Start and Completion Rate",
+      "title": "Start and Completion Rate (hourly)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -696,6 +691,131 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Completed etl-gardener-disco",
+          "color": "#508642"
+        },
+        {
+          "alias": "Completed etl-gardener-ndt",
+          "color": "#cca300"
+        },
+        {
+          "alias": "Completed etl-gardener-sidestream",
+          "color": "#e24d42"
+        },
+        {
+          "alias": "Started etl-gardener-disco",
+          "color": "#508642"
+        },
+        {
+          "alias": "Started etl-gardener-ndt",
+          "color": "#e5ac0e"
+        },
+        {
+          "alias": "Started etl-gardener-sidestream",
+          "color": "#e24d42"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:157",
+          "expr": "increase(gardener_completed_total{deployment=~\"$deployment\"}[24h])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Completed {{deployment}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [
+        {
+          "$$hashKey": "object:697",
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 40,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SLO: Completion Rate (Tasks / day)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:608",
+          "decimals": null,
+          "format": "short",
+          "label": "Tasks / Day",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:609",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -707,6 +827,7 @@
       {
         "current": {
           "selected": true,
+          "tags": [],
           "text": "Data Proc (mlab-oti)",
           "value": "Data Proc (mlab-oti)"
         },
@@ -745,7 +866,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -776,5 +897,5 @@
   "timezone": "utc",
   "title": "Pipeline: Gardener",
   "uid": "eBbUW6oik",
-  "version": 35
+  "version": 38
 }


### PR DESCRIPTION
This change adds a new panel to the Gardener dashboard for the daily reprocessing SLO: Tasks/Day. This also changes the query used by the Tasks/Hour panel to average over a single hour. And, in both cases the rates are aggregated by the deployment name to create consistent numbers across re-deployments.

https://grafana.mlab-sandbox.measurementlab.net/d/eBbUW6oik/pipeline-gardener?orgId=1&from=now-7d&to=now&var-datasource=Data%20Proc%20(mlab-oti)&var-deployment=All

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/336)
<!-- Reviewable:end -->
