### PR TITLE
Add monitoring and alert for prometheus in cluster master

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -859,4 +859,22 @@ groups:
         service running? Check for the epoxy-boot-api-* VM. Check for recent
         failed Cloud Builder builds caused by recent commits; check those logs.
         Check the VM service logs from Stackdriver.
-      dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/t_juk39ik/boot-epoxy-server
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/t_juk39ik/boot-epoxy-server
+
+# ClusterDown_PlatformMaster extends the ClusterDown alert to apply only to the
+# platform cluster instance of prometheus.
+# TODO: retire this alert in favor of ClusterDown when possible.
+  - alert: ClusterDown_PlatformMaster
+    expr: up{job="k8s-prometheus"}
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: page
+    annotations:
+      summary: Prometheus is down on the k8s platform master.
+      description: Prometheus instance on the platform cluster appears to be
+        down. This makes investigation using Prometheus impossible. Log into a
+        k8s master node. Verify that the cluster is healthy. Verify that the
+        node is connected to the cluster. Verify the Prometheus deployment is
+        running using - `kubectl get pods`. Check pod logs.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -281,18 +281,21 @@ scrape_configs:
         action: replace
         target_label: kubernetes_name
 
+  # Monitor whether we can monitor the k8s platform master.
+  # TODO: add to federation-targets job.
+  - job_name: 'k8s-prometheus'
+    static_configs:
+      - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'
     static_configs:
       - targets: ['eb.measurementlab.net:9100']
 
-
   # Scrape config for the node_exporter on mirror.measurementlab.net.
   - job_name: 'mirror-node-exporter'
     static_configs:
       - targets: ['mirror.measurementlab.net:9100']
-
 
   # Scrape config for the node_exporter on dns.measurementlab.net.
   - job_name: 'dns-node-exporter'


### PR DESCRIPTION
This change adds a static target to the prometheus config to monitor the prometheus instance running in the k8s platform master cluster.

Ultimately, we should remove this static config in favor of the `federation-targets` monitoring once we trust that the shorter wait time in the `ClusterDown` alert is safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/416)
<!-- Reviewable:end -->
