### PR TITLE
Scrape lame_duck_experiment metrics from the platform cluster

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -289,10 +289,19 @@ scrape_configs:
     params:
       # Scrape the status of all jobs. This should allow us determine
       # whether, for example, node_exporter is failing to be scraped
-      # somewhere, as well as other core and experiment services. Also scrape
-      # lame_duck_experiment metrics, since mlab-ns needs these, but ignorning
-      # the fake metric scraped from node-exporter.
-      # TODO: remove the synthetic ConfigMap node-exporter lame-duck metrics.
+      # somewhere, as well as other core and experiment services.
+      #
+      # Also scrape lame_duck_experiment metrics, since mlab-ns needs these,
+      # but ignorning the fake metric scraped from node-exporter.
+      #
+      # TODO/NOTE: Currently, this prometheus-federation cluster is scraping a
+      # publicly available endpoint of platform cluster metrics. This will add
+      # additional delay in the propagation of lame_duck_experiment status to
+      # mlab-ns, since the platform cluster scrapes every minute, and the
+      # federation cluster scrapes that cluster every minute, and mlab-ns
+      # queries the federation cluster every minute. We could potentially have
+      # up to 3m delay in propagation. We should find a better way to handle
+      # this.
       'match[]':
         - 'up{job=~".+"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
@@ -305,7 +314,7 @@ scrape_configs:
       # Adds an experiment label to lame_duck_experiment metrics for
       # consistency with our legacy way of doing things.
       #
-      # NOTE : In the future we may drop the 'experiment' label altogether in
+      # TODO: In the future we may drop the 'experiment' label altogether in
       # favor of some native k8s one (e.g., 'deployment'), or to at the very
       # least shorten the name to just 'ndt'
       - source_labels: [deployment]

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -289,13 +289,27 @@ scrape_configs:
     params:
       # Scrape the status of all jobs. This should allow us determine
       # whether, for example, node_exporter is failing to be scraped
-      # somewhere, as well as other core and experiment services."
+      # somewhere, as well as other core and experiment services. Also scrape
+      # lame_duck_experiment metrics, since mlab-ns needs these.
       'match[]':
         - 'up{job=~".+"}'
+        - 'lame_duck_experiment{deployment="ndt"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
         labels:
           cluster: "platform-cluster"
+
+    relabel_configs:
+      # Adds an experiment label to lame_duck_experiment metrics for
+      # consistency with our legacy way of doing things.
+      #
+      # NOTE : In the future we may drop the 'experiment' label altogether in
+      # favor of some native k8s one (e.g., 'deployment'), or to at the very
+      # least shorten the name to just 'ndt'
+      - source_labels: [deployment]
+        regex: ^ndt.*
+        target_label: experiment
+        replacement: ndt.iupui
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -290,16 +290,18 @@ scrape_configs:
       # Scrape the status of all jobs. This should allow us determine
       # whether, for example, node_exporter is failing to be scraped
       # somewhere, as well as other core and experiment services. Also scrape
-      # lame_duck_experiment metrics, since mlab-ns needs these.
+      # lame_duck_experiment metrics, since mlab-ns needs these, but ignorning
+      # the fake metric scraped from node-exporter.
+      # TODO: remove the synthetic ConfigMap node-exporter lame-duck metrics.
       'match[]':
         - 'up{job=~".+"}'
-        - 'lame_duck_experiment{deployment="ndt"}'
+        - 'lame_duck_experiment{job!="node-exporter"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
         labels:
           cluster: "platform-cluster"
 
-    relabel_configs:
+    metric_relabel_configs:
       # Adds an experiment label to lame_duck_experiment metrics for
       # consistency with our legacy way of doing things.
       #


### PR DESCRIPTION
mlab-ns needs `lame_duck_experiment` metrics, but on the platform-cluster, that metric currently only exists as a fake metric that will always be 0 in order to avoid alerts. These days experiments will natively export metrics, one of which will be `lame_duck_experiment`, as does the ndt-server running on the platform cluster. This PR adds that metric to the platform-cluster scrape job.

Additionally, a new label of `experiment=ndt.iupui` is added, since current mlab-ns queries used that label.

This PR should resolve m-lab/k8s-support#169.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/427)
<!-- Reviewable:end -->
