### PR TITLE
Adds scraping of the Linode VM for IPv6 monitoring.

### DIFF
--- a/IPV6_MONITORING.md
+++ b/IPV6_MONITORING.md
@@ -92,3 +92,15 @@ $ docker run --detach --publish 9115:9115 --volume `pwd`:/config \
     --restart always --name mlab-oti prom/blackbox-exporter:v0.12.0 \
     --config.file=/config/blackbox-exporter-config-mlab-oti.yml
 ```
+* Install node\_exporter so that we can scrape metrics from this machine.
+
+$ sudo apt install prometheus-node-exporter
+
+Then edit /etc/default/prometheus-node-exporter, comment out the existing ARGS
+definition, and add this one:
+
+ARGS="-collectors.enabled=filesystem,loadavg,meminfo,netdev"
+
+Restart node-exporter:
+
+$ sudo systemctl restart prometheus-node-exporter

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -355,6 +355,12 @@ scrape_configs:
     static_configs:
       - targets: ['epoxy-boot-api.{{PROJECT}}.measurementlab.net:9000']
 
+  # Scrape config for the node_exporter on the IPv6 Linode VM we use for
+  # monitoring IPv6.
+  - job_name: 'ipv6-node-exporter'
+    static_configs:
+      - targets: ['blackbox-exporter-ipv6.mlab-oti.measurementlab.net:9100']
+
   # Scrape config for federation.
   #
   # The '/federate' target allows retrieving a set of timeseries from other

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -359,7 +359,7 @@ scrape_configs:
   # monitoring IPv6.
   - job_name: 'ipv6-node-exporter'
     static_configs:
-      - targets: ['blackbox-exporter-ipv6.mlab-oti.measurementlab.net:9100']
+      - targets: ['blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:9100']
 
   # Scrape config for federation.
   #


### PR DESCRIPTION
The Linode VM we use for monitoring IPv6 on the platform is a critical piece of our overall monitoring configuration, but we are not currently scraping any metrics from it for basic resource monitoring. This PR addresses that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/487)
<!-- Reviewable:end -->
