### PR TITLE
Prevent two snmp-exporter pods running on the same node.

### DIFF
--- a/k8s/prometheus-federation/deployments/snmp-exporter.yml
+++ b/k8s/prometheus-federation/deployments/snmp-exporter.yml
@@ -15,6 +15,16 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: run
+                operator: In
+                values:
+                - snmp-exporter
+            topologyKey: kubernetes.io/hostname
       # Do an early fetch of the configuration so that snmp-exporter will start
       initContainers:
       - name: gcs-downloader-once


### PR DESCRIPTION
This PR applies the same configuration used in `blackbox-server` to avoid that two pods are scheduled to run on the same node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/460)
<!-- Reviewable:end -->
