### PR TITLE
PlatformCluster_NodeinfoMissing alerts is now PlatformCluster_HostExperimentMissing

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -954,17 +954,17 @@ groups:
         node-exporter`).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
-  - alert: PlatformCluster_NodeinfoMissing
-    expr: absent(up{deployment="nodeinfo", cluster="platform-cluster"})
+  - alert: PlatformCluster_HostExperimentMissing
+    expr: absent(up{deployment="host", cluster="platform-cluster"})
     for: 5m
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: The nodeinfo DaemonSet is missing or has no metrics.
-      description: The nodeinfo DaemonSet is missing or has no metrics.
+      summary: The host DaemonSet is missing or has no metrics.
+      description: The host DaemonSet is missing or has no metrics.
         Verify that the DaemonSet is healthy (`kubectl describe ds
-        nodeinfo`).
+        host`).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   # If any pod is down or otherwise broken, fire an alert, unless the node is


### PR DESCRIPTION
The old `nodeinfo` DaemonSet was subsumed and superseded by the new `host` one, but this alert did not get updated to reflect that. The naming convention of `HostExperimentMissing` is a little non-standard, at least compared to other similar alerts. To me, `HostMissing` was too ambiguous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/473)
<!-- Reviewable:end -->
