### PR TITLE
Add long flags

### DIFF
--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -39,9 +39,9 @@ spec:
             configMapKeyRef:
               name: alertmanager-env
               key: external-url
-        args: ["-config.file=/etc/alertmanager/config.yml",
-               "-web.external-url=$(ALERTMANAGER_EXTERNAL_URL)",
-               "-storage.path=/alertmanager"]
+        args: ["--config.file=/etc/alertmanager/config.yml",
+               "--web.external-url=$(ALERTMANAGER_EXTERNAL_URL)",
+               "--storage.path=/alertmanager"]
         ports:
           - containerPort: 9093
         resources:


### PR DESCRIPTION
Correct a typo missed in https://github.com/m-lab/prometheus-support/pull/345

I failed to verify behavior in sandbox. All my testing from #345  was done from a local deployment. The new version of alertmanager requires double `--` prefix before long options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/346)
<!-- Reviewable:end -->
