### PR TITLE
Add Prometheus metrics scraping for Reboot API.

### DIFF
--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         run: reboot-api
+      annotations:
+        prometheus.io/scrape: 'true'
     spec:
       containers:
       - name: reboot-api
@@ -30,6 +32,8 @@ spec:
           requests:
             cpu: 200m
             memory: 50Mi
+        ports:
+          - containerPort: 9990
       volumes:
         # SSH key to log into CoreOS nodes is provided as a Kubernetes secret.
         - name: credentials


### PR DESCRIPTION
This PR adds the `prometheus.io/scrape` annotation to `deployments/reboot-api.yml` and exposes the relevant containerPort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/448)
<!-- Reviewable:end -->
