### PR TITLE
Add job to scrape the GCE VM epoxy-boot-api target

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -299,6 +299,10 @@ scrape_configs:
     static_configs:
       - targets: ['dns.measurementlab.net:9100']
 
+  # Scrape config for the epoxy-boot-api.
+  - job_name: 'epoxy-boot-api'
+    static_configs:
+      - targets: ['epoxy-boot-api.{{PROJECT}}.measurementlab.net:9000']
 
   # Scrape config for federation.
   #


### PR DESCRIPTION
This change adds a new job to scrape the epoxy-boot-api server.

This change is necessary because the epoxy server no longer runs in AppEngine and gcp-service-discovery will no longer automatically discover it. We could one day enable GCE service discovery (natively supported by prometheus) if that is better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/404)
<!-- Reviewable:end -->
