### PR TITLE
Adds a 'machine' label to all metrics scraped from the platform-cluster

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -321,6 +321,13 @@ scrape_configs:
         regex: ^ndt.*
         target_label: experiment
         replacement: ndt.iupui
+      # mlab-ns queries use a 'machine' label for grouping results. This is the
+      # same as the value of the 'node' label in k8s metrics. Write the value
+      # of 'node' to a new label 'machine' so that mlab-ns will correctly
+      # identify and use lame_duck_experiment metrics.
+      - source_labels: [node]
+        action: replace
+        target_label: machine
 
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'


### PR DESCRIPTION
The legacy platform uses the label `machine` in a lot of places. The new platform knows about `nodes` (in most cases), not "machines". This PR adds a `machine` label to all metrics scraped from the platform-cluster so that existing queries will still work as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/428)
<!-- Reviewable:end -->
