### PR TITLE
Adds two new alerts for changed for lower-than-expected RAM.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1219,7 +1219,7 @@ groups:
       summary: System RAM is below the expected minimum value.
       description: All M-Lab machines have at least 16GB of RAM. The quantity
         of RAM on one or more machines has gone below 16GB, which may indicate
-        a failed RAM module. Log into the machine and double check
+        a failed RAM module. Login to the machine and double check
         the hardware and/or system messages.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
@@ -1236,6 +1236,36 @@ groups:
       summary: The amount of reported system RAM changed.
       description: The amount of RAM in a machine should never change. The
         reported amount of RAM in one or more machine changed, which may
-        indicate some problem with a RAM module. Log into the machine and
+        indicate some problem with a RAM module. Login to the machine and
         double check the hardware and/or system messages.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: PlatformHardware_EdacUncorrectableErrors
+    expr: |
+      node_edac_uncorrectable_errors_total{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"} > 0
+    for: 1d
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Uncorrectable errors detected in RAM.
+      description: EDAC metrics are reporting uncorrectable memory errors.
+        This may indicate a DIMM module beginning to go bad or an issue with
+        the mainboard. Login to the machine and double check the hardware
+        and/or system messages.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: PlatformHardware_EdacCorrectableErrors
+    expr: |
+      node_edac_correctable_errors_total{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"} > 0
+    for: 1d
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Correctable errors detected in RAM.
+      description: EDAC metrics are reporting correctable memory errors.
+        While correctable, this may indicate some issue with a DIMM module or
+        the mainboard. Login to the machine and double check the hardware
+        and/or system messages.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1223,23 +1223,6 @@ groups:
         the hardware and/or system messages.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  - alert: PlatformHardware_RamAmountChanged
-    expr: |
-      changes(
-        node_memory_MemTotal_bytes{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"}[1d]
-      ) != 0
-    for: 1m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: The amount of reported system RAM changed.
-      description: The amount of RAM in a machine should never change. The
-        reported amount of RAM in one or more machine changed, which may
-        indicate some problem with a RAM module. Login to the machine and
-        double check the hardware and/or system messages.
-      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
-
   - alert: PlatformHardware_EdacUncorrectableErrors
     expr: |
       node_edac_uncorrectable_errors_total{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"} > 0

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1206,4 +1206,36 @@ groups:
         bottleneck.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
-# Platform Cluster API server alerts.
+# Platform Hardware alerts
+
+  - alert: PlatformHardware_RamBelowExpected
+    expr: |
+      node_memory_MemTotal_bytes{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"} / 2^20 < 16000
+    for: 1d
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: System RAM is below the expected minimum value.
+      description: All M-Lab machines have at least 16GB of RAM. The quantity
+        of RAM on one or more machines has gone below 16GB, which may indicate
+        a failed RAM module. Log into the machine and double check
+        the hardware and/or system messages.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
+  - alert: PlatformHardware_RamAmountChanged
+    expr: |
+      changes(
+        node_memory_MemTotal_bytes{machine=~"^mlab[1-4].[a-z]{3}[0-9tc]{2}.*"}[1d]
+      ) != 0
+    for: 1m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The amount of reported system RAM changed.
+      description: The amount of RAM in a machine should never change. The
+        reported amount of RAM in one or more machine changed, which may
+        indicate some problem with a RAM module. Log into the machine and
+        double check the hardware and/or system messages.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -307,6 +307,7 @@ scrape_configs:
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_filesystem_avail_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
+        - 'node_memory_MemTotal_bytes'
         - 'kube_node_spec_taint{key="lame-duck"}'
         - 'etcd_server_has_leader'
         - 'etcd_server_leader_changes_seen_total'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -308,6 +308,8 @@ scrape_configs:
         - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_filesystem_avail_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
         - 'node_memory_MemTotal_bytes'
+        - 'node_edac_correctable_errors_total'
+        - 'node_edac_uncorrectable_errors_total'
         - 'kube_node_spec_taint{key="lame-duck"}'
         - 'etcd_server_has_leader'
         - 'etcd_server_leader_changes_seen_total'


### PR DESCRIPTION
This PR adds two new alerts to monitor changes in RAM on a machine. Mike Millner has been pressing us to check this sort of thing, because in his experience hardware goes bad all the time when you run enough of it. 

This PR is intended to resolve issue https://github.com/m-lab/ops-tracker/issues/523. That issue was opened thinking that we would monitor all sorts of things, but after considering, I couldn't think of anything else that is easily monitorable that we could alert on other than RAM.

**Note**: I'm a little unsure if the `PlatformHardware_RamAmountChanged` alert is implemented in the best way. Currently, I have it configured to look at changes in reported RAM over the past day, but to only tolerate those changes for 1m. The intention is that changes in RAM do no slip out of the sliding visibility window by setting the `for:` value too high. Please double check this for alert to be sure it makes sense. Another option would to alert on `delta()` instead of `changes()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/512)
<!-- Reviewable:end -->
