### PR TITLE
Adds GMX condition on three alerts.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -497,6 +497,7 @@ groups:
     expr: |
       up{service="nodeexporter"} == 1
         unless on(machine) lame_duck_node
+        unless on(machine) gmx_machine_maintenance == 1
     for: 30m
     labels:
       repo: dev-tracker
@@ -515,6 +516,7 @@ groups:
     expr: |
       up{service="nodeexporter"} == 1
         unless on(machine) (vdlimit_used and vdlimit_total)
+        unless on(machine) gmx_machine_maintenance == 1
     for: 30m
     labels:
       repo: ops-tracker
@@ -549,6 +551,7 @@ groups:
     expr: |
       up{service="nodeexporter"} == 1
         unless on(machine) collectd_mlab_success
+        unless on(machine) gmx_machine_maintenance == 1
     for: 10m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
We observed these three alerts to fire on nodes booted from ePoxy, but which hadn't yet been configured to export the necessary metrics. We don't want these firing when the nodes/site are in maintenance mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/360)
<!-- Reviewable:end -->
