### PR TITLE
Use new gcs-downloader container to fetch snmp-exporter config file

### DIFF
--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -42,7 +42,7 @@ spec:
         args:
         - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
         - -output=/config
-        - -period=5
+        - -period=5m
         resources:
           requests:
             memory: "150Mi"

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -20,8 +20,8 @@ spec:
       - name: gcs-downloader-once
         image: measurementlab/gcs-downloader:v0.1
         args:
-        - -source gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
-        - -output /config/snmp.yml
+        - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
+        - -output=/config/snmp.yml
         - -once
         volumeMounts:
         - mountPath: /config
@@ -38,9 +38,9 @@ spec:
       - name: gcs-downloader
         image: measurementlab/gcs-downloader:v0.1
         args:
-        - -source gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
-        - -output /config/snmp.yml
-        - -period 5
+        - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
+        - -output=/config/snmp.yml
+        - -period=5
         resources:
           requests:
             memory: "150Mi"

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -43,6 +43,8 @@ spec:
         - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
         - -output=/config
         - -period=5m
+        ports:
+        - containerPort: 9990
         resources:
           requests:
             memory: "150Mi"

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -30,7 +30,7 @@ spec:
       - name: snmp-exporter
         image: prom/snmp-exporter:v0.13.0
         args:
-        - -config.file=/etc/snmp_exporter/snmp_exporter_config.yaml
+        - --config.file=/etc/snmp_exporter/snmp_exporter_config.yaml
         ports:
         - containerPort: 9116
         volumeMounts:

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -21,14 +21,16 @@ spec:
         image: measurementlab/gcs-downloader:v0.1
         args:
         - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
-        - -output=/config/snmp.yml
+        - -output=/config
         - -once
         volumeMounts:
         - mountPath: /config
           name: snmp-exporter-storage
       containers:
-      - image: prom/snmp-exporter:v0.13.0
-        name: snmp-exporter
+      - name: snmp-exporter
+        image: prom/snmp-exporter:v0.13.0
+        args:
+        - -config.file=/etc/snmp_exporter/snmp_exporter_config.yaml
         ports:
         - containerPort: 9116
         volumeMounts:
@@ -39,7 +41,7 @@ spec:
         image: measurementlab/gcs-downloader:v0.1
         args:
         - -source=gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
-        - -output=/config/snmp.yml
+        - -output=/config
         - -period=5
         resources:
           requests:

--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -17,12 +17,12 @@ spec:
     spec:
       # Do an early fetch of the configuration so that snmp-exporter will start
       initContainers:
-      - name: fetch
-        image: gcr.io/cloud-builders/gsutil
+      - name: gcs-downloader-once
+        image: measurementlab/gcs-downloader:v0.1
         args:
-        - cp
-        - gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
-        - /config/snmp.yml
+        - -source gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
+        - -output /config/snmp.yml
+        - -once
         volumeMounts:
         - mountPath: /config
           name: snmp-exporter-storage
@@ -34,14 +34,13 @@ spec:
         volumeMounts:
         - mountPath: /etc/snmp_exporter
           name: snmp-exporter-storage
-      # Pull the snmp-exporter configuration again so that we can watch it.
-      # TODO: replace this bash-loop with a special-purpose container.
-      - name: service-discovery
-        image: gcr.io/cloud-builders/gsutil
-        command:
-        - bash
-        - -c
-        - "while true; do gsutil cp gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml /config/snmp.yml ; sleep 600 ; done"
+      # Pull the snmp-exporter configuration from GCS every 5 minutes.
+      - name: gcs-downloader
+        image: measurementlab/gcs-downloader:v0.1
+        args:
+        - -source gs://switch-config-{{GCLOUD_PROJECT}}/snmp_exporter_config.yaml
+        - -output /config/snmp.yml
+        - -period 5
         resources:
           requests:
             memory: "150Mi"


### PR DESCRIPTION
Currently, fetching the snmp-exporter config file from GCS is implemented in a very hackish manner which mostly works, but is overly complicated. This PR uses the new gcs-downloader Docker container that @stephen-soltesz created to fetch the config file from GCS periodically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/459)
<!-- Reviewable:end -->
