### PR TITLE
Remove all tabs and extra new lines.

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -97,15 +97,13 @@ receivers:
     - type: button
       text: '{{if .CommonAnnotations.dashboard}}Dashboard{{else}}Create Dashboard{{end}}'
       url: '{{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}https://grafana.mlab-sandbox.measurementlab.net/dashboard/new?orgId=1{{end}}'
-
-	# NOTE: buttons do not display if the URL is empty or invalid.
+    # NOTE: buttons do not display if the URL is empty or invalid.
     - type: button
       text: Github
-      url: '{{GITHUB_ISSUE_QUERY}}'
-
+      url: '{{GITHUB_ISSUE_QUERY}} '
     # NOTE: this goop constructs a query string for the alertmanager to create
-	# a silence. The format of the query is a url encoded label set: e.g.
-	# {foo="a",bar="b"}
+    # a silence. The format of the query is a url encoded label set: e.g.
+    # {foo="a",bar="b"}
     - type: button
       text: Add Silence
       url: '{{if eq .Status "firing"}}{{.ExternalURL}}/#/silences/new?filter=%7B{{$values := .CommonLabels.Values}}{{range $index, $name := .CommonLabels.Names}}{{if $index}}%2C{{end}}{{$name}}%3D%22{{index $values $index}}%22{{end}}%7D{{end}}'


### PR DESCRIPTION
Evidently, alertmanager was failing to parse the yaml due to:

```
level=error ts=2018-10-23T19:34:22.591921967Z caller=main.go:325 msg="Loading configuration file failed" file=/etc/alertmanager/config.yml err="yaml: line 101: found character that cannot start any token"
```
And,
```
level=error ts=2018-10-23T19:43:04.394886283Z caller=main.go:325 msg="Loading configuration file failed" file=/etc/alertmanager/config.yml err="yaml: line 102: did not find expected key"
```

I've tried removing all tabs and guaranteeing that an extra space is in the github url. This does seem to work in sandbox now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/347)
<!-- Reviewable:end -->
