### PR TITLE
Actually aggregate by machine

### DIFF
--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -83,7 +83,7 @@ groups:
 # Per-machine successful NDT5 tests counted by the server.
 # Units: requests per minute.
   - record: machine:ndt5_client_test_results:rpm2m
-    expr: 60 * sum without(direction) (irate(ndt5_client_test_results_total{result!="error-without-rate"}[4m]))
+    expr: 60 * sum by(machine) (irate(ndt5_client_test_results_total{result!="error-without-rate"}[4m]))
   # Per-machine maximum ratio of time spent performing I/O on all devices.
   # Units: none (sec/sec)
   - record: machine:node_disk_io_time_seconds:max2m


### PR DESCRIPTION
Now that tests have additional, protocol, direction, and result labels, the remaining (protocol, result) labels added too many timeseries to the dashboard.

This change actually groups by machine -- which is both how it's named and used in the dashboards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/523)
<!-- Reviewable:end -->
