### PR TITLE
Revert "Revert "Use snmp service running on gke cluster""

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -550,9 +550,7 @@ scrape_configs:
       - source_labels: []
         regex: .*
         target_label: __address__
-        # TODO: enable once all switches are updated.
-        # replacement: snmp-exporter-service.default.svc.cluster.local:9116
-        replacement: snmp-exporter.c.{{PROJECT}}.internal:9116
+        replacement: snmp-exporter-service.default.svc.cluster.local:9116
 
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.


### PR DESCRIPTION
This will make Prometheus scrape SNMP metrics from the instance deployed on GKE again.
It was originally reverted because the snmp-exporter service was failing to start, thus metrics could not be collected yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/391)
<!-- Reviewable:end -->
