### PR TITLE
Update format and make templates more readable

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -99,7 +99,7 @@ receivers:
     # NOTE: An empty url is invalid config. An invalid URL will not display.
     - type: button
       text: Github
-      url: '{{GITHUB_RECEIVER_URL}}%20'
+      url: '{{GITHUB_ISSUE_QUERY}}%20'
     # NOTE: Add a dashboard.
     - type: button
       text: '{{if .CommonAnnotations.dashboard}}Dashboard{{else}}Create Dashboard{{end}}'

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -84,29 +84,44 @@ receivers:
     api_url: {{SLACK_CHANNEL_URL}}
     channel: alerts-{{SHORT_PROJECT}}
     username: alertmanager
-
     title: >
       [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
-      {{.GroupLabels.alertname}}: {{.CommonAnnotations.summary}}
-
+      {{.GroupLabels.alertname}}
     text: |
-      *Description:* '{{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}{{else}}Please add an alert description!{{end}}'
-      *Details:* {{range $key, $value := .CommonLabels }} {{ $key }}=`{{ $value }}` {{end}}
-
+      {{- if eq .Status "firing" -}}
+      {{.CommonAnnotations.summary}}
+      > {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}
+      {{- else}}*Please add an alert description!*{{end -}}
+      <https://github.com/m-lab/prometheus-support/edit/master/config/federation/prometheus/alerts.yml|(edit...)>
+      {{- end }}
+      {{ range $key, $value := .CommonLabels }} {{ $key }}=*{{ $value }}*, {{ end }}
     actions:
-    - type: button
-      text: '{{if .CommonAnnotations.dashboard}}Dashboard{{else}}Create Dashboard{{end}}'
-      url: '{{if .CommonAnnotations.dashboard}}{{.CommonAnnotations.dashboard}}{{else}}https://grafana.mlab-sandbox.measurementlab.net/dashboard/new?orgId=1{{end}}'
-    # NOTE: buttons do not display if the URL is empty or invalid.
+    # NOTE: An empty url is invalid config. An invalid URL will not display.
     - type: button
       text: Github
-      url: '{{GITHUB_ISSUE_QUERY}} '
-    # NOTE: this goop constructs a query string for the alertmanager to create
+      url: '{{GITHUB_RECEIVER_URL}}%20'
+    # NOTE: Add a dashboard.
+    - type: button
+      text: '{{if .CommonAnnotations.dashboard}}Dashboard{{else}}Create Dashboard{{end}}'
+      url: >
+        {{- if .CommonAnnotations.dashboard }}{{ .CommonAnnotations.dashboard }}
+        {{- else }}https://grafana.mlab-sandbox.measurementlab.net/dashboard/new?orgId=1
+        {{- end -}}
+    # NOTE: this constructs a query string for the alertmanager to create
     # a silence. The format of the query is a url encoded label set: e.g.
     # {foo="a",bar="b"}
     - type: button
       text: Add Silence
-      url: '{{if eq .Status "firing"}}{{.ExternalURL}}/#/silences/new?filter=%7B{{$values := .CommonLabels.Values}}{{range $index, $name := .CommonLabels.Names}}{{if $index}}%2C{{end}}{{$name}}%3D%22{{index $values $index}}%22{{end}}%7D{{end}}'
+      url: >
+        {{- if eq .Status "firing" -}}
+          {{- .ExternalURL }}/#/silences/new?filter=
+          {{- printf "{" | urlquery }}
+          {{- range $index, $pair := .CommonLabels.SortedPairs }}
+            {{- if $index }}{{ printf "," | urlquery }}{{end}}
+            {{- printf "%s=\"%s\"" $pair.Name $pair.Value | urlquery }}
+          {{- end -}}
+          {{- printf "}" | urlquery }}
+        {{- end -}}
 
   # All alerts sent to slack are also sent to the github webhook receiver.
   webhook_configs:


### PR DESCRIPTION
This change updates the alertmanager slack alert format to remove unnecessary text and better place and format the summary and description text.

As well, the description text includes a static link to edit the alerts.yaml file via github.

Buttons are ordered so that their position is consistent between "FIRING" and "RESOLVED" states.

The template logic for construction of the "Add Silence" button is much clearer.

Example image:
<img width="597" alt="screen shot 2018-10-24 at 8 27 39 am" src="https://user-images.githubusercontent.com/1085316/47430195-b5b56480-d766-11e8-92b0-2817863e234e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/351)
<!-- Reviewable:end -->
