### PR TITLE
Readds the cluster=platform-cluster label to all federates metrics from k8s cluster

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -882,7 +882,7 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
   - alert: PlatformCluster_NodeExporterMissing
-    expr: absent(up{deployment="node-exporter", job="platform-cluster"})
+    expr: absent(up{deployment="node-exporter", cluster="platform-cluster"})
     for: 5m
     labels:
       repo: ops-tracker
@@ -899,10 +899,10 @@ groups:
   # the entire node is down.
   - alert: PlatformCluster_NodeExporterDown
     expr: |
-      up{deployment="node-exporter", job="platform-cluster"} == 0 unless on(machine) (
+      up{deployment="node-exporter", cluster="platform-cluster"} == 0 unless on(machine) (
           lame_duck_node == 1 or
           gmx_machine_maintenance == 1 or
-          up{job="kubernetes-nodes"} == 0
+          up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
         )
     for: 1h
     labels:
@@ -917,7 +917,7 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
   - alert: PlatformCluster_CadvisorMissing
-    expr: absent(up{deployment="cadvisor", job="platform-cluster"})
+    expr: absent(up{deployment="cadvisor", cluster="platform-cluster"})
     for: 5m
     labels:
       repo: ops-tracker
@@ -933,10 +933,10 @@ groups:
   # entire node is down.
   - alert: PlatformCluster_CadvisorDown
     expr: |
-      up{deployment="cadvisor", job="platform-cluster"} == 0 unless on(machine) (
+      up{deployment="cadvisor", cluster="platform-cluster"} == 0 unless on(machine) (
           lame_duck_node == 1 or
           gmx_machine_maintenance == 1 or
-          up{job="kubernetes-nodes"} == 0
+          up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
         )
     for: 1h
     labels:
@@ -951,7 +951,7 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
   - alert: PlatformCluster_NdtMissing
-    expr: absent(up{deployment="ndt", job="platform-cluster"})
+    expr: absent(up{deployment="ndt", cluster="platform-cluster"})
     for: 5m
     labels:
       repo: ops-tracker
@@ -967,10 +967,10 @@ groups:
   # node is down.
   - alert: PlatformCluster_NdtDown
     expr: |
-      up{deployment="ndt", job="platform-cluster"} == 0 unless on(machine) (
+      up{deployment="ndt", cluster="platform-cluster"} == 0 unless on(machine) (
           lame_duck_node == 1 or
           gmx_machine_maintenance == 1 or
-          up{job="kubernetes-nodes"} == 0
+          up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
         )
     for: 1h
     labels:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -294,6 +294,8 @@ scrape_configs:
         - 'up{job=~".+"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
+        labels:
+          cluster: "platform-cluster"
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'


### PR DESCRIPTION
This fixes a bug in the previous alerts which were looking for a `job="platform-cluster`, which didn't exist for the specified metrics. This PR adds back the `cluster=platform-cluster` label to all metrics scraped from the k8s platform cluster Prometheus instance so that we can reliably select for them and only them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/421)
<!-- Reviewable:end -->
