### PR TITLE
Make sure reboot-api will only be deployed on nodes with a static IP.

### DIFF
--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -39,3 +39,14 @@ spec:
         - name: credentials
           secret:
             secretName: reboot-api-credentials
+      # The Reboot API will only be scheduled onto nodes that we labeled
+      # as having a static outbound IP.
+      nodeSelector:
+        outbound-ip: static
+      # We can also taint nodes with static outbound IPs so that services that
+      # do not require a static IP aren't scheduled to that node. This
+      # deployment, however, will tolerate that taint.
+      tolerations:
+      - key: "outbound-ip"
+        value: "static"
+        effect: "NoSchedule"


### PR DESCRIPTION
This PR makes sure the Reboot API will only run on nodes with `outbound-ip: static` - i.e. nodes that have a static IP, managed by `kubeip`. This is necessary so we can enable source IP-based firewall rules on switches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/458)
<!-- Reviewable:end -->
