### PR TITLE
Make epoxy machine boot failure GMX aware

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -833,6 +833,7 @@ groups:
 # Boot_MachineFailedToBoot a machine has failed to boot for more than a day.
   - alert: Boot_MachineFailedToBoot
     expr: epoxy_last_success < epoxy_last_boot
+      unless on(machine) (lame_duck_node == 1 or gmx_machine_maintenance == 1)
     for: 24h
     labels:
       repo: dev-tracker


### PR DESCRIPTION
Machines with known issues should not cause this alert to fire.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/418)
<!-- Reviewable:end -->
