### PR TITLE
snmp_exporter w/ static outbound IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,59 @@ Delete the configmaps.
 
     kubectl delete configmap blackbox-config
 
+## SNMP Exporter
+
+The SNMP exporter allows probes of SNMP endpoints, mostly switches. However,
+the switches whitelist SNMP access by IP, so we need to do some special setup.
+We're going to create a two-node pool, make sure only services that need static
+outbound IPs run on it, and then use a service called [kubeIP](https://github.com/doitintl/kubeip)
+to assign static IPs to its nodes.
+
+## Create pool
+
+Create a two-node pool with a specific label (to make sure snmp-exporter can
+be selected onto it) and taint (to make sure other services are not run on it):
+```
+gcloud container node-pools create static-outbound-ip \
+--cluster=prometheus-federation --machine-type=n1-standard-8 --num-nodes=2 \
+--node-labels=outbound-ip=static --node-taints=outbound-ip=static:NoSchedule
+```
+
+## Create kubeIP credentials
+
+Create gcloud service-account for kubeIP:
+
+```
+gcloud iam service-accounts create kubeip-service-account --display-name "kubeIP"
+```
+Create role and attach the service-account to it:
+```
+gcloud iam roles create kubeip --project $GCLOUD_PROJECT --file config/kubeip/roles.yml
+gcloud projects add-iam-policy-binding $GCLOUD_PROJECT \
+--member serviceAccount:kubeip-service-account@$GCLOUD_PROJECT.iam.gserviceaccount.com \
+--role projects/$GCLOUD_PROJECT/roles/kubeip
+```
+Grab a key file for the service-account:
+```
+gcloud iam service-accounts keys create key.json --iam-account \
+kubeip-service-account@mlab-sandbox.iam.gserviceaccount.com
+```
+And then turn it into a Kubernetes secret:
+```
+kubectl create secret generic kubeip-key --from-file=key.json
+```
+Finally reserve static IPs for your new nodepool:
+```
+for i in {1..2}; do gcloud compute addresses create kubeip-ip$i \
+--project=$GCLOUD_PROJECT --region=us-central1; done
+```
+And label them for kubeIP:
+```
+for i in {1..2}; do gcloud beta compute addresses update kubeip-ip$i \
+--update-labels kubeip=$GCLOUD_PROJECT --region=us-central1; done
+```
+Then continue your deployment as normal.
+
 # Pushgateway
 
 A prometheus push gateway are useful for short-lived processes, or processes

--- a/README.md
+++ b/README.md
@@ -651,8 +651,8 @@ gcloud --project ${GCLOUD_PROJECT} \
     iam roles create kubeip --file config/federation/kubeip/roles.yml
 gcloud --project ${GCLOUD_PROJECT} \
     projects add-iam-policy-binding $GCLOUD_PROJECT \
-	--member serviceAccount:kubeip-service-account@$GCLOUD_PROJECT.iam.gserviceaccount.com \
-	--role projects/$GCLOUD_PROJECT/roles/kubeip
+    --member serviceAccount:kubeip-service-account@$GCLOUD_PROJECT.iam.gserviceaccount.com \
+    --role projects/$GCLOUD_PROJECT/roles/kubeip
 ```
 
 Grab a key file for the service-account:
@@ -660,7 +660,7 @@ Grab a key file for the service-account:
 ```
 gcloud --project ${GCLOUD_PROJECT} \
     iam service-accounts keys create key.json --iam-account \
-	kubeip-service-account@${GCLOUD_PROJECT}.iam.gserviceaccount.com
+    kubeip-service-account@${GCLOUD_PROJECT}.iam.gserviceaccount.com
 ```
 
 And then turn it into a Kubernetes secret:
@@ -675,7 +675,7 @@ Finally reserve static IPs for your new nodepool:
 ```
 for i in {1..2}; do
     gcloud --project ${GCLOUD_PROJECT} \
-	    compute addresses create kubeip-ip$i --region=us-central1
+        compute addresses create kubeip-ip$i --region=us-central1
 done
 ```
 
@@ -686,8 +686,8 @@ and `KUBEIP_LABELVALUE` values in the kubeIP deployment:
 ```
 for i in {1..2}; do
     gcloud --project ${GCLOUD_PROJECT} \
-	    beta compute addresses update kubeip-ip$i \
-		--update-labels kubeip=prometheus-federation --region=us-central1
+        beta compute addresses update kubeip-ip$i \
+        --update-labels kubeip=prometheus-federation --region=us-central1
 done
 ```
 

--- a/README.md
+++ b/README.md
@@ -647,30 +647,36 @@ gcloud iam service-accounts create kubeip-service-account --display-name "kubeIP
 Create role and attach the service-account to it:
 
 ```
-gcloud iam roles create kubeip --project $GCLOUD_PROJECT --file config/kubeip/roles.yml
-gcloud projects add-iam-policy-binding $GCLOUD_PROJECT \
---member serviceAccount:kubeip-service-account@$GCLOUD_PROJECT.iam.gserviceaccount.com \
---role projects/$GCLOUD_PROJECT/roles/kubeip
+gcloud --project ${GCLOUD_PROJECT} \
+    iam roles create kubeip --file config/federation/kubeip/roles.yml
+gcloud --project ${GCLOUD_PROJECT} \
+    projects add-iam-policy-binding $GCLOUD_PROJECT \
+	--member serviceAccount:kubeip-service-account@$GCLOUD_PROJECT.iam.gserviceaccount.com \
+	--role projects/$GCLOUD_PROJECT/roles/kubeip
 ```
 
 Grab a key file for the service-account:
 
 ```
-gcloud iam service-accounts keys create key.json --iam-account \
-kubeip-service-account@mlab-sandbox.iam.gserviceaccount.com
+gcloud --project ${GCLOUD_PROJECT} \
+    iam service-accounts keys create key.json --iam-account \
+	kubeip-service-account@${GCLOUD_PROJECT}.iam.gserviceaccount.com
 ```
 
 And then turn it into a Kubernetes secret:
 
 ```
-kubectl create secret generic kubeip-key --from-file=key.json
+kubectl --project ${GCLOUD_PROJECT} \
+    create secret generic kubeip-key --from-file=key.json
 ```
 
 Finally reserve static IPs for your new nodepool:
 
 ```
-for i in {1..2}; do gcloud compute addresses create kubeip-ip$i \
---project=$GCLOUD_PROJECT --region=us-central1; done
+for i in {1..2}; do
+    gcloud --project ${GCLOUD_PROJECT} \
+	    compute addresses create kubeip-ip$i --region=us-central1
+done
 ```
 
 And label them for kubeIP (use the same region as the GKE cluster). The
@@ -678,8 +684,11 @@ label `kubeip=prometheus-federation` corresponds to the `KUBEIP_LABELKEY`
 and `KUBEIP_LABELVALUE` values in the kubeIP deployment:
 
 ```
-for i in {1..2}; do gcloud beta compute addresses update kubeip-ip$i \
---update-labels kubeip=prometheus-federation --region=us-central1; done
+for i in {1..2}; do
+    gcloud --project ${GCLOUD_PROJECT} \
+	    beta compute addresses update kubeip-ip$i \
+		--update-labels kubeip=prometheus-federation --region=us-central1
+done
 ```
 
 Then continue your deployment as normal.

--- a/config/federation/kubeip/roles.yml
+++ b/config/federation/kubeip/roles.yml
@@ -1,0 +1,15 @@
+title: "kubeip"
+description: "required permissions to run KubeIP"
+stage: "GA"
+includedPermissions:
+- compute.addresses.list
+- compute.instances.addAccessConfig
+- compute.instances.deleteAccessConfig
+- compute.instances.get
+- compute.instances.list
+- compute.projects.get
+- container.clusters.get
+- container.clusters.list
+- resourcemanager.projects.get
+- compute.subnetworks.useExternalIp
+- compute.addresses.use

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -272,17 +272,16 @@ groups:
 
 # Prometheus is unable to get data from the snmp_exporter service.
   - alert: SnmpExporterDownOrMissing
-    expr: up{job="snmp-exporter"} == 0 or absent(up{job="snmp-exporter"})
+    expr: up{container="snmp-exporter"} == 0 or absent(up{container="snmp-exporter"})
     for: 10m
     labels:
       repo: dev-tracker
       severity: ticket
     annotations:
       summary: The snmp_exporter service is down or missing.
-      description: The snmp_exporter service runs in a Docker container on a
-        GCE VM named 'snmp-exporter' in each M-Lab GCP project. Look at the
-        Travis-CI builds/deploys for m-lab/snmp-exporter-support, or SSH to the
-        VM and poke around.
+      description: Check the status of Kubernetes clusters on each M-Lab GCP
+        project. Look at the travis deployment history for
+        m-lab/prometheus-support.
 
 # Some SNMP metrics are missing from Prometheus. These should always be present.
 # The wait period shouuld be longer than that for the SnmpExporterDownOrMissing

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -514,17 +514,6 @@ scrape_configs:
         replacement: blackbox-service.default.svc.cluster.local:9115
 
 
-  # Scrape config for the snmp_exporter. There is one snmp_exporter service
-  # running in a Docker container on a GCE VM in each GCP project.
-  #
-  # The snmp_exporter generates its own labels.
-  - job_name: 'snmp-exporter'
-    static_configs:
-      - targets:
-        - snmp-exporter.c.{{PROJECT}}.internal:9116
-        - snmp-exporter.c.{{PROJECT}}.internal:9100
-
-
   # SNMP configurations.
   - job_name: 'snmp-targets'
     metrics_path: /snmp

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -550,7 +550,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
+        replacement: snmp-exporter-service.default.svc.cluster.local:9116
 
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -28,21 +28,10 @@ spec:
             value: "prometheus-federation"
           - name: "KUBEIP_NODEPOOL"
             value: "static-outbound-ip"
-          - name: GOOGLE_APPLICATION_CREDENTIALS
+          - name: "GOOGLE_APPLICATION_CREDENTIALS"
             value: /var/secrets/google/key.json
         restartPolicy: Always
         serviceAccountName: kubeip
-        # kubeIP will only be scheduled onto nodes that we labeled
-        # as having a static outbound IP.
-        nodeSelector:
-          outbound-ip: static
-        # We can also taint nodes with static outbound IPs so that services that
-        # do not require a static IP aren't scheduled to that node. This 
-        # deployment, however, will tolerate that taint.
-        tolerations:
-        - key: "outbound-ip"
-          value: "static"
-          effect: "NoSchedule"
         volumes:
           - name: google-cloud-key
             secret:

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeip
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubeip
+  template:
+      metadata:
+        labels:
+          app: kubeip
+      spec:
+        priorityClassName: system-cluster-critical
+        containers:
+        - name: "kubeip"
+          image: doitintl/kubeip:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: google-cloud-key
+            mountPath: /var/secrets/google
+          env:
+          - name: "KUBEIP_LABELKEY"
+            value: "kubeip"
+          - name: "KUBEIP_LABELVALUE"
+            value: "prometheus-federation"
+          - name: "KUBEIP_NODEPOOL"
+            value: "static-outbound-ip"
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /var/secrets/google/key.json
+        restartPolicy: Always
+        serviceAccountName: kubeip
+        # kubeIP will only be scheduled onto nodes that we labeled
+        # as having a static outbound IP.
+        nodeSelector:
+          outbound-ip: static
+        # We can also taint nodes with static outbound IPs so that services that
+        # do not require a static IP aren't scheduled to that node. This 
+        # deployment, however, will tolerate that taint.
+        tolerations:
+        - key: "outbound-ip"
+          value: "static"
+          effect: "NoSchedule"
+        volumes:
+          - name: google-cloud-key
+            secret:
+              secretName: kubeip-key

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -16,18 +16,23 @@ spec:
         priorityClassName: system-cluster-critical
         containers:
         - name: "kubeip"
-          image: doitintl/kubeip:latest
+          image: doitintl/kubeip:issue-34
           imagePullPolicy: Always
           volumeMounts:
           - name: google-cloud-key
             mountPath: /var/secrets/google
           env:
+            # Key for GCP address labels
           - name: "KUBEIP_LABELKEY"
             value: "kubeip"
+            # Value for GCP address labels
           - name: "KUBEIP_LABELVALUE"
             value: "prometheus-federation"
+            # Nodepool to which KubeIP assigns addresses
           - name: "KUBEIP_NODEPOOL"
             value: "static-outbound-ip"
+            # GCP Application Default Credentials (ADS)
+            # See: https://cloud.google.com/docs/authentication/production
           - name: "GOOGLE_APPLICATION_CREDENTIALS"
             value: /var/secrets/google/key.json
         restartPolicy: Always

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -31,7 +31,7 @@ spec:
             # Nodepool to which KubeIP assigns addresses
           - name: "KUBEIP_NODEPOOL"
             value: "static-outbound-ip"
-            # GCP Application Default Credentials (ADS)
+            # GCP Application Default Credentials (ADC)
             # See: https://cloud.google.com/docs/authentication/production
           - name: "GOOGLE_APPLICATION_CREDENTIALS"
             value: /var/secrets/google/key.json

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: snmp-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: snmp-exporter
+  template:
+    metadata:
+      labels:
+        run: snmp-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - name: snmp-exporter
+        image: prom/snmp-exporter:v0.13.0
+        ports:
+        - containerPort: 9116
+      # The snmp-exporter will only be scheduled onto nodes that we labeled
+      # as having a static outbound IP.
+      nodeSelector:
+        outbound-ip: static
+      # We can also taint nodes with static outbound IPs so that services that
+      # do not require a static IP aren't scheduled to that node. This 
+      # deployment, however, will tolerate that taint.
+      tolerations:
+      - key: "outbound-ip"
+        value: "static"
+        effect: "NoSchedule"

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -15,6 +15,18 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      # Do an early fetch of the configuration so that snmp-exporter will start
+      initContainers:
+      - image: busybox
+        name: fetch
+        command:
+        - wget
+        - "-O"
+        - "/config/snmp.yml"
+        - "https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
+        volumeMounts:
+        - mountPath: /config
+          name: snmp-exporter-storage
       containers:
       - image: prom/snmp-exporter:v0.13.0
         name: snmp-exporter
@@ -23,7 +35,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/snmp_exporter
           name: snmp-exporter-storage
-          subPath: snmp-exporter
       # Pull the snmp-exporter configuration again so that we can watch it.
       - image: measurementlab/gcp-service-discovery:v1.0
         name: service-discovery
@@ -41,7 +52,6 @@ spec:
         # Mount snmp-exporter-storage for write access to the snmp_exporter configuration.
         - mountPath: /config
           name: snmp-exporter-storage
-          subPath: snmp-exporter
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
       - image: jimmidyson/configmap-reload:v0.2.2
@@ -59,7 +69,6 @@ spec:
         # Mount the snmp-exporter config volume so we can watch it for changes.
         - mountPath: /config
           name: snmp-exporter-storage
-          subPath: snmp-exporter
       # The snmp-exporter will only be scheduled onto nodes that we labeled
       # as having a static outbound IP.
       nodeSelector:
@@ -71,9 +80,7 @@ spec:
       - key: "outbound-ip"
         value: "static"
         effect: "NoSchedule"
-      # Disks created manually, can be named here explicitly using
-      # gcePersistentDisk instead of the persistentVolumeClaim.
+      # Use an emptyDir volume just to share config between containers.
       volumes:
       - name: snmp-exporter-storage
-        persistentVolumeClaim:
-          claimName: auto-prometheus-ssd0
+        emptyDir: {}

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -18,7 +18,7 @@ spec:
       # Pull the snmp-exporter configuration early so that it starts.
       initContainers:
       - image: measurementlab/gcp-service-discovery:v1.0
-        name: service-discovery
+        name: init-service-discovery
         args: [ "--http-target=/config/snmp.yml",
                 "--http-source=https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
                 "--project={{GCLOUD_PROJECT}}"]
@@ -30,9 +30,9 @@ spec:
             memory: "150Mi"
             cpu: "50m"
         volumeMounts:
-        # Mount prometheus-storage for write access to the snmp_exporter configuration.
+        # Mount snmp-exporter-storage for write access to the snmp_exporter configuration.
         - mountPath: /config
-          name: prometheus-storage
+          name: snmp-exporter-storage
           subPath: snmp-exporter
       containers:
       - image: prom/snmp-exporter:v0.13.0
@@ -41,7 +41,7 @@ spec:
         - containerPort: 9116
         volumeMounts:
         - mountPath: /etc/snmp_exporter
-          name: prometheus-storage
+          name: snmp-exporter-storage
           subPath: snmp-exporter
       # Pull the snmp-exporter configuration again so that we can watch it.
       - image: measurementlab/gcp-service-discovery:v1.0
@@ -57,9 +57,9 @@ spec:
             memory: "150Mi"
             cpu: "50m"
         volumeMounts:
-        # Mount prometheus-storage for write access to the snmp_exporter configuration.
+        # Mount snmp-exporter-storage for write access to the snmp_exporter configuration.
         - mountPath: /config
-          name: prometheus-storage
+          name: snmp-exporter-storage
           subPath: snmp-exporter
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
@@ -77,7 +77,7 @@ spec:
         volumeMounts:
         # Mount the snmp-exporter config volume so we can watch it for changes.
         - mountPath: /config
-          name: prometheus-storage
+          name: snmp-exporter-storage
           subPath: snmp-exporter
       # The snmp-exporter will only be scheduled onto nodes that we labeled
       # as having a static outbound IP.
@@ -90,3 +90,9 @@ spec:
       - key: "outbound-ip"
         value: "static"
         effect: "NoSchedule"
+      # Disks created manually, can be named here explicitly using
+      # gcePersistentDisk instead of the persistentVolumeClaim.
+      volumes:
+      - name: snmp-exporter-storage
+        persistentVolumeClaim:
+          claimName: auto-prometheus-ssd0

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -15,25 +15,6 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
-      # Pull the snmp-exporter configuration early so that it starts.
-      initContainers:
-      - image: measurementlab/gcp-service-discovery:v1.0
-        name: init-service-discovery
-        args: [ "--http-target=/config/snmp.yml",
-                "--http-source=https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
-                "--project={{GCLOUD_PROJECT}}"]
-        resources:
-          requests:
-            memory: "150Mi"
-            cpu: "50m"
-          limits:
-            memory: "150Mi"
-            cpu: "50m"
-        volumeMounts:
-        # Mount snmp-exporter-storage for write access to the snmp_exporter configuration.
-        - mountPath: /config
-          name: snmp-exporter-storage
-          subPath: snmp-exporter
       containers:
       - image: prom/snmp-exporter:v0.13.0
         name: snmp-exporter

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -23,7 +23,7 @@ spec:
         - wget
         - "-O"
         - "/config/snmp.yml"
-        - "https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
+        - "https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml"
         volumeMounts:
         - mountPath: /config
           name: snmp-exporter-storage

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -17,13 +17,12 @@ spec:
     spec:
       # Do an early fetch of the configuration so that snmp-exporter will start
       initContainers:
-      - image: busybox
-        name: fetch
-        command:
-        - wget
-        - "-O"
-        - "/config/snmp.yml"
-        - "https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml"
+      - name: fetch
+        image: gcr.io/cloud-builders/gsutil
+        args:
+        - cp
+        - gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
+        - /config/snmp.yml
         volumeMounts:
         - mountPath: /config
           name: snmp-exporter-storage
@@ -36,12 +35,13 @@ spec:
         - mountPath: /etc/snmp_exporter
           name: snmp-exporter-storage
       # Pull the snmp-exporter configuration again so that we can watch it.
-      # NOTE: Do not update gcp-service-discovery version.
-      - image: measurementlab/gcp-service-discovery:v1.0
-        name: service-discovery
-        args: [ "--http-target=/config/snmp.yml",
-                "--http-source=https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
-                "--project={{GCLOUD_PROJECT}}"]
+      # TODO: replace this bash-loop with a special-purpose container.
+      - name: service-discovery
+        image: gcr.io/cloud-builders/gsutil
+        command:
+        - bash
+        - -c
+        - "while true; do gsutil cp gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml /config/snmp.yml ; sleep 600 ; done"
         resources:
           requests:
             memory: "150Mi"
@@ -75,7 +75,7 @@ spec:
       nodeSelector:
         outbound-ip: static
       # We can also taint nodes with static outbound IPs so that services that
-      # do not require a static IP aren't scheduled to that node. This 
+      # do not require a static IP aren't scheduled to that node. This
       # deployment, however, will tolerate that taint.
       tolerations:
       - key: "outbound-ip"

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -3,7 +3,8 @@ kind: Deployment
 metadata:
   name: snmp-exporter
 spec:
-  replicas: 1
+  # Run two so that we can make sure we have failover.
+  replicas: 2
   selector:
     matchLabels:
       run: snmp-exporter
@@ -14,11 +15,70 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      # Pull the snmp-exporter configuration early so that it starts.
+      initContainers:
+      - image: measurementlab/gcp-service-discovery:v1.0
+        name: service-discovery
+        args: [ "--http-target=/config/snmp.yml",
+                "--http-source=https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
+                "--project={{GCLOUD_PROJECT}}"]
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "50m"
+          limits:
+            memory: "150Mi"
+            cpu: "50m"
+        volumeMounts:
+        # Mount prometheus-storage for write access to the snmp_exporter configuration.
+        - mountPath: /config
+          name: prometheus-storage
+          subPath: snmp-exporter
       containers:
-      - name: snmp-exporter
-        image: prom/snmp-exporter:v0.13.0
+      - image: prom/snmp-exporter:v0.13.0
+        name: snmp-exporter
         ports:
         - containerPort: 9116
+        volumeMounts:
+        - mountPath: /etc/snmp_exporter
+          name: prometheus-storage
+          subPath: snmp-exporter
+      # Pull the snmp-exporter configuration again so that we can watch it.
+      - image: measurementlab/gcp-service-discovery:v1.0
+        name: service-discovery
+        args: [ "--http-target=/config/snmp.yml",
+                "--http-source=https://storage.googleapis.com/switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml",
+                "--project={{GCLOUD_PROJECT}}"]
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "50m"
+          limits:
+            memory: "150Mi"
+            cpu: "50m"
+        volumeMounts:
+        # Mount prometheus-storage for write access to the snmp_exporter configuration.
+        - mountPath: /config
+          name: prometheus-storage
+          subPath: snmp-exporter
+      # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
+      # stable version.
+      - image: jimmidyson/configmap-reload:v0.2.2
+        name: configmap-reload
+        args: ["-webhook-url", "http://snmp-exporter.default.svc.cluster.local:9116/-/reload",
+               "-volume-dir", "/config"]
+        resources:
+          requests:
+            memory: "400Mi"
+            cpu: "200m"
+          limits:
+            memory: "400Mi"
+            cpu: "200m"
+        volumeMounts:
+        # Mount the snmp-exporter config volume so we can watch it for changes.
+        - mountPath: /config
+          name: prometheus-storage
+          subPath: snmp-exporter
       # The snmp-exporter will only be scheduled onto nodes that we labeled
       # as having a static outbound IP.
       nodeSelector:

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -36,6 +36,7 @@ spec:
         - mountPath: /etc/snmp_exporter
           name: snmp-exporter-storage
       # Pull the snmp-exporter configuration again so that we can watch it.
+      # NOTE: Do not update gcp-service-discovery version.
       - image: measurementlab/gcp-service-discovery:v1.0
         name: service-discovery
         args: [ "--http-target=/config/snmp.yml",

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -56,7 +56,7 @@ spec:
       # stable version.
       - image: jimmidyson/configmap-reload:v0.2.2
         name: configmap-reload
-        args: ["-webhook-url", "http://snmp-exporter.default.svc.cluster.local:9116/-/reload",
+        args: ["-webhook-url", "http://localhost:9116/-/reload",
                "-volume-dir", "/config"]
         resources:
           requests:

--- a/k8s/prometheus-federation/roles/rbac-kubeip.yml
+++ b/k8s/prometheus-federation/roles/rbac-kubeip.yml
@@ -1,0 +1,32 @@
+# Define a service account for kubeIP
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeip
+---
+# Allow kubeIP to keep an eye on nodes and pods
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubeip
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list","watch","patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list","watch"]
+---
+# Bind the kubeIP account to its role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeip
+subjects:
+  - kind: ServiceAccount
+    name: kubeip
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kubeip
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/prometheus-federation/services/snmp-exporter-service.yml
+++ b/k8s/prometheus-federation/services/snmp-exporter-service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    # We scrape snmp exporter instances through the pod auto discovery.
+    prometheus.io/scrape: 'false'
+  name: snmp-exporter-service
+  namespace: default
+spec:
+  ports:
+  - port: 9116
+    protocol: TCP
+    targetPort: 9116
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: snmp-exporter
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
This pull request adds the Prometheus snmp_exporter as a Kubernetes deployment. It also includes a gcp-service-discovery sidecar to automatically pull down the SNMP config from the switch-config bucket, and a configmap-reload sidecar to watch for changes and reload the exporter.

In order to facilitate static outbound IPs for switch whitelisting, it is necessary to create a new nodepool and assign static IPs to it. This pull request also includes a kubeIP deployment (which runs separately on the main nodepool) to monitor the nodes of the static nodepool and assign them IPs. Because setting up the nodepool and the necessary credentials for kubeip is outside the scope of Kubernetes, instructions on doing so via gcloud have been added to the README.

As currently running, before switching over sandbox to use this instance of snmp_exporter instead of the standalone VM, the IPs `35.224.169.63` and `35.226.122.118` will need to be added to the switch whitelists. Two additional IPs each will need to be allocated for the staging and oti prometheus-federation clusters, using the directions in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/362)
<!-- Reviewable:end -->
