### PR TITLE
Add blackbox-exporter-ipv6 vm to Ops_OamOverview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Ops_OamOverview.json
+++ b/config/federation/grafana/dashboards/Ops_OamOverview.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:605",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": false,
@@ -13,11 +12,10 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 209,
-  "iteration": 1532110127002,
+  "iteration": 1560433917273,
   "links": [],
   "panels": [
     {
@@ -33,7 +31,6 @@
       "repeat": "vm",
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:910",
           "selected": false,
           "text": "dns",
           "value": "dns"
@@ -72,12 +69,10 @@
       "mappingType": 1,
       "mappingTypes": [
         {
-          "$$hashKey": "object:1186",
           "name": "value to text",
           "value": 1
         },
         {
-          "$$hashKey": "object:1187",
           "name": "range to text",
           "value": 2
         }
@@ -85,6 +80,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "80%",
       "prefix": "",
@@ -99,7 +95,6 @@
       "repeat": null,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:910",
           "selected": false,
           "text": "dns",
           "value": "dns"
@@ -114,8 +109,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1110",
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
@@ -124,12 +118,10 @@
       ],
       "thresholds": "0.80,0.90",
       "title": "Root fs",
-      "transparent": false,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
         {
-          "$$hashKey": "object:1189",
           "op": "=",
           "text": "No data!",
           "value": "null"
@@ -178,6 +170,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -191,7 +184,6 @@
       ],
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:910",
           "selected": false,
           "text": "dns",
           "value": "dns"
@@ -206,8 +198,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1313",
-          "expr": "node_load15{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "node_load15{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -254,13 +245,13 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:910",
           "selected": false,
           "text": "dns",
           "value": "dns"
@@ -272,8 +263,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1395",
-          "expr": "(node_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=\"$vm.measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -283,7 +273,6 @@
       ],
       "thresholds": [
         {
-          "$$hashKey": "object:1618",
           "colorMode": "critical",
           "fill": true,
           "line": true,
@@ -293,6 +282,7 @@
         }
       ],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory usage",
       "tooltip": {
@@ -310,7 +300,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1464",
           "decimals": 2,
           "format": "percentunit",
           "label": null,
@@ -320,7 +309,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:1465",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -339,7 +327,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -361,13 +348,13 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:910",
           "selected": false,
           "text": "dns",
           "value": "dns"
@@ -379,8 +366,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1944",
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -388,8 +374,7 @@
           "refId": "A"
         },
         {
-          "$$hashKey": "object:1966",
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -399,6 +384,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network bits/s",
       "tooltip": {
@@ -416,7 +402,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1999",
           "format": "bps",
           "label": null,
           "logBase": 1,
@@ -425,7 +410,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:2000",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -450,11 +434,10 @@
       "id": 108,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:911",
           "selected": false,
           "text": "eb",
           "value": "eb"
@@ -493,12 +476,10 @@
       "mappingType": 1,
       "mappingTypes": [
         {
-          "$$hashKey": "object:1186",
           "name": "value to text",
           "value": 1
         },
         {
-          "$$hashKey": "object:1187",
           "name": "range to text",
           "value": 2
         }
@@ -506,6 +487,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "80%",
       "prefix": "",
@@ -518,12 +500,11 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:911",
           "selected": false,
           "text": "eb",
           "value": "eb"
@@ -538,8 +519,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1110",
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
@@ -548,12 +528,10 @@
       ],
       "thresholds": "0.80,0.90",
       "title": "Root fs",
-      "transparent": false,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
         {
-          "$$hashKey": "object:1189",
           "op": "=",
           "text": "No data!",
           "value": "null"
@@ -602,6 +580,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -613,12 +592,11 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:911",
           "selected": false,
           "text": "eb",
           "value": "eb"
@@ -633,8 +611,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1313",
-          "expr": "node_load15{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "node_load15{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -681,16 +658,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:911",
           "selected": false,
           "text": "eb",
           "value": "eb"
@@ -702,8 +679,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1395",
-          "expr": "(node_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=\"$vm.measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -713,7 +689,6 @@
       ],
       "thresholds": [
         {
-          "$$hashKey": "object:1618",
           "colorMode": "critical",
           "fill": true,
           "line": true,
@@ -723,6 +698,7 @@
         }
       ],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory usage",
       "tooltip": {
@@ -740,7 +716,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1464",
           "decimals": 2,
           "format": "percentunit",
           "label": null,
@@ -750,7 +725,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:1465",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -769,7 +743,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -791,16 +764,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:911",
           "selected": false,
           "text": "eb",
           "value": "eb"
@@ -812,8 +785,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1944",
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -821,8 +793,7 @@
           "refId": "A"
         },
         {
-          "$$hashKey": "object:1966",
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -832,6 +803,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network bits/s",
       "tooltip": {
@@ -849,7 +821,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1999",
           "format": "bps",
           "label": null,
           "logBase": 1,
@@ -858,7 +829,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:2000",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -883,11 +853,10 @@
       "id": 113,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:912",
           "selected": false,
           "text": "mirror",
           "value": "mirror"
@@ -926,12 +895,10 @@
       "mappingType": 1,
       "mappingTypes": [
         {
-          "$$hashKey": "object:1186",
           "name": "value to text",
           "value": 1
         },
         {
-          "$$hashKey": "object:1187",
           "name": "range to text",
           "value": 2
         }
@@ -939,6 +906,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "80%",
       "prefix": "",
@@ -951,12 +919,11 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:912",
           "selected": false,
           "text": "mirror",
           "value": "mirror"
@@ -971,8 +938,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1110",
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
@@ -981,12 +947,10 @@
       ],
       "thresholds": "0.80,0.90",
       "title": "Root fs",
-      "transparent": false,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
         {
-          "$$hashKey": "object:1189",
           "op": "=",
           "text": "No data!",
           "value": "null"
@@ -1035,6 +999,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -1046,12 +1011,11 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:912",
           "selected": false,
           "text": "mirror",
           "value": "mirror"
@@ -1066,8 +1030,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "$$hashKey": "object:1313",
-          "expr": "node_load15{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "node_load15{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1114,16 +1077,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:912",
           "selected": false,
           "text": "mirror",
           "value": "mirror"
@@ -1135,8 +1098,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1395",
-          "expr": "(node_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=\"$vm.measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=\"$vm.measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -1146,7 +1108,6 @@
       ],
       "thresholds": [
         {
-          "$$hashKey": "object:1618",
           "colorMode": "critical",
           "fill": true,
           "line": true,
@@ -1156,6 +1117,7 @@
         }
       ],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory usage",
       "tooltip": {
@@ -1173,7 +1135,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1464",
           "decimals": 2,
           "format": "percentunit",
           "label": null,
@@ -1183,7 +1144,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:1465",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1202,7 +1162,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -1224,16 +1183,16 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1532110127002,
+      "repeatIteration": 1560433917273,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
         "vm": {
-          "$$hashKey": "object:912",
           "selected": false,
           "text": "mirror",
           "value": "mirror"
@@ -1245,8 +1204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:1944",
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1254,8 +1212,7 @@
           "refId": "A"
         },
         {
-          "$$hashKey": "object:1966",
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=\"$vm.measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1265,6 +1222,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network bits/s",
       "tooltip": {
@@ -1282,7 +1240,6 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1999",
           "format": "bps",
           "label": null,
           "logBase": 1,
@@ -1291,7 +1248,425 @@
           "show": true
         },
         {
-          "$$hashKey": "object:2000",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 118,
+      "panels": [],
+      "repeat": null,
+      "repeatIteration": 1560433917273,
+      "repeatPanelId": 95,
+      "scopedVars": {
+        "vm": {
+          "selected": false,
+          "text": "blackbox-exporter-ipv6",
+          "value": "blackbox-exporter-ipv6"
+        }
+      },
+      "title": "$vm",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 22
+      },
+      "id": 119,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "80%",
+      "prefix": "",
+      "prefixFontSize": "80%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": 1560433917273,
+      "repeatPanelId": 18,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "vm": {
+          "selected": false,
+          "text": "blackbox-exporter-ipv6",
+          "value": "blackbox-exporter-ipv6"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.80,0.90",
+      "title": "Root fs",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "No data!",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 22
+      },
+      "id": 120,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeatIteration": 1560433917273,
+      "repeatPanelId": 7,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "vm": {
+          "selected": false,
+          "text": "blackbox-exporter-ipv6",
+          "value": "blackbox-exporter-ipv6"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "node_load15{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 2,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "5,10",
+      "title": "Load15",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "No data!",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 22
+      },
+      "id": 121,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1560433917273,
+      "repeatPanelId": 97,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "vm": {
+          "selected": false,
+          "text": "blackbox-exporter-ipv6",
+          "value": "blackbox-exporter-ipv6"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "60s",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 0.9,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 22
+      },
+      "id": 122,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1560433917273,
+      "repeatPanelId": 107,
+      "repeatedByRow": true,
+      "scopedVars": {
+        "vm": {
+          "selected": false,
+          "text": "blackbox-exporter-ipv6",
+          "value": "blackbox-exporter-ipv6"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "{{device}} In",
+          "refId": "A"
+        },
+        {
+          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "{{device}} Out",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network bits/s",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1306,24 +1681,26 @@
       }
     }
   ],
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "tags": [],
           "text": "default",
           "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Datasource",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -1340,31 +1717,33 @@
         "name": "vm",
         "options": [
           {
-            "$$hashKey": "object:909",
             "selected": true,
             "text": "All",
             "value": "$__all"
           },
           {
-            "$$hashKey": "object:910",
             "selected": false,
             "text": "dns",
             "value": "dns"
           },
           {
-            "$$hashKey": "object:911",
             "selected": false,
             "text": "eb",
             "value": "eb"
           },
           {
-            "$$hashKey": "object:912",
             "selected": false,
             "text": "mirror",
             "value": "mirror"
+          },
+          {
+            "selected": false,
+            "text": "blackbox-exporter-ipv6",
+            "value": "blackbox-exporter-ipv6"
           }
         ],
-        "query": "dns,eb,mirror",
+        "query": "dns,eb,mirror,blackbox-exporter-ipv6",
+        "skipUrlSync": false,
         "type": "custom"
       }
     ]
@@ -1401,5 +1780,5 @@
   "timezone": "",
   "title": "Ops: OA&M Overview",
   "uid": "gJ8d46Oik",
-  "version": 12
+  "version": 130
 }

--- a/config/federation/grafana/dashboards/Ops_OamOverview.json
+++ b/config/federation/grafana/dashboards/Ops_OamOverview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1560433917273,
+  "iteration": 1560447495922,
   "links": [],
   "panels": [
     {
@@ -327,6 +327,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -434,7 +435,7 @@
       "id": 108,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -500,7 +501,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -592,7 +593,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -663,7 +664,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -769,7 +770,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -853,7 +854,7 @@
       "id": 113,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -919,7 +920,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1011,7 +1012,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1082,7 +1083,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1188,7 +1189,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1272,7 +1273,7 @@
       "id": 118,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -1338,7 +1339,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1430,7 +1431,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1501,7 +1502,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1607,7 +1608,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560433917273,
+      "repeatIteration": 1560447495922,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1780,5 +1781,5 @@
   "timezone": "",
   "title": "Ops: OA&M Overview",
   "uid": "gJ8d46Oik",
-  "version": 130
+  "version": 131
 }


### PR DESCRIPTION
This PR adds the blackbox-exporter-ipv6 VM to the "Ops: OA&M dashboard".

The `instance="$vm.measurementlab.net"` condition has been replaced with a pattern matching to account for instance names containing the project name (such as blackbox-exporter-ipv6).

As discussed in a previous PR, I've left this dashboard `editable` as it makes making future changes easier and we cannot save provisioned dashboards anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/488)
<!-- Reviewable:end -->
