### PR TITLE
Add ndt5 metrics to Global Test Rate

### DIFF
--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 288,
-  "iteration": 1565888374564,
+  "iteration": 1565889514091,
   "links": [],
   "panels": [
     {
@@ -73,7 +72,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -82,7 +81,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -91,7 +90,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Total",
@@ -179,7 +178,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -188,7 +187,7 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or vector(0))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "One Week",
@@ -196,7 +195,7 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or vector(0))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or vector(0))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Two Week",
@@ -303,5 +302,5 @@
   "timezone": "utc",
   "title": "NDT: Global Test Rate",
   "uid": "Cyq7WeNiz",
-  "version": 14
+  "version": 140
 }

--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -12,9 +12,11 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": 288,
+  "iteration": 1565888374564,
   "links": [],
   "panels": [
     {
@@ -28,6 +30,7 @@
       "id": 21,
       "links": [],
       "mode": "markdown",
+      "options": {},
       "title": "",
       "type": "text"
     },
@@ -36,7 +39,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "gridPos": {
@@ -59,6 +62,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -69,7 +73,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m]))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -78,7 +82,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m]))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -87,7 +91,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m]))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Total",
@@ -97,6 +101,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "NDT Global Test Rate (Up, Down) (5m average)",
       "tooltip": {
@@ -140,7 +145,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
       "gridPos": {
@@ -163,6 +168,7 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -173,15 +179,16 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m]))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Current",
           "refId": "C",
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "One Week",
@@ -189,7 +196,7 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Two Week",
@@ -199,6 +206,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Week-over-week - NDT Global Total Test Rate",
       "tooltip": {
@@ -239,14 +247,32 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus (mlab-oti)",
+          "value": "Prometheus (mlab-oti)"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/Prometheus/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-20d",
     "to": "now"
   },
   "timepicker": {
@@ -277,5 +303,5 @@
   "timezone": "utc",
   "title": "NDT: Global Test Rate",
   "uid": "Cyq7WeNiz",
-  "version": 13
+  "version": 14
 }

--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -73,7 +73,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or absent(ndt_test_total))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -82,7 +82,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or absent(ndt_test_total))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -91,7 +91,7 @@
           "step": 120
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Total",
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -188,7 +188,7 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or vector(0)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or vector(0))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "One Week",
@@ -196,7 +196,7 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
+          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or vector(0))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or vector(0))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Two Week",


### PR DESCRIPTION
This change adds the ndt5 metrics to the Global Test Rate dashboard. The data just before the upgrade and just after the metrics change are a little wobbly but mostly complete. The apparent loss of traffic is in fact a loss of monitoring fidelity.

This change also adds a datasource selector.

https://grafana.mlab-sandbox.measurementlab.net/d/Cyq7WeNiz/ndt-global-test-rate?orgId=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/524)
<!-- Reviewable:end -->
