### PR TITLE
Add instructions to select project before running kubectl to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,11 +663,14 @@ gcloud --project ${GCLOUD_PROJECT} \
     kubeip-service-account@${GCLOUD_PROJECT}.iam.gserviceaccount.com
 ```
 
-And then turn it into a Kubernetes secret:
+And then turn it into a Kubernetes secret, after making sure the right project
+is selected for kubectl:
 
 ```
-kubectl --project ${GCLOUD_PROJECT} \
-    create secret generic kubeip-key --from-file=key.json
+gcloud container clusters get-credentials prometheus-federation `
+    --zone us-central1-a --project ${GCLOUD_PROJECT}
+
+kubectl create secret generic kubeip-key --from-file=key.json
 ```
 
 Finally reserve static IPs for your new nodepool:


### PR DESCRIPTION
A project must be selected explicitly before running kubectl, or it will run in the previously selected project (which may or may not be the one we want to operate on).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/389)
<!-- Reviewable:end -->
