### PR TITLE
Add monitoring for 6 hour client requests

### DIFF
--- a/config/federation/bigquery/bq_mlabns_sixhour_requests.sql
+++ b/config/federation/bigquery/bq_mlabns_sixhour_requests.sql
@@ -1,0 +1,82 @@
+WITH
+  clientsInSixHourPeriods AS (
+    SELECT
+      protoPayload.ip as ip,
+      protoPayload.resource as resource,
+      COUNT(*) AS requestsPerDay,
+      CASE
+        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 19 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 81 MINUTE) THEN 1
+        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 379 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 441 MINUTE) THEN 2
+        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 739 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 801 MINUTE) THEN 4
+        WHEN protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1099 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1161 MINUTE) THEN 8
+        ELSE 0
+      END AS period
+    FROM
+  `mlab-ns.exports.appengine_googleapis_com_request_log_*`
+    WHERE
+         (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
+      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+      AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY))
+      AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
+      AND protoPayload.userAgent is NULL
+    GROUP BY
+      -- Also group by 'period' to guarantee that we only have one representative
+      -- request from each ip and resource.
+      ip, resource, period
+  ),
+  clientsOutsideSixHourPeriods AS (
+    SELECT
+      protoPayload.ip as ip
+    FROM
+  `mlab-ns.exports.appengine_googleapis_com_request_log_*`
+    WHERE
+         (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
+      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY))
+      OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+      AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 DAY))
+      AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
+      AND protoPayload.userAgent is NULL
+      AND (
+          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 0 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 19 MINUTE) OR
+          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 81 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 379 MINUTE) OR
+          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 441 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 739 MINUTE) OR
+          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 801 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1099 MINUTE) OR
+          protoPayload.startTime BETWEEN TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1161 MINUTE) AND TIMESTAMP_ADD(TIMESTAMP_TRUNC(protoPayload.startTime, DAY), INTERVAL 1440 MINUTE)
+      )
+    GROUP BY
+      ip
+  ),
+  nsRequestsInSixHourPeriods AS (
+    SELECT
+      ip, resource, SUM(period) as total
+    FROM
+      clientsInSixHourPeriods
+    GROUP BY
+      ip, resource
+    HAVING
+      -- Guarantee that each client runs in each period by totaling the 'period'
+      -- values. If all periods are represented, then the sum(1 + 2 + 4 + 8) = 15.
+      total = 15
+  ),
+  uniqueIPsInSixHourPeriods AS (
+    (SELECT ip FROM nsRequestsInSixHourPeriods WHERE resource = "/neubot" AND ip NOT IN ( SELECT ip FROM clientsOutsideSixHourPeriods )
+     intersect DISTINCT
+     SELECT ip FROM nsRequestsInSixHourPeriods WHERE resource = "/ndt" AND ip NOT IN ( SELECT ip FROM clientsOutsideSixHourPeriods ))
+  )
+
+SELECT
+    protoPayload.resource as resource,
+    COUNT(*) as value
+FROM
+   `mlab-ns.exports.appengine_googleapis_com_request_log_*`
+WHERE
+     (_table_suffix = FORMAT_DATE("%Y%m%d", CURRENT_DATE())
+  OR  _table_suffix = FORMAT_DATE("%Y%m%d", DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)))
+  AND protoPayload.starttime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 15 MINUTE)
+  AND protoPayload.starttime <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 MINUTE)
+  AND (protoPayload.resource = '/neubot' OR protoPayload.resource = '/ndt')
+  AND protoPayload.userAgent IS NULL
+  AND protoPayload.ip IN ( SELECT ip FROM uniqueIPsInSixHourPeriods )
+GROUP BY
+  resource

--- a/config/federation/grafana/dashboards/MLABNS_6_HourClients.json
+++ b/config/federation/grafana/dashboards/MLABNS_6_HourClients.json
@@ -1,0 +1,255 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Monitor behavior of clients running tests to NDT & Neubot every 6 hours",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 257,
+  "iteration": 1553886501954,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "The query used to collect these counts is based on the one used by mlab-ns-rate-limiter.\n\nCounts are offset 15m",
+      "fill": 1,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "bq_mlabns_sixhour_requests",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{resource}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Raw 5m Request Counts to MLAB-NS by 6-hour clients",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "The query used to collect these counts is based on the one used by mlab-ns-rate-limiter.\n\nCounts are offset 15m",
+      "fill": 1,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (index)(8 * rate(sidestream_transmit_bytes_total{index=~\"neubot.mlab|ndt.iupui\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{index}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Raw 5m Request Counts to MLAB-NS by 6-hour clients",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "Prometheus (mlab-oti)",
+          "value": "Prometheus (mlab-oti)"
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/Prometheus/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "MLAB-NS: 6-hour Client Counts",
+  "uid": "CR4zGH6mk",
+  "version": 4
+}

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -18,6 +18,7 @@ spec:
       - name: bigquery-exporter
         image: measurementlab/prometheus-bigquery-exporter:production-0.3
         args: [ "--project={{GCLOUD_PROJECT}}",
+                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
                 "--type=gauge", "--query=/queries/bq_ipv6_bias.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_annotation.sql",
@@ -25,7 +26,6 @@ spec:
                 "--type=gauge", "--query=/queries/bq_ndt_worldmap_server.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_geohash_client.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_server.sql",
-                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
               ]
         ports:
         - containerPort: 9050

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -24,7 +24,9 @@ spec:
                 "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_worldmap_server.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_geohash_client.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_server.sql" ]
+                "--type=gauge", "--query=/queries/bq_ndt_server.sql",
+                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
+              ]
         ports:
         - containerPort: 9050
         volumeMounts:


### PR DESCRIPTION
This change adds a BQ exporter query that reports 5-minute counts of the number of requests received from 6-hour clients in the last two days. This will allow us to track changes in client behavior to determine whether we can retire the 6-hour rate limiting.

The dashbboard sources data from the same project, but currently mlab-oti does not have this new bq exporter data and sandbox does not have all sidestream data.

https://grafana.mlab-sandbox.measurementlab.net/d/CR4zGH6mk/mlab-ns-6-hour-client-counts?orgId=1&from=now-24h&to=now&var-datasource=Prometheus%20(mlab-oti)