### PR TITLE
Add cadvisor for per-container or per-pod resource utilization

### DIFF
--- a/k8s/prometheus-federation/deployments/cadvisor.yml
+++ b/k8s/prometheus-federation/deployments/cadvisor.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
   name: cadvisor
-  namespace: cadvisor
+  namespace: default
   annotations:
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:

--- a/k8s/prometheus-federation/deployments/cadvisor.yml
+++ b/k8s/prometheus-federation/deployments/cadvisor.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: cadvisor
-        image: k8s.gcr.io/cadvisor:v0.30.2
+        image: k8s.gcr.io/cadvisor:v0.31.0
         args:
           - --housekeeping_interval=60s
           - --max_housekeeping_interval=75s

--- a/k8s/prometheus-federation/deployments/cadvisor.yml
+++ b/k8s/prometheus-federation/deployments/cadvisor.yml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: cadvisor
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  selector:
+    matchLabels:
+      name: cadvisor
+  template:
+    metadata:
+      labels:
+        name: cadvisor
+      annotations:
+        prometheus.io/scrape: 'true'
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: cadvisor
+        image: k8s.gcr.io/cadvisor:v0.30.2
+        args:
+          - --housekeeping_interval=60s
+          - --max_housekeeping_interval=75s
+          - --event_storage_event_limit=default=0
+          - --event_storage_age_limit=default=0
+          # Note: tcp,udp stats are very expensive.
+          # Enable only network, diskIO, cpu, memory.
+          - --disable_metrics=percpu,disk,tcp,udp
+          # Only show stats for docker containers.
+          - --docker_only
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+          limits:
+            cpu: 300m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk


### PR DESCRIPTION
kube-state-metrics provides static information about containers, e.g. resources allocated, restart counts, pending or available.

And, while early versions of the GKE kubelet appeared to include container resource metrics, over time that functionality has been removed or otherwise made unavailable.

This change adds the cAdvisor container to the prometheus federation cluster to collect per-container resource utilization metrics such as:

* container_cpu_usage_seconds_total
* container_memory_usage_bytes
* container_network_{receive,transmit}_bytes_total
* container_fs_{reads,writes}_bytes_total
* and others.

With these it will be possible to build richer dashboards inspecting the resource utilization of individual containers, aggregate pods, or all pods on a node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/341)
<!-- Reviewable:end -->
