### PR TITLE
Add containerPort:9990 to expose Prometheus metrics

### DIFF
--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -30,6 +30,7 @@ spec:
                 "--label=in progress",
                 "--enable-inmemory={{GITHUB_RECEIVER_INMEMORY}}" ]
         ports:
+        # TODO: receiver and metrics should be available on the same port.
         - containerPort: 9393
           name: receiver
         - containerPort: 9990

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -30,3 +30,4 @@ spec:
                 "--enable-inmemory={{GITHUB_RECEIVER_INMEMORY}}" ]
         ports:
         - containerPort: 9393
+        - containerPort: 9990

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -13,6 +13,7 @@ spec:
         run: github-receiver
       annotations:
         prometheus.io/scrape: 'true'
+        prometheus.io/port: '9990'
     spec:
       containers:
       - name: github-receiver
@@ -30,4 +31,6 @@ spec:
                 "--enable-inmemory={{GITHUB_RECEIVER_INMEMORY}}" ]
         ports:
         - containerPort: 9393
+          name: receiver
         - containerPort: 9990
+          name: metrics


### PR DESCRIPTION
This PR adds a `containerPort: 9990` to the YAML deployment configuration for `github-receiver`. 

Prometheus metrics for this receiver are available at `<receiver-url>:9990/metrics`, while the HTTP server serving the webhook listens on port 9393. Since only port 9393 was exposed, Prometheus could not scrape the github-receiver metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/492)
<!-- Reviewable:end -->
