### PR TITLE
Disable collection of gardener traceroute metrics

### DIFF
--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -20,11 +20,12 @@ FROM (
       "sidestream" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
     FROM
       `{{PROJECT}}.base_tables.sidestream`
-  UNION ALL
-    SELECT
-      "traceroute" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
-    FROM
-      `{{PROJECT}}.base_tables.traceroute`
+-- TODO: enable once the traceroute parser is reenabled.
+--  UNION ALL
+--    SELECT
+--      "traceroute" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time
+--    FROM
+--      `{{PROJECT}}.base_tables.traceroute`
   UNION ALL
     SELECT
       "switch" AS dataset, MAX(parse_time) AS max_parse_time, MIN(parse_time) AS min_parse_time


### PR DESCRIPTION
Before starting the long term plan for the traceroute parser (https://github.com/m-lab/etl/issues/590), we are disabling the etl gardener instance for traceroute (https://github.com/m-lab/etl-gardener/pull/119). This change removes traceroute from the metrics that we alert on for the gardener SLO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/378)
<!-- Reviewable:end -->
