### PR TITLE
Update ndt test results recording rule

### DIFF
--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -152,7 +152,7 @@
           "refId": "A"
         },
         {
-          "expr": "machine:ndt_test_rpm:98th_quantile_$interval / 120 > ($percent / 100)",
+          "expr": "machine:ndt5_client_test_results_rpm:98th_quantile_$interval / 120 > ($percent / 100)",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -477,7 +477,7 @@
           "refId": "F"
         },
         {
-          "expr": "quantile_over_time(0.9, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 60",
+          "expr": "quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 60",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -485,7 +485,7 @@
           "refId": "G"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 96",
+          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 96",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -493,7 +493,7 @@
           "refId": "H"
         },
         {
-          "expr": "machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}",
+          "expr": "machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -501,7 +501,7 @@
           "refId": "I"
         },
         {
-          "expr": "quantile_over_time(0.90, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.90, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -509,7 +509,7 @@
           "refId": "J"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:ndt_test:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -324,8 +324,7 @@ scrape_configs:
         - 'kube_pod_info'
         - 'kube_pod_status_ready'
         # For recording rules for NDT Early Warning dashboard and Global Test Rates.
-        - 'ndt_test_total'
-        - 'ndt_active_tests'
+        - 'ndt5_client_test_results_total'
         - 'node_disk_io_time_seconds_total{deployment="node-exporter"}'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -82,8 +82,8 @@ groups:
 #
 # Per-machine successful NDT5 tests counted by the server.
 # Units: requests per minute.
-  - record: machine:ndt_test:rpm2m
-    expr: 60 * sum without(direction) (irate(ndt_test_total{code="200"}[4m]))
+  - record: machine:ndt5_client_test_results:rpm2m
+    expr: 60 * sum without(direction) (irate(ndt5_client_test_results_total{result!="error-without-rate"}[4m]))
   # Per-machine maximum ratio of time spent performing I/O on all devices.
   # Units: none (sec/sec)
   - record: machine:node_disk_io_time_seconds:max2m
@@ -134,8 +134,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_30m
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[30m])
   # k8s
-  - record: machine:ndt_test_rpm:90th_quantile_30m
-    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[30m])
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[30m])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[30m])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_30m
@@ -152,8 +152,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_1h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[1h])
   # k8s
-  - record: machine:ndt_test_rpm:90th_quantile_1h
-    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[1h])
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[1h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[1h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_1h
@@ -170,8 +170,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_2h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
-  - record: machine:ndt_test_rpm:90th_quantile_2h
-    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[2h])
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[2h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_2h
@@ -188,8 +188,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:90th_quantile_6h
     expr: quantile_over_time(0.9, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
-  - record: machine:ndt_test_rpm:90th_quantile_6h
-    expr: quantile_over_time(0.9, machine:ndt_test:rpm2m[6h])
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[6h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_6h
@@ -207,8 +207,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:98th_quantile_2h
     expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[2h])
   # k8s
-  - record: machine:ndt_test_rpm:98th_quantile_2h
-    expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[2h])
+  - record: machine:ndt5_client_test_results_rpm:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[2h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_2h
@@ -225,8 +225,8 @@ groups:
   - record: candidate_ndt:vdlimit_used_ratio_12h_prediction:98th_quantile_6h
     expr: quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h[6h])
   # k8s
-  - record: machine:ndt_test_rpm:98th_quantile_6h
-    expr: quantile_over_time(0.98, machine:ndt_test:rpm2m[6h])
+  - record: machine:ndt5_client_test_results_rpm:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[6h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_6h


### PR DESCRIPTION
This change updates the recording rules that previously used the new deprecated `ndt_test_total` metric in favor of the `ndt5_client_test_results_total` metric. This change is a consequence of https://github.com/m-lab/ndt-server/pull/169 which retired the `ndt_test_total` metric due to needing more visibility into client successes / errors before deciding how to actually count `ndt_test_total`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/520)
<!-- Reviewable:end -->
