### PR TITLE
Use snmp service running on GKE cluster

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -550,9 +550,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        # TODO: enable once all switches are updated.
-        # replacement: snmp-exporter-service.default.svc.cluster.local:9116
-        replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
+        replacement: snmp-exporter-service.default.svc.cluster.local:9116
 
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.


### PR DESCRIPTION
After updating all switches with the new kubeip static IPs, https://github.com/m-lab/ops-tracker/issues/551 this change modifies the default prometheus configuration to scrape the local snmp exporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/380)
<!-- Reviewable:end -->
