### PR TITLE
Add alert and dashboard for the epoxy server.

### DIFF
--- a/config/federation/grafana/dashboards/Boot_Machines.json
+++ b/config/federation/grafana/dashboards/Boot_Machines.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 251,

--- a/config/federation/grafana/dashboards/Boot_ePoxy_Server.json
+++ b/config/federation/grafana/dashboards/Boot_ePoxy_Server.json
@@ -1,0 +1,273 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 252,
+  "iteration": 1551399244725,
+  "links": [],
+  "panels": [
+    {
+      "content": "# Help\n\nThere's not much here. Please add a new panel that helps you answer the question you're investigating now.\n\n## Ideas\n\n* Links to cloud builder in each project\n* Links to stack driver\n* Links to list of relevant GCE VMs",
+      "gridPos": {
+        "h": 9,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": false,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 4,
+        "y": 0
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "up{job=\"epoxy-boot-api\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Online",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ePoxy Boot API is online",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 4,
+        "y": 9
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(epoxy_stage1_total[1h]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "boots / hr",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Boot Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus (mlab-staging)",
+          "value": "Prometheus (mlab-staging)"
+        },
+        "hide": 1,
+        "label": null,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/Prometheus/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Boot: ePoxy Server",
+  "uid": "t_juk39ik",
+  "version": 2
+}

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -843,3 +843,19 @@ groups:
         Check the k8s setup logs on the machine (/tmp/setup_k8s.log). Check the
         epoxy-boot-api VM logs in Stackdriver.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/JaSyFC9mk/boot-nodes
+
+# Boot_EpoxyServerOfflineOrMissing a machine has failed to boot for more than a
+# day.
+  - alert: Boot_EpoxyServerOfflineOrMissing
+    expr: up{job="epoxy-boot-api"} == 0 or absent(up{job="epoxy-boot-api"})
+    for: 30m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      summary: The ePoxy boot api server is down or missing. Nodes cannot boot!
+      description: Has the configuration been removed from prometheus? Is the
+        service running? Check for the epoxy-boot-api-* VM. Check for recent
+        failed Cloud Builder builds caused by recent commits; check those logs.
+        Check the VM service logs from Stackdriver.
+      dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/t_juk39ik/boot-epoxy-server

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -844,8 +844,8 @@ groups:
         epoxy-boot-api VM logs in Stackdriver.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/JaSyFC9mk/boot-nodes
 
-# Boot_EpoxyServerOfflineOrMissing a machine has failed to boot for more than a
-# day.
+# Boot_EpoxyServerOfflineOrMissing fires when the epoxy boot api server is
+# offline or misconfigured.
   - alert: Boot_EpoxyServerOfflineOrMissing
     expr: up{job="epoxy-boot-api"} == 0 or absent(up{job="epoxy-boot-api"})
     for: 30m


### PR DESCRIPTION
This change adds a new alert for the epoxy server itself to make sure that it is online and metrics exist.

This also includes a basic target dashboard for the alert.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/413)
<!-- Reviewable:end -->
