### PR TITLE
Add new kubeip permission compute.networks.useExternalIp

### DIFF
--- a/config/federation/kubeip/roles.yml
+++ b/config/federation/kubeip/roles.yml
@@ -11,5 +11,6 @@ includedPermissions:
 - container.clusters.get
 - container.clusters.list
 - resourcemanager.projects.get
+- compute.networks.useExternalIp
 - compute.subnetworks.useExternalIp
 - compute.addresses.use


### PR DESCRIPTION
This change adds an additional permission needed by kubeip for some network configurations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/374)
<!-- Reviewable:end -->
