### PR TITLE
Scrapes kube_node_spec_taint metric from platform cluster federation job.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -307,6 +307,7 @@ scrape_configs:
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_filesystem_free_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
+        - 'kube_node_spec_taint{value="lame-duck"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION
This will allow mlab-ns, and other things, to query the lame-duck status of a k8s platform node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/435)
<!-- Reviewable:end -->
