### PR TITLE
Update version of gcp-service-discovery and increase CPU alloc

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -166,7 +166,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/gcp-service-discovery:v1.0
+      - image: measurementlab/gcp-service-discovery:v1.1
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",
@@ -211,13 +211,15 @@ spec:
                 "--http-target=/targets/blackbox-targets/switches_ping.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/switches_ping.json",
                 "--project={{GCLOUD_PROJECT}}"]
+        ports:
+          - containerPort: 9373
         resources:
           requests:
             memory: "150Mi"
-            cpu: "50m"
+            cpu: "150m"
           limits:
             memory: "150Mi"
-            cpu: "50m"
+            cpu: "150m"
         volumeMounts:
         # Mount the the prometheus-storage for write access to the target
         # directories.

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -166,7 +166,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/gcp-service-discovery:v1.0
+      - image: measurementlab/gcp-service-discovery:v1.2
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -167,7 +167,7 @@ spec:
           name: prometheus-storage
 
           # - image: measurementlab/gcp-service-discovery:v1.2
-      - image: soltesz/gcp-service-discovery:0.1
+      - image: soltesz/gcp-service-discovery:v0.1
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -166,7 +166,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/gcp-service-discovery:v1.1
+      - image: measurementlab/gcp-service-discovery:v1.0
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -166,7 +166,8 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-      - image: measurementlab/gcp-service-discovery:v1.2
+          # - image: measurementlab/gcp-service-discovery:v1.2
+      - image: soltesz/gcp-service-discovery:0.1
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -166,8 +166,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-storage
 
-          # - image: measurementlab/gcp-service-discovery:v1.2
-      - image: soltesz/gcp-service-discovery:v0.1
+      - image: measurementlab/gcp-service-discovery:v1.3
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",


### PR DESCRIPTION
This change includes a new version of the gcp-service-discovery, which now collects and exports Prometheus metrics related to it's behavior and environment. This also increases the CPU alloc for that container to make sure it is not CPU starved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/397)
<!-- Reviewable:end -->
