### PR TITLE
Change condition to use rates

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -690,7 +690,7 @@ groups:
 # deployed (ideally with a fix).
   - alert: ETL_ParserPanicNonZero
     expr: irate(etl_panic_count[4m]) > 0
-    for: 10m
+    for: 5m
     labels:
       repo: dev-tracker
       severity: ticket

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -685,9 +685,11 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/eBbUW6oik
 
 # ETL_ParserPanicNonZero fires when an ETL parser panics. The number of panics
-# should always be zero because a panic indicates a bug in the parser. The
-# alert will continue to fire until the parser is restarted or a new version is
-# deployed (ideally with a fix).
+# may increase due to a transient issue or a short-lived trigger for a parser
+# bug. The alert will fire as long as the rate is above zero for more than 5
+# minutes. So, it's possible for false-negatives in response to isolated events,
+# but it also allows the alert to stop firing without a redeploy when the event
+# is short-lived.
   - alert: ETL_ParserPanicNonZero
     expr: irate(etl_panic_count[4m]) > 0
     for: 5m

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -689,7 +689,7 @@ groups:
 # alert will continue to fire until the parser is restarted or a new version is
 # deployed (ideally with a fix).
   - alert: ETL_ParserPanicNonZero
-    expr: etl_panic_count > 0
+    expr: irate(etl_panic_count[4m]) > 0
     for: 10m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
This change updates the ETL panic alert to use a rate rather than the absolute count so that an instance can continue running without firing an alert if it only ever experiences a finite number of panics.

With this change the instance would have to have a non-zero increase in panics for more than 5m. So, this would not alert on isolated panics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/379)
<!-- Reviewable:end -->
