### PR TITLE
 Add Gardener_ParseTimeDifferenceTooOld alert

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -214,6 +214,10 @@ if [[ -n "${ALERTMANAGER_URL}" ]] ; then
         --dry-run -o json | kubectl apply -f -
 fi
 
+# Evaluate bq queries as templates.
+sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
+    config/federation/bigquery/bq_gardener_parse_time.sql.template > \
+    config/federation/bigquery/bq_gardener_parse_time.sql
 # Apply the bigquery exporter configurations.
 kubectl create configmap bigquery-exporter-config \
     --from-file=config/federation/bigquery \

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -30,7 +30,7 @@ route:
   repeat_interval: 3h
 
   # When no other routes match, use the default receiver.
-  receiver: slack-alerts-email
+  receiver: slack-alerts-ticket
 
   # The above attributes are inherited by all child routes. Children can
   # overwrite any value.
@@ -102,16 +102,25 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-page
-    text: '{{GITHUB_ISSUE_QUERY}}'
+    text: |
+	  Open Issues: {{GITHUB_ISSUE_QUERY}}
+	  Summary    : {{ .CommonAnnotations.summary }}
+	  Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
+	  Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
+
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'
 
-- name: 'slack-alerts-email'
+- name: 'slack-alerts-ticket'
   slack_configs:
   - send_resolved: true
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
-    username: alert-email
-    text: '{{GITHUB_ISSUE_QUERY}}'
+    username: alertmanager
+    text: |
+	  Open Issues: {{GITHUB_ISSUE_QUERY}}
+	  Summary    : {{ .CommonAnnotations.summary }}
+	  Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
+	  Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -103,10 +103,10 @@ receivers:
     channel: alerts-{{SHORT_PROJECT}}
     username: alert-page
     text: |
-	  Open Issues: {{GITHUB_ISSUE_QUERY}}
-	  Summary    : {{ .CommonAnnotations.summary }}
-	  Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
-	  Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
+      Open Issues: {{GITHUB_ISSUE_QUERY}}
+      Summary    : {{ .CommonAnnotations.summary }}
+      Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
+      Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
 
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'
@@ -118,9 +118,9 @@ receivers:
     channel: alerts-{{SHORT_PROJECT}}
     username: alertmanager
     text: |
-	  Open Issues: {{GITHUB_ISSUE_QUERY}}
-	  Summary    : {{ .CommonAnnotations.summary }}
-	  Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
-	  Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
+      Open Issues: {{GITHUB_ISSUE_QUERY}}
+      Summary    : {{ .CommonAnnotations.summary }}
+      Description: {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}
+      Dashboard  : {{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}Please add an alert dashboard!{{end}}
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -1,0 +1,33 @@
+#standardSQL
+-- bq_gardener_parse_time calculates the maximum difference of parse_times in
+-- seconds for each gardener managed dataset.
+--
+-- This query exports one metric:
+--
+--   bq_gardener_parse_time_difference -- (MAX(parse_time) - MIN(parse_time))
+--       in seconds, labeled with the dataset name.
+
+SELECT
+  TIMESTAMP_DIFF(max_parse_time, min_parse_time, SECOND) AS value_difference,
+  dataset
+FROM (
+    SELECT
+      "ndt" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
+    FROM
+      `{{PROJECT}}.base_tables.ndt`
+  UNION ALL
+    SELECT
+      "sidestream" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
+    FROM
+      `{{PROJECT}}.base_tables.sidestream`
+  UNION ALL
+    SELECT
+      "traceroute" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
+    FROM
+      `{{PROJECT}}.base_tables.traceroute`
+  UNION ALL
+    SELECT
+      "switch" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
+    FROM
+      `{{PROJECT}}.base_tables.switch`
+)

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -4,11 +4,11 @@
 --
 -- This query exports one metric:
 --
---   bq_gardener_parse_time_difference -- (MAX(parse_time) - MIN(parse_time))
---       in seconds, labeled with the dataset name.
+--   bq_gardener_parse_time_difference_days -- (MAX(parse_time) - MIN(parse_time))
+--       in days, labeled with the dataset name.
 
 SELECT
-  TIMESTAMP_DIFF(max_parse_time, min_parse_time, SECOND) AS value_difference,
+  TIMESTAMP_DIFF(max_parse_time, min_parse_time, DAY) AS value_difference_days,
   dataset
 FROM (
     SELECT

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -661,7 +661,7 @@ groups:
 # Gardener_ParseTimeDifferenceTooOld fires when the maximum and minimum
 # parse_time values for each data set are greater than 80 days.
   - alert: Gardener_ParseTimeDifferenceTooOld
-    expr: bq_gardener_parse_time_difference > 80*24*60*60
+    expr: bq_gardener_parse_time_difference_days > 80
     for: 10m
     labels:
       repo: dev-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -657,3 +657,17 @@ groups:
       hints: The annotator runs in AppEngine. Check logs and recent deployments. The
         daily and batch parsers may also be affected.
       summary: Too many NDT tests are missing annotations!
+
+# Gardener_ParseTimeDifferenceTooOld fires when the maximum and minimum
+# parse_time values for each data set are greater than 80 days.
+  - alert: Gardener_ParseTimeDifferenceTooOld
+    expr: bq_gardener_parse_time_difference > 80*24*60*60
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      hints: Gardener throughput is dependent on the etl-batch-parser and
+        associated queues.yaml.
+      summary: 'Gardener progress is too slow for some dataset: {{ $labels.dataset }}'
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/eBbUW6oik/pipeline-gardener

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -21,6 +21,7 @@ spec:
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
                 "--type=gauge", "--query=/queries/bq_ipv6_bias.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_annotation.sql",
+                "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_worldmap_server.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_geohash_client.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_server.sql" ]


### PR DESCRIPTION
This change adds a BQ exporter query (bq_gardener_parse_time.sql.template) to define the metric used by a new alert  Gardener_ParseTimeDifferenceTooOld. As well, this change adds additional metadata to the alertmanager messages sent to slack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/338)
<!-- Reviewable:end -->
