### PR TITLE
Expands k8s-prometheus scrape job and adds three new k8s-platform alerts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -901,7 +901,7 @@ groups:
     expr: |
       up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(node) (
           label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
         )
     for: 1h
     labels:
@@ -934,7 +934,7 @@ groups:
     expr: |
       up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(node) (
           label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
         )
     for: 1h
     labels:
@@ -967,7 +967,7 @@ groups:
     expr: |
       up{deployment="ndt", job="platform-cluster"} == 0 unless on(node) (
           label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
         )
     for: 1h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -899,9 +899,10 @@ groups:
   # the entire node is down.
   - alert: PlatformCluster_NodeExporterDown
     expr: |
-      up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
+      up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(machine) (
+          lame_duck_node == 1 or
+          gmx_machine_maintenance == 1 or
+          up{job="kubernetes-nodes"} == 0
         )
     for: 1h
     labels:
@@ -932,9 +933,10 @@ groups:
   # entire node is down.
   - alert: PlatformCluster_CadvisorDown
     expr: |
-      up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
+      up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(machine) (
+          lame_duck_node == 1 or
+          gmx_machine_maintenance == 1 or
+          up{job="kubernetes-nodes"} == 0
         )
     for: 1h
     labels:
@@ -965,9 +967,10 @@ groups:
   # node is down.
   - alert: PlatformCluster_NdtDown
     expr: |
-      up{deployment="ndt", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
-          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)") == 0
+      up{deployment="ndt", job="platform-cluster"} == 0 unless on(machine) (
+          lame_duck_node == 1 or
+          gmx_machine_maintenance == 1 or
+          up{job="kubernetes-nodes"} == 0
         )
     for: 1h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -879,3 +879,51 @@ groups:
         node is connected to the cluster. Verify the Prometheus deployment is
         running using - `kubectl get pods`. Check pod logs.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+
+  - alert: Cluster_PlatformNodeExporterDownOrMissing
+    expr: |
+      up{deployment="node-exporter", cluster="k8s-platform"} == 0 or
+        absent(up{deployment="node-exporter", cluster="k8s-platform"})
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: At least one node-exporter instance is down on the k8s-platform cluster.
+      description: At least one node-exporter instance is down. Verify that
+        the node-exporter DaemonSet is healthy. Maybe there is a node down
+        causing node-exporter to be down on that node too? Try using `kubectl
+        get nodes` to view node states, and `kubectl get pods` to see pod state.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: Cluster_PlatformCadvisorDownOrMissing
+    expr: |
+      up{deployment="cadvisor", cluster="k8s-platform"} == 0 or
+        absent(up{deployment="cadvisor", cluster="k8s-platform"})
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: At least one CAdvisor instance is down on the k8s-platform cluster.
+      description: At least one CAdvisor instance is down. Verify that the
+        CAdvisor DaemonSet is healthy. Maybe there is a node down causing
+        CAdvisor to be down on that node too? Try using `kubectl get nodes` to
+        view node states, and `kubectl get pods` to see pod state.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: Cluster_PlatformNdtDownOrMissing
+    expr: |
+      up{deployment="ndt", cluster="k8s-platform"} == 0 or
+        absent(up{deployment="ndt", cluster="k8s-platform"})
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: At least one NDT instance is down on the k8s-platform cluster.
+      description: At least one NDT instance is down. Verify that the NDT
+        DaemonSet is healthy. Maybe there is a node down causing NDT to be down
+        on that node too? Try using `kubectl get nodes` to view node states, and
+        `kubectl get pods` to see pod state.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -900,7 +900,7 @@ groups:
   - alert: PlatformCluster_NodeExporterDown
     expr: |
       up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
           label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
         )
     for: 1h
@@ -933,7 +933,7 @@ groups:
   - alert: PlatformCluster_CadvisorDown
     expr: |
       up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
           label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
         )
     for: 1h
@@ -966,7 +966,7 @@ groups:
   - alert: PlatformCluster_NdtDown
     expr: |
       up{deployment="ndt", job="platform-cluster"} == 0 unless on(node) (
-          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
           label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
         )
     for: 1h

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -865,7 +865,7 @@ groups:
 # Cluster_PlatformMasterDownOrMissing extends the ClusterDown alert to apply
 # only to the platform cluster instance of prometheus.
 # TODO: retire this alert in favor of ClusterDown when possible.
-  - alert: Cluster_PlatformMasterDownOrMissing
+  - alert: PlatformCluster_DownOrMissing
     expr: up{job="k8s-prometheus"} == 0 or absent(up{job="k8s-prometheus"})
     for: 1h
     labels:
@@ -880,7 +880,7 @@ groups:
         running using - `kubectl get pods`. Check pod logs.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
-  - alert: Cluster_PlatformNodeExporterDownOrMissing
+  - alert: PlatformCluster_NodeExporterDownOrMissing
     expr: |
       up{deployment="node-exporter", cluster="k8s-platform"} == 0 or
         absent(up{deployment="node-exporter", cluster="k8s-platform"})
@@ -896,7 +896,7 @@ groups:
         get nodes` to view node states, and `kubectl get pods` to see pod state.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  - alert: Cluster_PlatformCadvisorDownOrMissing
+  - alert: PlatformCluster_CadvisorDownOrMissing
     expr: |
       up{deployment="cadvisor", cluster="k8s-platform"} == 0 or
         absent(up{deployment="cadvisor", cluster="k8s-platform"})
@@ -912,7 +912,7 @@ groups:
         view node states, and `kubectl get pods` to see pod state.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  - alert: Cluster_PlatformNdtDownOrMissing
+  - alert: PlatformCluster_NdtDownOrMissing
     expr: |
       up{deployment="ndt", cluster="k8s-platform"} == 0 or
         absent(up{deployment="ndt", cluster="k8s-platform"})

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -862,68 +862,121 @@ groups:
         Check the VM service logs from Stackdriver.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/t_juk39ik/boot-epoxy-server
 
-# Cluster_PlatformMasterDownOrMissing extends the ClusterDown alert to apply
-# only to the platform cluster instance of prometheus.
+# PlatformCluster_DownOrMissing extends the ClusterDown alert to apply only to
+# the platform cluster instance of Prometheus.
 # TODO: retire this alert in favor of ClusterDown when possible.
   - alert: PlatformCluster_DownOrMissing
-    expr: up{job="k8s-prometheus"} == 0 or absent(up{job="k8s-prometheus"})
+    expr: up{job="platform-cluster"} == 0 or absent(up{job="platform-cluster"})
     for: 1h
     labels:
       repo: ops-tracker
       severity: page
     annotations:
-      summary: Prometheus is down on the k8s platform master.
-      description: Prometheus instance on the platform cluster appears to be
-        down. This makes investigation using Prometheus impossible. Log into a
-        k8s master node. Verify that the cluster is healthy. Verify that the
-        node is connected to the cluster. Verify the Prometheus deployment is
-        running using - `kubectl get pods`. Check pod logs.
+      summary: Prometheus is down on the k8s platform cluster.
+      description: The Prometheus instance on the platform cluster appears to
+        be down. This makes investigation using Prometheus impossible. Verify
+        ithat the node where Prometheus should be running is healthy (`kubectl
+        get nodes --selector run=prometheus-server`). Verify that the node is
+        connected to the cluster. Verify the Prometheus deployment is running
+        using - `kubectl get pods`. Check pod logs.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
-  - alert: PlatformCluster_NodeExporterDownOrMissing
-    expr: |
-      up{deployment="node-exporter", cluster="k8s-platform"} == 0 or
-        absent(up{deployment="node-exporter", cluster="k8s-platform"})
-    for: 1h
+  - alert: PlatformCluster_NodeExporterMissing
+    expr: absent(up{deployment="node-exporter", job="platform-cluster"})
+    for: 5m
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: At least one node-exporter instance is down on the k8s-platform cluster.
-      description: At least one node-exporter instance is down. Verify that
-        the node-exporter DaemonSet is healthy. Maybe there is a node down
-        causing node-exporter to be down on that node too? Try using `kubectl
-        get nodes` to view node states, and `kubectl get pods` to see pod state.
+      summary: The node_exporter DaemonSet is missing or has no metrics.
+      description: The node_exporter DaemonSet is missing or has no metrics.
+        Verify that the DaemonSet is healthy (`kubectl describe ds
+        node-exporter`).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  - alert: PlatformCluster_CadvisorDownOrMissing
+  # If a node_exporter pod is down or otherwise broken, fire an alert, unless
+  # the node is in lame-duck mode, GMX maintenance mode, or the scrape job for
+  # the entire node is down.
+  - alert: PlatformCluster_NodeExporterDown
     expr: |
-      up{deployment="cadvisor", cluster="k8s-platform"} == 0 or
-        absent(up{deployment="cadvisor", cluster="k8s-platform"})
+      up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(node) (
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+        )
     for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: At least one CAdvisor instance is down on the k8s-platform cluster.
-      description: At least one CAdvisor instance is down. Verify that the
-        CAdvisor DaemonSet is healthy. Maybe there is a node down causing
-        CAdvisor to be down on that node too? Try using `kubectl get nodes` to
-        view node states, and `kubectl get pods` to see pod state.
+      summary: At least one node has a broken or no node_exporter pod.
+      description: At least one node has a broken or no node_exporter pod.
+        Verify that the DaemonSet is healthy. Check the status of the node that
+        the pod is supposed to be running on. Check the status of the pod
+        itself, if it exists.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  - alert: PlatformCluster_NdtDownOrMissing
+  - alert: PlatformCluster_CadvisorMissing
+    expr: absent(up{deployment="cadvisor", job="platform-cluster"})
+    for: 5m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The CAdvisor DaemonSet is missing or has no metrics.
+      description: The CAdvisor DaemonSet is missing or has no metrics. Verify that
+        the DaemonSet is healthy (`kubectl describe ds cadvisor`).
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  # If a CAdvisor pod is down or otherwise broken, fire an alert, unless the
+  # node is in lame-duck mode, GMX maintenance mode, or the scrape job for the
+  # entire node is down.
+  - alert: PlatformCluster_CadvisorDown
     expr: |
-      up{deployment="ndt", cluster="k8s-platform"} == 0 or
-        absent(up{deployment="ndt", cluster="k8s-platform"})
+      up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(node) (
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+        )
     for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: At least one NDT instance is down on the k8s-platform cluster.
-      description: At least one NDT instance is down. Verify that the NDT
-        DaemonSet is healthy. Maybe there is a node down causing NDT to be down
-        on that node too? Try using `kubectl get nodes` to view node states, and
-        `kubectl get pods` to see pod state.
+      summary: At least one node has a broken or no CAdvisor pod.
+      description: At least one node has a broken or no CAdvisor pod. Verify that
+        the DaemonSet is healthy. Check the status of the node that the pod is
+        supposed to be running on. Check the status of the pod itself, if it
+        exists.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: PlatformCluster_NdtMissing
+    expr: absent(up{deployment="ndt", job="platform-cluster"})
+    for: 5m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The NDT DaemonSet is missing or has no metrics.
+      description: The NDT DaemonSet is missing or has no metrics. Verify that
+        the DaemonSet is healthy (`kubectl describe ds ndt`).
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  # If a NDT pod is down or otherwise broken, fire an alert, unless the node is
+  # in lame-duck mode, GMX maintenance mode, or the scrape job for the entire
+  # node is down.
+  - alert: PlatformCluster_NdtDown
+    expr: |
+      up{deployment="ndt", job="platform-cluster"} == 0 unless on(node) (
+          label_replace(lame_duck_node == 1 or gmx_machine_maintenance == 1 "node", "$1", "machine", "(.*)") or
+          label_replace(up{job="kubernetes-nodes"}, "node", "$1", "kubernetes_io_hostname", "(.*)")
+        )
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: At least one node has a broken or no NDT pod.
+      description: At least one node has a broken or no NDT pod. Verify that
+        the DaemonSet is healthy. Check the status of the node that the pod
+        is supposed to be running on. Check the status of the pod itself, if it
+        exists.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -294,6 +294,11 @@ scrape_configs:
         - 'up{job=~".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
+        # Add a unique label that will allow us to 100% we are selecting
+        # metrics from the k8s-platform cluster, since other clusters runs many
+        # of the same services (e.g., cadvisor)
+        labels:
+          cluster: 'k8s-platform'
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -284,6 +284,14 @@ scrape_configs:
   # Monitor whether we can monitor the k8s platform master.
   # TODO: add to federation-targets job.
   - job_name: 'k8s-prometheus'
+    honor_labels: true
+    metrics_path: '/federate'
+    params:
+      'match[]':
+	# Scrape the status of all jobs. This should allow us determine
+	# whether, for example, node_exporter is failing to be scraped
+	# somewhere.
+	- 'up{job=".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
 
@@ -344,7 +352,6 @@ scrape_configs:
           - /federation-targets/*.json
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
-
 
   # Blackbox configurations.
   #

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -291,7 +291,7 @@ scrape_configs:
 	# Scrape the status of all jobs. This should allow us determine
 	# whether, for example, node_exporter is failing to be scraped
 	# somewhere.
-	- 'up{job=".+"}'
+        - 'up{job=".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -283,7 +283,7 @@ scrape_configs:
 
   # Monitor whether we can monitor the k8s platform master.
   # TODO: add to federation-targets job.
-  - job_name: 'k8s-prometheus'
+  - job_name: 'platform-cluster'
     honor_labels: true
     metrics_path: '/federate'
     params:
@@ -294,11 +294,6 @@ scrape_configs:
         - 'up{job=~".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
-        # Add a unique label that will allow us to 100% we are selecting
-        # metrics from the k8s-platform cluster, since other clusters runs many
-        # of the same services (e.g., cadvisor)
-        labels:
-          cluster: 'k8s-platform'
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -287,10 +287,10 @@ scrape_configs:
     honor_labels: true
     metrics_path: '/federate'
     params:
+      # Scrape the status of all jobs. This should allow us determine
+      # whether, for example, node_exporter is failing to be scraped
+      # somewhere, as well as other core and experiment services."
       'match[]':
-	# Scrape the status of all jobs. This should allow us determine
-	# whether, for example, node_exporter is failing to be scraped
-	# somewhere.
         - 'up{job=".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -291,7 +291,7 @@ scrape_configs:
       # whether, for example, node_exporter is failing to be scraped
       # somewhere, as well as other core and experiment services."
       'match[]':
-        - 'up{job=".+"}'
+        - 'up{job=~".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
 


### PR DESCRIPTION
This PR aims to at least partially resolve issue m-lab/k8s-support#142. It expands the scrape job that currently exists for the k8s-prometheus instances by using a new `/federate` metrics path and selecting information about all jobs.

This PR also adds three new alerts for jobs that may be down or missing:
* node-exporter
* cadvisor
* ndt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/420)
<!-- Reviewable:end -->
