### PR TITLE
Bumps GMX image tag from v0.1 to v0.1.2, which is a bugfix version.

### DIFF
--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -23,7 +23,7 @@ spec:
         run: gmx-server
     spec:
       containers:
-      - image: measurementlab/github-maintenance-exporter:v0.1
+      - image: measurementlab/github-maintenance-exporter:v0.1.2
         name: gmx-server
         args: ["--storage.state-file=/var/lib/gmx/gmx-state"]
         env:


### PR DESCRIPTION
There was [a bug in GMX](https://github.com/m-lab/github-maintenance-exporter/issues/15), which has since been resolved, so we need a new version of the GMX image deployed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/396)
<!-- Reviewable:end -->
