### PR TITLE
Change Rebot_MissingMetrics to use run='rebot'

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -808,7 +808,7 @@ groups:
 # Rebot_MissingMetrics fires when no metrics can be collected for rebot for
 # the past 10 minutes.
   - alert: Rebot_MissingMetrics
-    expr: absent(up{job='rebot'})
+    expr: absent(up{run='rebot'})
     for: 10m
     labels:
       repo: ops-tracker


### PR DESCRIPTION
There is no job='rebot' anymore, but we can check if metrics are being scraped with run='rebot'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/454)
<!-- Reviewable:end -->
