### PR TITLE
Modifies the PlatformCluster_PodDown alert to actually alert on pod failures

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1023,9 +1023,9 @@ groups:
   # node is down.
   - alert: PlatformCluster_PodDown
     expr: |
-      up{deployment=~".+", cluster="platform-cluster"} == 0 unless on(machine) (
-          lame_duck_node == 1 or
-          gmx_machine_maintenance == 1 or
+      kube_pod_info == 1 and on(exported_pod) kube_pod_status_ready{condition="true"} == 0 unless on(node) (
+          kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} or
+          label_replace(gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
           up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
         )
     for: 1h

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -318,6 +318,8 @@ scrape_configs:
         - 'kube_daemonset_status_desired_number_scheduled'
         - 'kube_deployment_status_replicas'
         - 'kube_deployment_spec_replicas'
+        - 'kube_pod_info'
+        - 'kube_pod_status_ready'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION
The current `PlatformCluster_PodDown` actually alerts on containers being down, and if an entire pod with 6 containers is down the we'll get 6 alerts, rather than the single one we want. This hopefully resolves issue #489.

Also in this PR, we remove the check on the `lame_duck_node` metric, which is a legacy metric that no longer exists on the platform cluster, and replaces it with a metric from our new way of lame-ducking a node (adding a taint with a key of `lame-duck`).

Additionally, currently GMX does not export a `node` label, so we add one using `label_replace` so that we can match all criteria `on(node)`.  I have opened an issue on the [an issue on the GMX repo](https://github.com/m-lab/github-maintenance-exporter/issues/22) to add a `node` label to all metrics to avoid this ugly use of `label_replace`.

This PR is dependent on PR https://github.com/m-lab/k8s-support/pull/239.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/507)
<!-- Reviewable:end -->
