### PR TITLE
Get user/reverse-proxy-counter custom metric from Stackdriver

### DIFF
--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes",
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter",
         ]
         ports:
         - containerPort: 9255


### PR DESCRIPTION
This PR adds the user-defined `user/reverse-proxy-counter` metric to the list of metrics that the stackdriver-exporter will fetch from stackdriver.

After merging this, the metric can be queried as `stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter`. 

https://grafana.mlab-sandbox.measurementlab.net/explore?left=%5B"now-30m","now","Prometheus%20(mlab-sandbox)",%7B"expr":"stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/532)
<!-- Reviewable:end -->
