### PR TITLE
Change high disk usage threshold for NPAD to 9GB

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -559,7 +559,7 @@ groups:
       description: Check /var/spool/iupui_npad/ on the node to see if data is
         being collected. If not, then check the health of scraper for this node
         and slice. If so, then check or other sources of disk usage, like
-        /var/logs.
+        /var/logs and /home/iupui_npad/VAR/logs/paris-traceroute.log.
 
 # A collectd-mlab service has a problem and is down.
   - alert: CoreServices_CollectdMlabDown

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -546,15 +546,10 @@ groups:
         /etc/cron.d/prom_vdlimit_metrics.cron.
       dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/JAq7W6Nmk/
 
-# NPAD_VdlimitTooMuchUsedDisk checks whether NPAD is using more local storage
-# than scraper can support when all files are small (i.e. from
-# paris-traceroute).
-#
-# Note: the threshold is calculated from the number of default inodes allocated
-# in scraper disks (~700k) and the average paris-traceroute file size (~3800b)
-# plus the minimal experiment filesystem size (~1.2GB).
+# NPAD_VdlimitTooMuchUsedDisk checks whether the disk usage for the NPAD vserver
+# is higher than 9GB (90%, as NPAD is set up with a 10GB disk).
   - alert: NPAD_VdlimitTooMuchUsedDisk
-    expr: vdlimit_used{experiment="npad.iupui"} > 3.5*1024*1024
+    expr: vdlimit_used{experiment="npad.iupui"} > 9*1024*1024
     for: 30m
     labels:
       repo: ops-tracker


### PR DESCRIPTION
This PR updates alerts.yml to change the disk usage threshold from 3.5GB to 9GB, since the condition which previously led us to set it to 3.5GB just happened once and on a different slice.
It also adds a mention of the `paris-traceroute.log` files which keeps growing indefinitely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/394)
<!-- Reviewable:end -->
