### PR TITLE
Changes the platform cluster datasource URL for mlab-oti

### DIFF
--- a/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-oti.yml.template
@@ -8,7 +8,7 @@ datasources:
   type: prometheus
   access: proxy
   orgId: 1
-  url: http://k8s-prometheus.mlab-oti.measurementlab.net:9090
+  url: http://prometheus-platform-cluster.mlab-oti.measurementlab.net:9090
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: false


### PR DESCRIPTION
We migrated the mlab-oti platform cluster to use the new GCP object/resource names and domain names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/499)
<!-- Reviewable:end -->
