### PR TITLE
Make sure that rsyncd is up before firing alert RsyncRunningWithoutScraper

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -251,9 +251,12 @@ groups:
       summary: "Scraper deployments are running without rsyncd monitoring"
       description: ""
 
-# Rsync inventory includes machine "b", but machine "b" does not have a configured scraper.
+# Rsync inventory includes machine "b" and rsyncd is actually running, but
+# machine "b" does not have a configured scraper.
   - alert: RsyncRunningWithoutScraper
-    expr: up{service="rsyncd"} unless on(machine, experiment) up{container="scraper"}
+    expr: |
+      up{service="rsyncd"} and on(machine, experiment) probe_success{service="rsyncd"} == 1
+        unless on(machine, experiment) up{container="scraper"}
     for: 30m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
Another possible place to fix this would be in the operator repo by simply not [generating rsyncd blackbox targets for staging patterns](https://github.com/m-lab/operator/blob/master/generate_prometheus_targets.sh#L46). The reason I'm not choosing that alternative is because it will become tedious to unworkable as we incrementally start transitioning the production platform. It's probably best to modify the alerts themselves.

This PR works around the fact that mlab4s no longer have scraper instances and don't run rsyncd either. Previously, the (very reasonable) assumption for the alert `RsyncRunningWithoutScraper` was that all nodes should be running rsyncd for all experiments. Our Prometheus instance is still monitoring for rsyncd on mlab4, even though it doesn't exists there. This change requires that not only is Prometheus attempting to probe for rsyncd, but also that rsyncd is actually up and running. This makes the alert slightly less robust, but gets us around the fact that over time we will be running less and less rsyncd on the platform. In any case, this alert is rare as hen's teeth.

Assigning this PR to @pboothe since we were talking about it at the end of the day today, but also flagging @stephen-soltesz in case he has commentary on the PR, or situation in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/439)
<!-- Reviewable:end -->
