### PR TITLE
Removes anything to do with the scraper-cluster in .travis.yml for sandbox and staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,14 +70,6 @@ deploy:
     condition: "$TRAVIS_EVENT_TYPE == push"
 
 - provider: script
-  script: "$TRAVIS_BUILD_DIR/kubectl.sh mlab-sandbox scraper-cluster ./apply-cluster.sh"
-  skip_cleanup: true
-  on:
-    repo: m-lab/prometheus-support
-    branch: sandbox-*
-    condition: "$TRAVIS_EVENT_TYPE == push"
-
-- provider: script
   script: "$TRAVIS_BUILD_DIR/kubectl.sh mlab-sandbox downloader ./apply-cluster.sh"
   skip_cleanup: true
   on:
@@ -120,14 +112,6 @@ deploy:
 
 - provider: script
   script: $TRAVIS_BUILD_DIR/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
-  skip_cleanup: true
-  on:
-    repo: m-lab/prometheus-support
-    all_branches: true
-    condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
-
-- provider: script
-  script: $TRAVIS_BUILD_DIR/kubectl.sh mlab-staging scraper-cluster ./apply-cluster.sh
   skip_cleanup: true
   on:
     repo: m-lab/prometheus-support


### PR DESCRIPTION
We no longer use scraper in those projects, so let's not setup anything to do with scraper in those projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/508)
<!-- Reviewable:end -->
