### PR TITLE
Platform cluster etcd alerts + new WorkloadOverview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1556562899704,
+  "iteration": 1556568689370,
   "links": [],
   "panels": [
     {
@@ -25,7 +25,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Aggregate container CPU usage expressed as a percentage of the entire cluster CPU capacity.",
+      "description": "Left Y: Aggregate container CPU usage expressed as a percentage of the entire cluster CPU capacity in cores.\nRight Y: Aggregate container CPU usage as an absolute number of cores.",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -85,7 +85,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Aggregate container CPU usage (% total cluster)",
+      "title": "Aggregate container CPU usage",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -129,7 +129,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "Aggregate container memory expressed as a percentage of the entire cluster's memory capacity.",
+      "description": "Left Y: Aggregate container memory expressed as a percentage of the entire cluster's memory capacity.\nRight Y: Aggregate container memory usage expressed as an absolute number of bytes.",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -187,7 +187,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Aggregate container memory usage (% total cluster)",
+      "title": "Aggregate container memory usage",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -231,7 +231,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "",
+      "description": "Left Y: Aggregate container CPU usage expressed as a percentage of a node's total CPU cores.\nRight Y: Aggregate container CPU usage as an absolute number of cores.",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -334,7 +334,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "",
+      "description": "Left Y: Aggregate container memory expressed as a percentage of a node's total memory capacity.\nRight Y: Aggregate container memory usage on a node expressed as an absolute number of bytes.",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -391,7 +391,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Top10: container memory usage by node",
+      "title": "Top10: Container memory usage by node",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -581,7 +581,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Top 10: Container network usage by node",
+      "title": "Top 10: Container network usage by node (bits/s)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1303,7 +1303,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
@@ -1334,5 +1334,5 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 80
+  "version": 81
 }

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -1,0 +1,1282 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 261,
+  "iteration": 1556314159362,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Aggregate container CPU usage expressed as a percentage of the entire cluster CPU capacity.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "container_name:container_cpu_usage_seconds_total:sum_rate5m /\n  ignoring(container_label_io_kubernetes_container_name) group_left sum(machine_cpu_cores)\n",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{container_label_io_kubernetes_container_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Aggregate container CPU usage (% total cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Aggregate container memory expressed as a percentage of the entire cluster's memory capacity.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "container_name:container_memory_working_set_bytes:sum_rate5m /\n  ignoring(container_label_io_kubernetes_container_name) group_left sum(machine_memory_bytes)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{container_label_io_kubernetes_container_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Aggregate container memory usage (% total cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 30,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (container_label_workload) (\n  rate (\n    container_network_transmit_bytes_total{\n      container_label_io_kubernetes_container_name = \"POD\",\n      container_label_workload != \"\",\n      interface =~ \"(eth0|net1)\"\n    }\n  [5m]) * 8\n)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{container_label_workload}} tranmitted",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (container_label_workload) (\n  - rate (\n    container_network_receive_bytes_total{\n      container_label_io_kubernetes_container_name = \"POD\",\n      container_label_workload != \"\",\n      interface =~ \"(eth0|net1)\"\n    }\n  [5m]) * 8\n)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{container_label_workload}} received",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Aggregate container network usage (bits/s)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m / on(node) group_left machine_cpu_cores\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 10: Container CPU usage by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "id": 32,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m/ on(node) group_left machine_memory_bytes\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top10: container memory usage by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "id": 33,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10,\n  sum by (node, container_label_workload) (\n    rate (\n      container_network_transmit_bytes_total{\n        container_label_io_kubernetes_container_name = \"POD\",\n        container_label_workload != \"\"\n      }\n    [5m]) * 8\n  )\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container_label_workload}} tranmitted ({{node}})",
+          "refId": "B"
+        },
+        {
+          "expr": "topk(10,\n  sum by (node, container_label_workload) (\n    - rate (\n      container_network_receive_bytes_total{\n        container_label_io_kubernetes_container_name = \"POD\",\n        container_label_workload != \"\"\n      }\n    [5m]) * 8\n  )\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{container_label_workload}} received ({{node}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 10: Container network usage by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 0,
+        "y": 14
+      },
+      "hideTimeOverride": false,
+      "id": 23,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "DaemonSet",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/^daemonset$/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Current",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "/Value #A/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Desired",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "/Value #B/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "sum by (daemonset) (kube_daemonset_status_current_number_scheduled)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Current",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (daemonset) (kube_daemonset_status_desired_number_scheduled)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Desired",
+          "refId": "B"
+        }
+      ],
+      "title": "DaemonSets: Desired vs Curernt",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 5,
+        "y": 14
+      },
+      "hideTimeOverride": false,
+      "id": 24,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Deployment",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/^exported_deployment$/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Current",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "/Value #A/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Desired",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "/Value #B/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "sum by (exported_deployment) (kube_deployment_status_replicas)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Current",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (exported_deployment) (kube_deployment_spec_replicas)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Desired",
+          "refId": "B"
+        }
+      ],
+      "title": "Deployments: Desired vs Curernt",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 10,
+        "y": 14
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count(kube_pod_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Count",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total pods (all namespaces)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 17,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Pod",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/^exported_pod$/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Namespace",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/^namespace$/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "kube_pod_status_ready{condition=\"true\"} == 0",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods not ready",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 14,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 16,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "DaemonSet",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/^daemonset$/",
+          "preserveFormat": false,
+          "rangeMaps": [
+            {
+              "from": "",
+              "text": "",
+              "to": ""
+            }
+          ],
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Namespace",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/exported_namespace/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "kube_daemonset_status_current_number_scheduled != kube_daemonset_status_desired_number_scheduled",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "DaemonSets: desired != current",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 10,
+        "y": 19
+      },
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kube_pod_container_status_restarts_total[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{exported_pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Container restarts (rate/s entire cluster)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 4,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 16,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "Deployment",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/exported_deployment/",
+          "preserveFormat": false,
+          "rangeMaps": [
+            {
+              "from": "",
+              "text": "",
+              "to": ""
+            }
+          ],
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Namespace",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "/exported_namespace/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "kube_deployment_spec_replicas != kube_deployment_status_replicas",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Deployments: desired != current",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "k8s platform (mlab-sandbox)",
+          "value": "k8s platform (mlab-sandbox)"
+        },
+        "hide": 0,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "K8s: Workload Overview",
+  "uid": "tZHLFQRZk",
+  "version": 79
+}

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1556568689370,
+  "iteration": 1556570505236,
   "links": [],
   "panels": [
     {
@@ -66,7 +66,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_name:container_cpu_usage_seconds_total:sum_rate5m /\n  ignoring(container_label_io_kubernetes_container_name) group_left sum(machine_cpu_cores)\n",
+          "expr": "container_name:container_cpu_usage_seconds:sum_rate5m /\n  ignoring(container_label_io_kubernetes_container_name) group_left sum(machine_cpu_cores)\n",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -74,7 +74,7 @@
           "refId": "A"
         },
         {
-          "expr": "container_name:container_cpu_usage_seconds_total:sum_rate5m",
+          "expr": "container_name:container_cpu_usage_seconds:sum_rate5m",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Cores {{container_label_io_kubernetes_container_name}}",
@@ -272,14 +272,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m / on(node) group_left machine_cpu_cores\n)",
+          "expr": "topk(10,\n  node_container_name:container_cpu_usage_seconds:sum_rate5m / on(node) group_left machine_cpu_cores\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "% Total {{container_label_io_kubernetes_container_name}} ({{node}})",
           "refId": "A"
         },
         {
-          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m\n)",
+          "expr": "topk(10,\n  node_container_name:container_cpu_usage_seconds:sum_rate5m\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Cores {{container_label_io_kubernetes_container_name}} ({{node}})",
@@ -373,14 +373,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m / on(node) group_left machine_memory_bytes\n)",
+          "expr": "topk(10,\n  node_container_name:container_memory_working_set_bytes:sum_rate5m / on(node) group_left machine_memory_bytes\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "% Total {{container_label_io_kubernetes_container_name}} ({{node}})",
           "refId": "A"
         },
         {
-          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m\n)",
+          "expr": "topk(10,\n  node_container_name:container_memory_working_set_bytes:sum_rate5m\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Memory {{container_label_io_kubernetes_container_name}} ({{node}})",
@@ -1334,5 +1334,6 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 81
+  "version": 82
 }
+

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1556314159362,
+  "iteration": 1556562899704,
   "links": [],
   "panels": [
     {
@@ -29,19 +29,21 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 0
       },
       "id": 28,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "hideEmpty": true,
         "hideZero": true,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -53,7 +55,12 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/^Cores/",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -61,9 +68,17 @@
         {
           "expr": "container_name:container_cpu_usage_seconds_total:sum_rate5m /\n  ignoring(container_label_io_kubernetes_container_name) group_left sum(machine_cpu_cores)\n",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{container_label_io_kubernetes_container_name}}",
+          "legendFormat": "% Total {{container_label_io_kubernetes_container_name}}",
           "refId": "A"
+        },
+        {
+          "expr": "container_name:container_cpu_usage_seconds_total:sum_rate5m",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Cores {{container_label_io_kubernetes_container_name}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -88,7 +103,7 @@
         {
           "decimals": null,
           "format": "percentunit",
-          "label": null,
+          "label": "% Total Cores",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -96,7 +111,7 @@
         },
         {
           "format": "short",
-          "label": null,
+          "label": "Cores",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -118,17 +133,19 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 8,
+        "w": 12,
+        "x": 12,
         "y": 0
       },
       "id": 29,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -140,7 +157,12 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/^Memory/",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -150,8 +172,15 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{container_label_io_kubernetes_container_name}}",
+          "legendFormat": "% Total {{container_label_io_kubernetes_container_name}}",
           "refId": "A"
+        },
+        {
+          "expr": "container_name:container_memory_working_set_bytes:sum_rate5m",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Memory {{container_label_io_kubernetes_container_name}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -176,15 +205,15 @@
         {
           "decimals": null,
           "format": "percentunit",
-          "label": null,
+          "label": "% Total Memory",
           "logBase": 1,
           "max": null,
           "min": null,
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
+          "format": "decbytes",
+          "label": "Memory",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -206,9 +235,213 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 0
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Cores/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m / on(node) group_left machine_cpu_cores\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "% Total {{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "A"
+        },
+        {
+          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Cores {{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 10: Container CPU usage by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": "% Total Cores",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "Cores",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 32,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Memory/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m / on(node) group_left machine_memory_bytes\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "% Total {{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "A"
+        },
+        {
+          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Memory {{container_label_io_kubernetes_container_name}} ({{node}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top10: container memory usage by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": "% Total Memory",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "decbytes",
+          "label": "Memory",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 14
       },
       "id": 30,
       "legend": {
@@ -300,185 +533,9 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 7
-      },
-      "id": 31,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "topk(10,\n  node_containername:container_cpu_usage_seconds_total:sum_rate5m / on(node) group_left machine_cpu_cores\n)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{node}})",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Top 10: Container CPU usage by node",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "description": "",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 7
-      },
-      "id": 32,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "topk(10,\n  node_containername:container_memory_working_set_bytes:sum_rate5m/ on(node) group_left machine_memory_bytes\n)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{node}})",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Top10: container memory usage by node",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "percentunit",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "description": "",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 7
+        "w": 12,
+        "x": 12,
+        "y": 14
       },
       "id": 33,
       "legend": {
@@ -570,7 +627,7 @@
         "h": 10,
         "w": 5,
         "x": 0,
-        "y": 14
+        "y": 21
       },
       "hideTimeOverride": false,
       "id": 23,
@@ -676,7 +733,7 @@
         "h": 10,
         "w": 5,
         "x": 5,
-        "y": 14
+        "y": 21
       },
       "hideTimeOverride": false,
       "id": 24,
@@ -785,7 +842,7 @@
         "h": 5,
         "w": 6,
         "x": 10,
-        "y": 14
+        "y": 21
       },
       "id": 19,
       "legend": {
@@ -867,7 +924,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 14
+        "y": 21
       },
       "id": 17,
       "links": [],
@@ -947,7 +1004,7 @@
         "h": 3,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 25
       },
       "id": 14,
       "links": [],
@@ -1048,7 +1105,7 @@
         "h": 5,
         "w": 6,
         "x": 10,
-        "y": 19
+        "y": 26
       },
       "id": 21,
       "legend": {
@@ -1132,7 +1189,7 @@
         "h": 3,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 28
       },
       "id": 4,
       "links": [],
@@ -1230,7 +1287,6 @@
     "list": [
       {
         "current": {
-          "tags": [],
           "text": "k8s platform (mlab-sandbox)",
           "value": "k8s platform (mlab-sandbox)"
         },
@@ -1247,7 +1303,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -1278,5 +1334,5 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 79
+  "version": 80
 }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1016,7 +1016,7 @@ groups:
 
   - alert: PlatformCluster_EtcdHasNoLeader
     expr: etcd_server_has_leader == 0
-    for: 1m
+    for: 3m
     labels:
       repo: ops-tracker
       severity: page
@@ -1040,7 +1040,7 @@ groups:
         Leader changes are normal (e.g., a master node is rebooted), but they
         should not happen too often. Look into networking, resource or other
         issues on the master nodes.
-      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
   - alert: PlatformCluster_EtcdTooManyProposalFailures
     expr: rate(etcd_server_proposals_failed_total[15m]) > 5
@@ -1085,7 +1085,7 @@ groups:
         it are taking too long. Check that there are no problems with the disk
         on the master node, and that disk I/O throughput is not becoming a
         bottleneck.
-      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
   - alert: PlatformCluster_EtcdBackedCommitsTooSlow
     expr: |
@@ -1102,6 +1102,6 @@ groups:
         taking too long to complete.  Check that there are no problems with the
         disk on the master node, and that disk I/O throughput is not becoming a
         bottleneck.
-      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
 # Platform Cluster API server alerts.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1010,3 +1010,96 @@ groups:
         /cache/data/*`.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
+# Etcd alerts mostly gleaned from:
+# https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules.yml
+
+  - alert: PlatformCluster_EtcdHasNoLeader
+    expr: etcd_server_has_leader == 0
+    for: 1m
+    labels:
+      repo: ops-tracker
+      severity: page
+    annotations:
+      summary: At least one etcd cluster member has no leader.
+      description: An etcd cluster member is reporting that it has no leader.
+        This should never happen. Find out which master server is hosting the
+        ectd instance(s) and make sure that node is healthy and has network
+        connectivity to the other masters.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/milv1PgZz/k8s-etcd-overview
+
+  - alert: PlatformCluster_EtcdTooManyLeaderChanges
+    expr: rate(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}[15m]) > 3
+    for: 15m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Too many leader changes in the etcd cluster.
+      description: etcd cluster members are changing leaders too frequently.
+        Leader changes are normal (e.g., a master node is rebooted), but they
+        should not happen too often. Look into networking, resource or other
+        issues on the master nodes.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+
+  - alert: PlatformCluster_EtcdTooManyProposalFailures
+    expr: rate(etcd_server_proposals_failed_total[15m]) > 5
+    for: 15m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Too many raft protocol proposal failures in the etcd cluster.
+      description: There are too many raft protocol proposal failures happening
+        in the etcd cluster. These type of errors are normally related to two
+        issues - temporary failures related to a leader election or longer
+        downtime caused by a loss of quorum in the cluster.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/milv1PgZz/k8s-etcd-overview
+
+  - alert: PlatformCluster_EtcdMemberCommunicationTooSlow
+    expr: |
+      histogram_quantile(0.99,
+        rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m])
+      ) > 0.15
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Network communication between etcd cluster members is too slow.
+      description: The members of the etcd cluster are on different master
+        nodes, and each node is in a different power zone. Communication
+        between the members is taking too long. Make sure that the VPC network
+        is working as intended, and that it isn't overloaded.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/milv1PgZz/k8s-etcd-overview
+
+  - alert: PlatformCluster_EtcdWalFsyncsTooSlow
+    expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: etcd write-ahead-log fsync operations are taking too long.
+      description: etcd uses a WAL (Write Ahead Log), and fsync operations to
+        it are taking too long. Check that there are no problems with the disk
+        on the master node, and that disk I/O throughput is not becoming a
+        bottleneck.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+
+  - alert: PlatformCluster_EtcdBackedCommitsTooSlow
+    expr: |
+      histogram_quantile(0.99,
+        rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m])
+      ) > 0.25
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: etcd backend commits are taking too long to complete.
+      description: etcd writes incremental snapshots to disk. These writes are
+        taking too long to complete.  Check that there are no problems with the
+        disk on the master node, and that disk I/O throughput is not becoming a
+        bottleneck.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
+

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1010,7 +1010,8 @@ groups:
         /cache/data/*`.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-# Etcd alerts mostly gleaned from:
+# PlatformCluster Etcd alerts.
+# Mostly gleaned from:
 # https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules.yml
 
   - alert: PlatformCluster_EtcdHasNoLeader
@@ -1103,3 +1104,4 @@ groups:
         bottleneck.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
+# Platform Cluster API server alerts.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1016,7 +1016,7 @@ groups:
 
   - alert: PlatformCluster_EtcdHasNoLeader
     expr: etcd_server_has_leader == 0
-    for: 3m
+    for: 5m
     labels:
       repo: ops-tracker
       severity: page
@@ -1029,8 +1029,8 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/milv1PgZz/k8s-etcd-overview
 
   - alert: PlatformCluster_EtcdTooManyLeaderChanges
-    expr: rate(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}[15m]) > 3
-    for: 15m
+    expr: rate(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}[30m]) > 3
+    for: 30m
     labels:
       repo: ops-tracker
       severity: ticket
@@ -1043,8 +1043,8 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
   - alert: PlatformCluster_EtcdTooManyProposalFailures
-    expr: rate(etcd_server_proposals_failed_total[15m]) > 5
-    for: 15m
+    expr: rate(etcd_server_proposals_failed_total[30m]) > 5
+    for: 30m
     labels:
       repo: ops-tracker
       severity: ticket
@@ -1059,9 +1059,9 @@ groups:
   - alert: PlatformCluster_EtcdMemberCommunicationTooSlow
     expr: |
       histogram_quantile(0.99,
-        rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m])
+        rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[30m])
       ) > 0.15
-    for: 10m
+    for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
@@ -1074,8 +1074,8 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/milv1PgZz/k8s-etcd-overview
 
   - alert: PlatformCluster_EtcdWalFsyncsTooSlow
-    expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
-    for: 10m
+    expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m])) > 0.5
+    for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
@@ -1090,9 +1090,9 @@ groups:
   - alert: PlatformCluster_EtcdBackedCommitsTooSlow
     expr: |
       histogram_quantile(0.99,
-        rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m])
+        rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[30m])
       ) > 0.25
-    for: 10m
+    for: 1h
     labels:
       repo: ops-tracker
       severity: ticket

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -308,6 +308,12 @@ scrape_configs:
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_filesystem_free_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'kube_node_spec_taint{key="lame-duck"}'
+        - 'etcd_server_has_leader'
+        - 'etcd_server_leader_changes_seen_total'
+        - 'etcd_server_proposals_failed_total'
+        - 'etcd_network_peer_round_trip_time_seconds_bucket'
+        - 'etcd_disk_wal_fsync_duration_seconds_bucket'
+        - 'etcd_disk_backend_commit_duration_seconds_bucket'
     static_configs:
       - targets: ['k8s-prometheus.{{PROJECT}}.measurementlab.net:9090']
         labels:

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -177,8 +177,8 @@ groups:
       sum by (container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
           container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != ""},
-          image != ""
+          container_label_io_kubernetes_container_name != "",
+          image != ""}
         [5m])
       )
   - record: container_name:container_memory_working_set_bytes:sum_rate5m
@@ -186,7 +186,7 @@ groups:
       sum by (container_label_io_kubernetes_container_name) (
         rate (container_memory_working_set_bytes{
           container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != ""},
-          image != ""
+          container_label_io_kubernetes_container_name != "",
+          image != ""}
         [5m])
       )

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -168,25 +168,3 @@ groups:
 # of the precalculated value needed by the rule.
   - record: candidate_service:etl_test_count:increase24h
     expr: sum by(service) (increase(etl_test_count{service!~".*batch.*",status="ok"}[1d]))
-
-## PlatformCluster
-#
-# Optimize aggregation of container CPU and memory utilization by containter_name.
-  - record: container_name:container_cpu_usage_seconds_total:sum_rate5m
-    expr: |
-      sum by (container_label_io_kubernetes_container_name) (
-        rate (container_cpu_usage_seconds_total{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          image != ""}
-        [5m])
-      )
-  - record: container_name:container_memory_working_set_bytes:sum_rate5m
-    expr: |
-      sum by (container_label_io_kubernetes_container_name) (
-        rate (container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          image != ""}
-        [5m])
-      )

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -168,3 +168,25 @@ groups:
 # of the precalculated value needed by the rule.
   - record: candidate_service:etl_test_count:increase24h
     expr: sum by(service) (increase(etl_test_count{service!~".*batch.*",status="ok"}[1d]))
+
+## PlatformCluster
+#
+# Optimize aggregation of container CPU and memory utilization by containter_name.
+  - record: container_name:container_cpu_usage_seconds_total:sum_rate5m
+    expr: |
+      sum by (container_label_io_kubernetes_container_name) (
+        rate (container_cpu_usage_seconds_total{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != ""},
+          image != ""
+        [5m])
+      )
+  - record: container_name:container_memory_working_set_bytes:sum_rate5m
+    expr: |
+      sum by (container_label_io_kubernetes_container_name) (
+        rate (container_memory_working_set_bytes{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != ""},
+          image != ""
+        [5m])
+      )


### PR DESCRIPTION
This PR implements a number of, hopefully, useful etcd alerts for the platform cluster. In order to make these alerts possible, some additional metrics were added to the `platform-cluster` federation scrape job.

This PR also adds a new Grafana dashboard, "K8s: Workload Overview", which gives fairly high level view of pods and container resource utilization (currently CPU, memory, network). It also includes some information about desired vs current pods for a workload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/442)
<!-- Reviewable:end -->
