### PR TITLE
Add k8s-platform data sources

### DIFF
--- a/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-oti.yml.template
@@ -1,0 +1,14 @@
+# config file version
+apiVersion: 1
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources:
+- name: k8s platform (mlab-oti)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://k8s-prometheus.mlab-oti.measurementlab.net:9090
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false

--- a/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-sandbox.yml.template
@@ -1,0 +1,14 @@
+# config file version
+apiVersion: 1
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources:
+- name: k8s platform (mlab-sandbox)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://k8s-prometheus.mlab-sandbox.measurementlab.net:9090
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false

--- a/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/k8s-platform_mlab-staging.yml.template
@@ -1,0 +1,14 @@
+# config file version
+apiVersion: 1
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources:
+- name: k8s platform (mlab-staging)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://k8s-prometheus.mlab-staging.measurementlab.net:9090
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false


### PR DESCRIPTION
This change adds pre-defined data sources for the k8s platform instances of  prometheus.

This change includes a definition for mlab-oti for convenience even though that deployment does not yet exist.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/395)
<!-- Reviewable:end -->
