### PR TITLE
Specify DS namespace when providing an example command

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1183,7 +1183,7 @@ groups:
       summary: DaemonSet {{ $labels.daemonset }} has fewer pods scheduled than desired.
       description: DaemonSet {{ $labels.daemonset }} has fewer pods scheduled than desired.
         Check the status of the DaemonSet for clues with
-        `kubectl describe daemonset {{ $labels.daemonset }}`
+        `kubectl describe daemonset {{ $labels.daemonset }} -n {{ $labels.namespace }}`
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   # The desired number of replicas for a Deployment are not equal to the


### PR DESCRIPTION
This PR adds `-n namespace` to `kubectl describe daemonset` in the alert description.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/530)
<!-- Reviewable:end -->
