### PR TITLE
Update Rebot image to v0.1.1

### DIFF
--- a/k8s/prometheus-federation/deployments/rebot.yml
+++ b/k8s/prometheus-federation/deployments/rebot.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: rebot
-        image: measurementlab/rebot:v0.1.0
+        image: measurementlab/rebot:v0.1.1
         imagePullPolicy: Always
         args:
           - "-project={{GCLOUD_PROJECT}}"


### PR DESCRIPTION
This PR updates the Rebot image to v0.1.1. The only difference is that now Rebot takes advantage of the recently added "site" label instead of using `label_replace`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/469)
<!-- Reviewable:end -->
