### PR TITLE
Scrapes kube_node_spec_taint{key='lame-duck'} instead of the value.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -307,7 +307,7 @@ scrape_configs:
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_filesystem_free_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
-        - 'kube_node_spec_taint{value="lame-duck"}'
+        - 'kube_node_spec_taint{key="lame-duck"}'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/436)
<!-- Reviewable:end -->
