### PR TITLE
Add "site" label to blackbox-exporter targets

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -462,9 +462,12 @@ scrape_configs:
         target_label: __address__
         replacement: blackbox-service.default.svc.cluster.local:9115
 
+    # This metric relabel config adds the "site" label on blackbox-exporter
+    # targets.
+    # TODO: retire this in favor of adding the label at target generation time.
     metric_relabel_configs:
       - source_labels: [machine]
-        regex: mlab[1-4c]\.([a-z]{3}[0-9tc]{2}).+
+        regex: mlab[1-4]\.([a-z]{3}[0-9tc]{2}).+
         target_label: site
         replacement: $1
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -2623,3 +2623,7 @@ scrape_configs:
         regex: 11
         target_label: index
         replacement: utility.mlab
+      - source_labels: [machine]
+        regex: mlab[1-4c]\.([a-z]{3}[0-9t]{2}).+
+        target_label: site
+        replacement: $1

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -464,7 +464,7 @@ scrape_configs:
 
     metric_relabel_configs:
       - source_labels: [machine]
-        regex: mlab[1-4c]\.([a-z]{3}[0-9t]{2}).+
+        regex: mlab[1-4c]\.([a-z]{3}[0-9tc]{2}).+
         target_label: site
         replacement: $1
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -462,6 +462,11 @@ scrape_configs:
         target_label: __address__
         replacement: blackbox-service.default.svc.cluster.local:9115
 
+    metric_relabel_configs:
+      - source_labels: [machine]
+        regex: mlab[1-4c]\.([a-z]{3}[0-9t]{2}).+
+        target_label: site
+        replacement: $1
 
   # Blackbox configurations for IPv6 probes.
   #
@@ -2623,7 +2628,3 @@ scrape_configs:
         regex: 11
         target_label: index
         replacement: utility.mlab
-      - source_labels: [machine]
-        regex: mlab[1-4c]\.([a-z]{3}[0-9t]{2}).+
-        target_label: site
-        replacement: $1


### PR DESCRIPTION
This PR adds the "site" label to all the `blackbox-exporter` targets, extracting that from "machine" with a regex. This allows us to simplify several queries where to get the site we have been using `label_replace`.

Tested in sandbox, `probe_success{job="blackbox-targets",site=""}` gives an empty result set - all the metrics have the `site` label.

Related to https://github.com/m-lab/prometheus-support/issues/92 but I'm not sure this would close that issue since it's limited to blackbox-exporter targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/466)
<!-- Reviewable:end -->
