### PR TITLE
Update NDT: Early warning to support k8s platform nodes

### DIFF
--- a/config/federation/grafana/dashboards/K8s_MasterCluster.json
+++ b/config/federation/grafana/dashboards/K8s_MasterCluster.json
@@ -994,7 +994,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -2022,7 +2022,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -3050,7 +3050,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", node=\"k8s-platform-master-$master\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -891,7 +891,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -982,7 +982,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_free_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_avail_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2417,7 +2417,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2511,7 +2511,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_free_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_avail_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3970,7 +3970,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"} -\n    node_filesystem_avail_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -4064,7 +4064,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_free_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"} -\n  node_filesystem_avail_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"})\n  / node_filesystem_size_bytes{mountpoint=\"/cache/data\", node=\"$node.$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,

--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -521,7 +521,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "inotify $machine.$site > 60 rpm",
+      "title": "NDT Test Count $machine.$site > 60 rpm",
       "tooltip": {
         "shared": false,
         "sort": 2,

--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -2,7 +2,6 @@
   "annotations": {
     "list": [
       {
-        "$$hashKey": "object:705",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": false,
@@ -13,11 +12,10 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 48,
-  "iteration": 1539288858555,
+  "iteration": 1564600646975,
   "links": [],
   "panels": [
     {
@@ -31,6 +29,7 @@
       "id": 8,
       "links": [],
       "mode": "markdown",
+      "options": {},
       "title": "",
       "type": "text"
     },
@@ -76,6 +75,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -105,7 +105,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:261",
           "expr": "candidate_machine:inotify_extension_create_rpm:98th_quantile_$interval / 120 > ($percent / 100)",
           "format": "time_series",
           "hide": false,
@@ -116,7 +115,6 @@
           "step": 300
         },
         {
-          "$$hashKey": "object:262",
           "expr": "candidate_site:uplink:98th_quantile_$interval{ifAlias=\"uplink\", speed=\"1g\"} / 1e9 > ($percent / 100) OR candidate_site:uplink:98th_quantile_$interval{ifAlias=\"uplink\", speed=\"10g\"} / 10e9 > ($percent / 100)",
           "format": "time_series",
           "hide": false,
@@ -127,7 +125,6 @@
           "step": 300
         },
         {
-          "$$hashKey": "object:263",
           "expr": "candidate_machine:node_disk_io_time_ratio:98th_quantile_$interval > ($percent / 100)",
           "format": "time_series",
           "hide": false,
@@ -138,7 +135,6 @@
           "step": 300
         },
         {
-          "$$hashKey": "object:264",
           "expr": "candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_$interval / 100e6 > ($percent / 100)",
           "format": "time_series",
           "hide": false,
@@ -151,6 +147,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$interval, 98th Percentiles that are over $percent% Capacity",
       "tooltip": {
@@ -233,6 +230,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -262,7 +260,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:518",
           "expr": "candidate_site:uplink:90th_quantile_6h{ifAlias=\"uplink\", speed=\"1g\"} / 1e9 > (40 / 100)",
           "format": "time_series",
           "hide": false,
@@ -275,6 +272,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "6h, 1G sites where 90th Percentile is over 40% Capacity",
       "tooltip": {
@@ -357,6 +355,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -392,7 +391,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:333",
           "expr": "quantile_over_time(0.9, machine:inotify_extension_create:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 60",
           "format": "time_series",
           "hide": false,
@@ -403,7 +401,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:334",
           "expr": "quantile_over_time(0.98, machine:inotify_extension_create:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 96",
           "format": "time_series",
           "interval": "1m",
@@ -412,7 +409,6 @@
           "refId": "D"
         },
         {
-          "$$hashKey": "object:335",
           "expr": "machine:inotify_extension_create:rpm2m{machine=~\"$machine.$site.*\"}",
           "format": "time_series",
           "hide": false,
@@ -423,7 +419,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:336",
           "expr": "quantile_over_time(0.90, machine:inotify_extension_create:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "instant": false,
@@ -433,7 +428,6 @@
           "refId": "C"
         },
         {
-          "$$hashKey": "object:337",
           "expr": "quantile_over_time(0.98, machine:inotify_extension_create:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "instant": false,
@@ -441,10 +435,60 @@
           "intervalFactor": 1,
           "legendFormat": "q98 - {{machine}}",
           "refId": "E"
+        },
+        {
+          "expr": "/* k8s */",
+          "format": "time_series",
+          "hide": true,
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "F"
+        },
+        {
+          "expr": "quantile_over_time(0.9, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 60",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "warning - {{machine}}",
+          "refId": "G"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 96",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "error - {{machine}}",
+          "refId": "H"
+        },
+        {
+          "expr": "machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "raw - {{machine}}",
+          "refId": "I"
+        },
+        {
+          "expr": "quantile_over_time(0.90, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q90 - {{machine}}",
+          "refId": "J"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q98 - {{machine}}",
+          "refId": "K"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "inotify $machine.$site > 60 rpm",
       "tooltip": {
@@ -526,6 +570,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -564,7 +609,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:592",
           "expr": "quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"1g\"}[$range]) > 500e6",
           "format": "time_series",
           "hide": false,
@@ -574,7 +618,6 @@
           "refId": "E"
         },
         {
-          "$$hashKey": "object:593",
           "expr": "quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"1g\"}[$range]) > 600e6",
           "format": "time_series",
           "intervalFactor": 2,
@@ -582,7 +625,6 @@
           "refId": "F"
         },
         {
-          "$$hashKey": "object:594",
           "expr": "switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"1g\"}",
           "format": "time_series",
           "hide": false,
@@ -592,7 +634,6 @@
           "refId": "C"
         },
         {
-          "$$hashKey": "object:595",
           "expr": "quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"1g\"}[$range])",
           "format": "time_series",
           "interval": "1m",
@@ -601,7 +642,6 @@
           "refId": "D"
         },
         {
-          "$$hashKey": "object:596",
           "expr": "quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"1g\"}[$range])",
           "format": "time_series",
           "hide": false,
@@ -611,7 +651,6 @@
           "refId": "A"
         },
         {
-          "$$hashKey": "object:597",
           "expr": "quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"10g\"}[$range]) > 5e9",
           "format": "time_series",
           "interval": "1m",
@@ -620,7 +659,6 @@
           "refId": "B"
         },
         {
-          "$$hashKey": "object:598",
           "expr": "quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"10g\"}[$range]) > 6e9",
           "format": "time_series",
           "interval": "1m",
@@ -629,7 +667,6 @@
           "refId": "G"
         },
         {
-          "$$hashKey": "object:599",
           "expr": "switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"10g\"}",
           "format": "time_series",
           "interval": "1m",
@@ -638,7 +675,6 @@
           "refId": "H"
         },
         {
-          "$$hashKey": "object:600",
           "expr": "quantile_over_time(0.90, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"10g\"}[$range])",
           "format": "time_series",
           "interval": "1m",
@@ -647,7 +683,6 @@
           "refId": "I"
         },
         {
-          "$$hashKey": "object:601",
           "expr": "quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias=\"uplink\", site=~\"$site.*\", speed=\"10g\"}[$range])",
           "format": "time_series",
           "interval": "1m",
@@ -658,6 +693,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "switch $site - > 500 Mbps",
       "tooltip": {
@@ -726,6 +762,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -761,7 +798,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:436",
           "expr": "quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range]) > 0.5",
           "format": "time_series",
           "hide": false,
@@ -772,7 +808,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:437",
           "expr": "quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range]) > 0.8",
           "format": "time_series",
           "hide": false,
@@ -783,7 +818,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:438",
           "expr": "machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}",
           "format": "time_series",
           "hide": false,
@@ -794,7 +828,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:439",
           "expr": "quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
@@ -805,7 +838,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:440",
           "expr": "quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
@@ -818,6 +850,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk IO Utilization $machine.$site - > 50%",
       "tooltip": {
@@ -885,6 +918,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -920,7 +954,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "$$hashKey": "object:724",
           "expr": "quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > 50000000",
           "format": "time_series",
           "interval": "1m",
@@ -930,7 +963,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:725",
           "expr": "quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > 80000000",
           "format": "time_series",
           "interval": "1m",
@@ -940,7 +972,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:726",
           "expr": "ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
           "format": "time_series",
           "hide": false,
@@ -951,7 +982,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:727",
           "expr": "quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
           "format": "time_series",
           "hide": false,
@@ -962,7 +992,6 @@
           "step": 900
         },
         {
-          "$$hashKey": "object:728",
           "expr": "quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
           "format": "time_series",
           "hide": false,
@@ -975,6 +1004,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Disk Usage - 12hour estimates - $machine.$site - > 50GB",
       "tooltip": {
@@ -1015,30 +1045,34 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "tags": [],
-          "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "selected": false,
+          "text": "Prometheus (mlab-sandbox)",
+          "value": "Prometheus (mlab-sandbox)"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Datasource",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "Prometheus.*",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {
           "selected": true,
+          "tags": [],
           "text": "mlab1",
           "value": "mlab1"
         },
@@ -1070,15 +1104,17 @@
           }
         ],
         "query": "mlab1,mlab2,mlab3,mlab4",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
         "current": {
-          "text": "ord02",
-          "value": "ord02"
+          "text": "lga.t",
+          "value": "lga.t"
         },
         "datasource": null,
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Site",
@@ -1088,6 +1124,7 @@
         "query": "label_values(machine)",
         "refresh": 1,
         "regex": ".*mlab[1-4].([a-z]{3}..).*",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -1175,12 +1212,13 @@
           }
         ],
         "query": "5m,15m,30m,1h,2h,3h,4h,6h,8h,10h,12h,18h,24h",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "6h",
           "value": "6h"
         },
@@ -1202,13 +1240,13 @@
           }
         ],
         "query": "2h,6h",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "tags": [],
+          "selected": true,
           "text": "80",
           "value": "80"
         },
@@ -1235,12 +1273,13 @@
           }
         ],
         "query": "60,75,80",
+        "skipUrlSync": false,
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -1271,5 +1310,5 @@
   "timezone": "utc",
   "title": "NDT: Early Warning",
   "uid": "UM67WeHmz",
-  "version": 52
+  "version": 139
 }

--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1564600646975,
+  "iteration": 1564682328114,
   "links": [],
   "panels": [
     {
@@ -1179,7 +1179,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Prometheus (mlab-sandbox)",
           "value": "Prometheus (mlab-sandbox)"
         },
@@ -1198,10 +1198,8 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "tags": [],
-          "text": "mlab1",
-          "value": "mlab1"
+          "text": "mlab.",
+          "value": "mlab."
         },
         "hide": 0,
         "includeAll": false,
@@ -1210,7 +1208,7 @@
         "name": "machine",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "mlab1",
             "value": "mlab1"
           },
@@ -1262,13 +1260,13 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "tags": [],
           "text": "2h",
           "value": "2h"
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Interval",
+        "label": "Range",
         "multi": false,
         "name": "range",
         "options": [
@@ -1346,22 +1344,23 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "6h",
-          "value": "6h"
+          "tags": [],
+          "text": "2h",
+          "value": "2h"
         },
         "hide": 0,
         "includeAll": false,
-        "label": "98th % Range",
+        "label": "98th % Interval",
         "multi": false,
         "name": "interval",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "2h",
             "value": "2h"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "6h",
             "value": "6h"
           }
@@ -1406,7 +1405,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -1437,5 +1436,5 @@
   "timezone": "utc",
   "title": "NDT: Early Warning",
   "uid": "UM67WeHmz",
-  "version": 139
+  "version": 141
 }

--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -135,7 +135,7 @@
           "step": 300
         },
         {
-          "expr": "candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_$interval / 100e6 > ($percent / 100)",
+          "expr": "candidate_ndt:vdlimit_used_ratio_12h_prediction:98th_quantile_$interval > ($percent / 100)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -143,6 +143,37 @@
           "legendFormat": "disk usage > $percent% {{machine}}",
           "refId": "H",
           "step": 300
+        },
+        {
+          "expr": "/* k8s */",
+          "format": "time_series",
+          "hide": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "expr": "machine:ndt_test_rpm:98th_quantile_$interval / 120 > ($percent / 100)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "ndt_tests  > $percent% - {{machine}}",
+          "refId": "B"
+        },
+        {
+          "expr": "machine:node_disk_io_time_seconds_max:98th_quantile_$interval > ($percent / 100)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "disk i/o > $percent% {{machine}}",
+          "refId": "C"
+        },
+        {
+          "expr": "machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_$interval > ($percent/100)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "disk usage > $percent% {{machine}}",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -747,6 +778,7 @@
         "y": 22
       },
       "id": 14,
+      "interval": "",
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -846,6 +878,53 @@
           "legendFormat": "q98 - {{machine}}",
           "refId": "E",
           "step": 900
+        },
+        {
+          "expr": "/* k8s */",
+          "format": "time_series",
+          "hide": true,
+          "intervalFactor": 1,
+          "refId": "F"
+        },
+        {
+          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range]) > 0.5",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "warning - {{machine}}",
+          "refId": "G"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range]) > 0.8",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "error - {{machine}}",
+          "refId": "H"
+        },
+        {
+          "expr": "machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "raw - {{machine}}",
+          "refId": "I"
+        },
+        {
+          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q90 - {{machine}}",
+          "refId": "J"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q98 - {{machine}}",
+          "refId": "K"
         }
       ],
       "thresholds": [],
@@ -954,7 +1033,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > 50000000",
+          "expr": "quantile_over_time(0.90, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .5",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -963,7 +1042,7 @@
           "step": 900
         },
         {
-          "expr": "quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > 80000000",
+          "expr": "quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .8",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -972,7 +1051,7 @@
           "step": 900
         },
         {
-          "expr": "ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
+          "expr": "ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -982,7 +1061,7 @@
           "step": 900
         },
         {
-          "expr": "quantile_over_time(0.90, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "expr": "quantile_over_time(0.90, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -992,7 +1071,7 @@
           "step": 900
         },
         {
-          "expr": "quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "expr": "quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1000,6 +1079,54 @@
           "legendFormat": "q98 - {{machine}}",
           "refId": "A",
           "step": 900
+        },
+        {
+          "expr": "/* k8s */",
+          "format": "time_series",
+          "hide": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .5",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "warning - {{machine}}",
+          "refId": "C"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .8",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "error - {{machine}}",
+          "refId": "D"
+        },
+        {
+          "expr": "machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "raw - {{machine}}",
+          "refId": "I"
+        },
+        {
+          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q90 - {{machine}}",
+          "refId": "J"
+        },
+        {
+          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "q98 - {{machine}}",
+          "refId": "K"
         }
       ],
       "thresholds": [],
@@ -1022,7 +1149,7 @@
       },
       "yaxes": [
         {
-          "format": "deckbytes",
+          "format": "percentunit",
           "label": "Used Space",
           "logBase": 1,
           "max": null,

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -320,6 +320,12 @@ scrape_configs:
         - 'kube_deployment_spec_replicas'
         - 'kube_pod_info'
         - 'kube_pod_status_ready'
+        # For recording rules for NDT Early Warning dashboard and Global Test Rates.
+        - 'ndt_test_total'
+        - 'ndt_active_tests'
+        - 'node_disk_io_time_seconds_total{deployment="node-exporter"}'
+        - 'node_filesystem_avail_bytes{mountpoint="/cache/data"}'
+        - 'node_filesystem_size_bytes{mountpoint="/cache/data"}'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -306,7 +306,7 @@ scrape_configs:
         - 'up{job=~".+"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
-        - 'node_filesystem_free_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
+        - 'node_filesystem_avail_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'kube_node_spec_taint{key="lame-duck"}'
         - 'etcd_server_has_leader'
         - 'etcd_server_leader_changes_seen_total'
@@ -324,8 +324,6 @@ scrape_configs:
         - 'ndt_test_total'
         - 'ndt_active_tests'
         - 'node_disk_io_time_seconds_total{deployment="node-exporter"}'
-        - 'node_filesystem_avail_bytes{mountpoint="/cache/data"}'
-        - 'node_filesystem_size_bytes{mountpoint="/cache/data"}'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -120,69 +120,112 @@ groups:
 # 90th percentiles @ 30m
   - record: candidate_site:uplink:90th_quantile_30m
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[30m])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[30m])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[30m])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_30m
     expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[30m])
+  # k8s
+  - record: machine:ndt_test_rpm:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[30m])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[30m])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[30m])
+
 # 90th percentiles @ 1h.
   - record: candidate_site:uplink:90th_quantile_1h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[1h])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[1h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[1h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_1h
     expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[1h])
+  # k8s
+  - record: machine:ndt_test_rpm:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[1h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[1h])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[1h])
+
 # 90th percentiles @ 2h.
   - record: candidate_site:uplink:90th_quantile_2h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[2h])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[2h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[2h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_2h
     expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[2h])
+  # k8s
+  - record: machine:ndt_test_rpm:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[2h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[2h])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[2h])
+
 # 90th percentiles @ 6h.
   - record: candidate_site:uplink:90th_quantile_6h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[6h])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[6h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[6h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_6h
     expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[6h])
+  # k8s
+  - record: machine:ndt_test_rpm:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[6h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[6h])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[6h])
+
 ##############################################################################
 # 98th percentiles @ 2h.
   - record: candidate_site:uplink:98th_quantile_2h
     expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[2h])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:inotify_extension_create:rpm2m[2h])
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[2h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_2h
     expr: quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h[2h])
+  # k8s
+  - record: machine:ndt_test_rpm:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[2h])
+  - record: machine:node_disk_io_time_seconds_max:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[2h])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_bytes:predict_linear3h_12h[2h])
+
 # 98th percentiles @ 6h.
   - record: candidate_site:uplink:98th_quantile_6h
     expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink"}[6h])
+  # vserver
   - record: candidate_machine:inotify_extension_create_rpm:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:inotify_extension_create:rpm2m[6h])
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[6h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_6h
     expr: quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h[6h])
-## NDT Early Warning 2x site capacity thresholds.
-#
-# Raw boolean threshold violations.
-  - record: candidate_site:uplink:gt_500mbps
-    expr: switch:ifHCOutOctets:bps2m{ifAlias="uplink"} > bool 5e+08
-  - record: candidate_machine:inotify_extension_create_rpm:gt_60
-    expr: machine:inotify_extension_create:rpm2m > bool 60
-  - record: candidate_machine:node_disk_io_time_ratio:gt_50_pct
-    expr: machine:node_disk_io_time_ms:max_ratio2m > bool 0.5
-  - record: candidate_ndt:vdlimit_used_12h_prediction:gt_50gb
-    expr: ndt:vdlimit_used:predict_linear3h_12h > bool 5e+07
+  # k8s
+  - record: machine:ndt_test_rpm:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[6h])
+  - record: machine:node_disk_io_time_seconds_max:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[6h])
+  - record: machine:node_filesystem_used_bytes_12h_prediction:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_bytes:predict_linear3h_12h[6h])
+
 ## Parser volume checks.
 #
 # This rule optimizes the alert query used for ParserDailyVolumeTooLow. Rather

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -56,21 +56,27 @@ groups:
 # Units: requests per minute.
   - record: machine:inotify_extension_create:rpm2m
     expr: 60 * sum without(ext) (irate(inotify_extension_create_total{ext=~".*_snaplog"}[4m]))
-# TODO: aggregate on per-machine interface aliases when available.
-# Per-switch "Out" (i.e. Download) bits per second. We use irate to calculate
-# rates over the last two samples only.
-# Units: bits per second.
+  # TODO: aggregate on per-machine interface aliases when available.
+  # Per-switch "Out" (i.e. Download) bits per second. We use irate to calculate
+  # rates over the last two samples only.
+  # Units: bits per second.
   - record: switch:ifHCOutOctets:bps2m
     expr: 8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m])
-# Per-machine maximum ratio of time spent performing I/O on all devices.
-# Units: none (sec/sec)
+  # Per-machine maximum ratio of time spent performing I/O on all devices.
+  # Units: none (sec/sec)
   - record: machine:node_disk_io_time_ms:max_ratio2m
     expr: max without(device) (irate(node_disk_io_time_ms{service="nodeexporter"}[4m])) / 1000
-# NDT vserver disk quota utilization, 12 hour estimate. Base 12h estimate on a
-# time range at least 25% of the time forward.
-# Units: KB
+  # NDT vserver disk quota utilization, 12 hour estimate. Base 12h estimate on a
+  # time range at least 25% of the time forward.
+  # Units: KB
+  # TODO: remove this metric in favor of the ratio metrics below.
   - record: ndt:vdlimit_used:predict_linear3h_12h
     expr: predict_linear(vdlimit_used{experiment="ndt.iupui"}[3h], 12 * 60 * 60)
+  # NOTE: here we add a ratio value to calculate %used rather than an absolute usage count.
+  - record: ndt:vdlimit_used_bytes:ratio
+    expr: vdlimit_used{experiment="ndt.iupui"} / vdlimit_total{experiment="ndt.iupui"}
+  - record: ndt:vdlimit_used_ratio:predict_linear3h_12h
+    expr: predict_linear(ndt:vdlimit_used_bytes:ratio[3h], 12 * 60 * 60)
 
 ## NDT Early Warning aggregation rules for Kubernetes platform.
 #
@@ -84,7 +90,7 @@ groups:
     expr: max without(device) (irate(node_disk_io_time_seconds_total{deployment="node-exporter"}[4m]))
   # Machine disk quota utilization, 12 hour estimate. Base 12h estimate on a
   # time range at least 25% of the time forward.
-  # Units: B(ytes)
+  # Units: none (bytes/bytes)
   - record: machine:node_filesystem_used_bytes:ratio
     expr: 1 - node_filesystem_avail_bytes{mountpoint="/cache/data"} / node_filesystem_size_bytes{mountpoint="/cache/data"}
   # NOTE: this expression uses the recording rule above. This may add an extra
@@ -126,7 +132,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[30m])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_30m
-    expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[30m])
+    expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[30m])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[30m])
@@ -144,7 +150,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[1h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_1h
-    expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[1h])
+    expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[1h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[1h])
@@ -162,7 +168,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[2h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_2h
-    expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[2h])
+    expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[2h])
@@ -180,7 +186,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[6h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_6h
-    expr: quantile_over_time(0.9, ndt:vdlimit_used:predict_linear3h_12h[6h])
+    expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[6h])
@@ -199,7 +205,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[2h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_2h
-    expr: quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h[2h])
+    expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
   - record: machine:ndt_test_rpm:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[2h])
@@ -217,7 +223,7 @@ groups:
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[6h])
   - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_6h
-    expr: quantile_over_time(0.98, ndt:vdlimit_used:predict_linear3h_12h[6h])
+    expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
   - record: machine:ndt_test_rpm:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[6h])

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -39,6 +39,7 @@ groups:
 # Precalculate the sum of sidestream connections per experiment "last six bits".
   - record: lsb:sidestream_connection_count:increase2m
     expr: sum by(lsb) (increase(sidestream_connection_count{type=~"ipv4|ipv6"}[2m]))
+
 ## NDT Early Warning aggregation rules.
 #
 # Rules are evaluated every global.evaluation_interval seconds. When
@@ -62,7 +63,7 @@ groups:
   - record: switch:ifHCOutOctets:bps2m
     expr: 8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m])
 # Per-machine maximum ratio of time spent performing I/O on all devices.
-# Units: none
+# Units: none (sec/sec)
   - record: machine:node_disk_io_time_ms:max_ratio2m
     expr: max without(device) (irate(node_disk_io_time_ms{service="nodeexporter"}[4m])) / 1000
 # NDT vserver disk quota utilization, 12 hour estimate. Base 12h estimate on a
@@ -70,6 +71,27 @@ groups:
 # Units: KB
   - record: ndt:vdlimit_used:predict_linear3h_12h
     expr: predict_linear(vdlimit_used{experiment="ndt.iupui"}[3h], 12 * 60 * 60)
+
+## NDT Early Warning aggregation rules for Kubernetes platform.
+#
+# Per-machine successful NDT5 tests counted by the server.
+# Units: requests per minute.
+  - record: machine:ndt_test:rpm2m
+    expr: 60 * sum without(direction) (irate(ndt_test_total{code="200"}[4m]))
+  # Per-machine maximum ratio of time spent performing I/O on all devices.
+  # Units: none (sec/sec)
+  - record: machine:node_disk_io_time_seconds:max2m
+    expr: max without(device) (irate(node_disk_io_time_seconds_total{deployment="node-exporter"}[4m]))
+  # Machine disk quota utilization, 12 hour estimate. Base 12h estimate on a
+  # time range at least 25% of the time forward.
+  # Units: B(ytes)
+  - record: node:node_filesystem_used_bytes
+    expr: 1 - node_filesystem_avail_bytes{mountpoint="/cache/data"} / node_filesystem_size_bytes{mountpoint="/cache/data"}
+  # NOTE: this expression uses the recording rule above. This may add an extra
+  # minute to current data, but the time scale of the prediction is much longer.
+  - record: node:node_filesystem_used_bytes:predict_linear3h_12h
+    expr: predict_linear(node:node_filesystem_used_bytes[3h], 12 * 60 * 60)
+
 ## Switch SNMP metrics
 #
 # Discarded packets for Junipers

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -85,12 +85,12 @@ groups:
   # Machine disk quota utilization, 12 hour estimate. Base 12h estimate on a
   # time range at least 25% of the time forward.
   # Units: B(ytes)
-  - record: machine:node_filesystem_used_bytes
+  - record: machine:node_filesystem_used_bytes:ratio
     expr: 1 - node_filesystem_avail_bytes{mountpoint="/cache/data"} / node_filesystem_size_bytes{mountpoint="/cache/data"}
   # NOTE: this expression uses the recording rule above. This may add an extra
   # minute to current data, but the time scale of the prediction is much longer.
-  - record: machine:node_filesystem_used_bytes:predict_linear3h_12h
-    expr: predict_linear(machine:node_filesystem_used_bytes[3h], 12 * 60 * 60)
+  - record: machine:node_filesystem_used_ratio:predict_linear3h_12h
+    expr: predict_linear(machine:node_filesystem_used_bytes:ratio[3h], 12 * 60 * 60)
 
 ## Switch SNMP metrics
 #
@@ -132,8 +132,8 @@ groups:
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[30m])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[30m])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_30m
-    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[30m])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:node_filesystem_ratio_bytes:predict_linear3h_12h[30m])
 
 # 90th percentiles @ 1h.
   - record: candidate_site:uplink:90th_quantile_1h
@@ -150,8 +150,8 @@ groups:
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[1h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[1h])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_1h
-    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[1h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[1h])
 
 # 90th percentiles @ 2h.
   - record: candidate_site:uplink:90th_quantile_2h
@@ -168,8 +168,8 @@ groups:
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[2h])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_2h
-    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[2h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
 
 # 90th percentiles @ 6h.
   - record: candidate_site:uplink:90th_quantile_6h
@@ -186,8 +186,8 @@ groups:
     expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[6h])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:90th_quantile_6h
-    expr: quantile_over_time(0.9, machine:node_filesystem_used_bytes:predict_linear3h_12h[6h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[6h])
 
 ##############################################################################
 # 98th percentiles @ 2h.
@@ -205,8 +205,8 @@ groups:
     expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[2h])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:98th_quantile_2h
-    expr: quantile_over_time(0.98, machine:node_filesystem_used_bytes:predict_linear3h_12h[2h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
 
 # 98th percentiles @ 6h.
   - record: candidate_site:uplink:98th_quantile_6h
@@ -223,8 +223,8 @@ groups:
     expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[6h])
-  - record: machine:node_filesystem_used_bytes_12h_prediction:98th_quantile_6h
-    expr: quantile_over_time(0.98, machine:node_filesystem_used_bytes:predict_linear3h_12h[6h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h[6h])
 
 ## Parser volume checks.
 #

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -131,7 +131,7 @@ groups:
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[30m])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[30m])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_30m
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_30m
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[30m])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_30m
@@ -149,7 +149,7 @@ groups:
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[1h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[1h])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_1h
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_1h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[1h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_1h
@@ -167,7 +167,7 @@ groups:
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[2h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[2h])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_2h
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_2h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_2h
@@ -185,7 +185,7 @@ groups:
     expr: quantile_over_time(0.9, machine:inotify_extension_create:rpm2m[6h])
   - record: candidate_machine:node_disk_io_time_ratio:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_ms:max_ratio2m[6h])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:90th_quantile_6h
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_6h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
   - record: machine:ndt_test_rpm:90th_quantile_6h
@@ -204,7 +204,7 @@ groups:
     expr: quantile_over_time(0.98, machine:inotify_extension_create:rpm2m[2h])
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[2h])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_2h
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:98th_quantile_2h
     expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
   - record: machine:ndt_test_rpm:98th_quantile_2h
@@ -222,7 +222,7 @@ groups:
     expr: quantile_over_time(0.98, machine:inotify_extension_create:rpm2m[6h])
   - record: candidate_machine:node_disk_io_time_ratio:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m[6h])
-  - record: candidate_ndt:vdlimit_used_12h_prediction:98th_quantile_6h
+  - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:98th_quantile_6h
     expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
   - record: machine:ndt_test_rpm:98th_quantile_6h

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -85,12 +85,12 @@ groups:
   # Machine disk quota utilization, 12 hour estimate. Base 12h estimate on a
   # time range at least 25% of the time forward.
   # Units: B(ytes)
-  - record: node:node_filesystem_used_bytes
+  - record: machine:node_filesystem_used_bytes
     expr: 1 - node_filesystem_avail_bytes{mountpoint="/cache/data"} / node_filesystem_size_bytes{mountpoint="/cache/data"}
   # NOTE: this expression uses the recording rule above. This may add an extra
   # minute to current data, but the time scale of the prediction is much longer.
-  - record: node:node_filesystem_used_bytes:predict_linear3h_12h
-    expr: predict_linear(node:node_filesystem_used_bytes[3h], 12 * 60 * 60)
+  - record: machine:node_filesystem_used_bytes:predict_linear3h_12h
+    expr: predict_linear(machine:node_filesystem_used_bytes[3h], 12 * 60 * 60)
 
 ## Switch SNMP metrics
 #


### PR DESCRIPTION
This change consists of new recording rules and updates to the NDT:Early Warning dashboard.

Unfortunately, right now all sandbox nodes are new-stack, which means the changes to the vdlimit metrics are unverified for now.

The Early Warning dashboard panels now include "vserver" and "k8s" queries.

The prometheus server configuration template includes new metrics from the platform-cluster used by the recording rules that define the metrics below.

New metrics for vservers to report space used as a ratio 0-1 (as the k8s nodes now do):

- ndt:vdlimit_used_bytes:ratio
- ndt:vdlimit_used_ratio:predict_linear3h_12h (replaces ndt:vdlimit_used:predict_linear3h_12h)

New metrics for k8s nodes:

- machine:ndt_test:rpm2m - ndt test count
- machine:node_disk_io_time_seconds:max2m - disk io utilization
- machine:node_filesystem_used_bytes:ratio - used by predict_linear metric below.
- machine:node_filesystem_used_ratio:predict_linear3h_12h - 12hr prediction of used disk space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/510)
<!-- Reviewable:end -->
