### PR TITLE
Stop scraping Rebot instance on EB.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -730,15 +730,6 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-  # Scrape config for the rebot. There is only one rebot service currently
-  # running on the eb.measurementlab.net machine.
-  #
-  # The rebot service generates its own labels.
-  - job_name: 'rebot'
-    static_configs:
-      - targets:
-        - eb.measurementlab.net:9999
-
   # Scrape config for legacy targets.
   #
   # Using an out-of-band process, generated configs can be copied into the


### PR DESCRIPTION
This PR removes the Rebot instance on EB from the scraping targets list since Rebot is being migrated to GKE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/449)
<!-- Reviewable:end -->
