### PR TITLE
Use snmp exporter VM until all VMs are updated

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -550,7 +550,9 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        replacement: snmp-exporter-service.default.svc.cluster.local:9116
+        # TODO: enable once all switches are updated.
+        # replacement: snmp-exporter-service.default.svc.cluster.local:9116
+        replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
 
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.


### PR DESCRIPTION
TBR -- until all switches are updated with the new IP whitelist, we should continue to use the snmp-exporter VMs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/376)
<!-- Reviewable:end -->
