### PR TITLE
Fix down or missing alert for k8s prometheus

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -861,11 +861,11 @@ groups:
         Check the VM service logs from Stackdriver.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/t_juk39ik/boot-epoxy-server
 
-# ClusterDown_PlatformMaster extends the ClusterDown alert to apply only to the
-# platform cluster instance of prometheus.
+# Cluster_PlatformMasterDownOrMissing extends the ClusterDown alert to apply
+# only to the platform cluster instance of prometheus.
 # TODO: retire this alert in favor of ClusterDown when possible.
-  - alert: ClusterDown_PlatformMaster
-    expr: up{job="k8s-prometheus"}
+  - alert: Cluster_PlatformMasterDownOrMissing
+    expr: up{job="k8s-prometheus"} == 0 or absent(up{job="k8s-prometheus"})
     for: 1h
     labels:
       repo: ops-tracker


### PR DESCRIPTION
The previous expression did not work correctly.

This change uses the more common pattern in our alerts to check for 'down or missing' condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/417)
<!-- Reviewable:end -->
