### PR TITLE
Add MlabNSReverseProxyNotWorking alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -629,8 +629,8 @@ groups:
         means there is a persistent failure in the underlying service. Please
         check the GAE dashboard and logs to determine the cause.
 
-# If no traffic has been redirected to the staging instance for the past 24h,
-# an alert should fire.
+# If no ndt_ssl traffic has been redirected to the staging instance in the past
+# hour, an alert should fire.
   - alert: MlabNSNdtSslReverseProxyNotWorking
     expr: |
       sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
@@ -640,15 +640,19 @@ groups:
       repo: dev-tracker
       severity: ticket
     annotations:
-      summary: mlab-ns' reverse proxy is not redirecting any traffic.
+      summary: mlab-ns' reverse proxy is not redirecting any ndt_ssl traffic.
       description: >
-        mlab-ns is supposed to send some of the production traffic to the
-        staging instance, and this has not been happening for the past 24h.
-        Please check that the probability values on Google Cloud Datastore are
-        not zero for every experiment and that there are no errors related to
-        reverse proxying in the mlab-ns logs.
+        mlab-ns is supposed to send some of the ndt_ssl traffic to the
+        staging instance, and this has not been happening for the past hour.
+        Please check that the probability set on Google Cloud Datastore is
+        not zero for the ndt_ssl experiment and that there are no errors
+        related to reverse proxying in the mlab-ns logs.
 
-# If not traffic for
+# If the 24h average of redirected requests does not match the configured
+# probability, an alert should fire.
+  - alert: MlabNSNdtSSlReverseProxyProbabilityMismatch
+    expr: |
+
 
 # One or more NDT-specific metrics is missing. These are the NDT metrics that
 # mlab-ns relies on to determine whether NDT is up and running, so we need to

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -631,9 +631,11 @@ groups:
 
 # If no traffic has been redirected to the staging instance for the past 24h,
 # an alert should fire.
-  - alert: MlabNSReverseProxyNotWorking
+  - alert: MlabNSNdtSslReverseProxyNotWorking
     expr: |
-      sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter[24h]) == 0
+      sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
+        experiment="ndt_ssl"}[1h]) == 0
+    for: 1m
     labels:
       repo: dev-tracker
       severity: ticket
@@ -645,6 +647,8 @@ groups:
         Please check that the probability values on Google Cloud Datastore are
         not zero for every experiment and that there are no errors related to
         reverse proxying in the mlab-ns logs.
+
+# If not traffic for
 
 # One or more NDT-specific metrics is missing. These are the NDT metrics that
 # mlab-ns relies on to determine whether NDT is up and running, so we need to

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -634,7 +634,7 @@ groups:
   - alert: MlabNSNdtSslReverseProxyNotWorking
     expr: |
       sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
-        experiment="ndt_ssl"}[1h]) == 0
+        resource="ndt_ssl"}[1h]) == 0
     for: 1m
     labels:
       repo: dev-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -648,12 +648,6 @@ groups:
         not zero for the ndt_ssl experiment and that there are no errors
         related to reverse proxying in the mlab-ns logs.
 
-# If the 24h average of redirected requests does not match the configured
-# probability, an alert should fire.
-  - alert: MlabNSNdtSSlReverseProxyProbabilityMismatch
-    expr: |
-
-
 # One or more NDT-specific metrics is missing. These are the NDT metrics that
 # mlab-ns relies on to determine whether NDT is up and running, so we need to
 # make sure that the metrics are always present. NOTE: mlab-ns additionally

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -611,6 +611,23 @@ groups:
         means there is a persistent failure in the underlying service. Please
         check the GAE dashboard and logs to determine the cause.
 
+# If no traffic has been redirected to the staging instance for the past 24h,
+# an alert should fire.
+  - alert: MlabNSReverseProxyNotWorking
+    expr: |
+      sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter[24h]) == 0
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      summary: mlab-ns' reverse proxy is not redirecting any traffic.
+      description: >
+        mlab-ns is supposed to send some of the production traffic to the
+        staging instance, and this has not been happening for the past 24h.
+        Please check that the probability values on Google Cloud Datastore are
+        not zero for every experiment and that there are no errors related to
+        reverse proxying in the mlab-ns logs.
+
 # One or more NDT-specific metrics is missing. These are the NDT metrics that
 # mlab-ns relies on to determine whether NDT is up and running, so we need to
 # make sure that the metrics are always present. NOTE: mlab-ns additionally

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes",
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter",
         ]
         ports:
         - containerPort: 9255


### PR DESCRIPTION
This PR adds an alert that checks if mlab-ns redirected any traffic to staging over the past 24h. This is not very fine-grained as it does not differentiate among experiments (we don't have that information in the metric) but should at least tell us if the proxying is entirely broken. 

Please note that the counter in question is actually a gauge: https://grafana.mlab-sandbox.measurementlab.net/explore?left=%5B"now-24h","now","Prometheus%20(mlab-sandbox)",%7B"expr":"stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter"%7D,%7B"ui":%5Btrue,true,true,"none"%5D%7D%5D

Assuming we don't want to keep this redirection indefinitely (e.g. are we going to remove it after the k8s migration has been completed?) we'll need to remove this alert at some point.

I believe it closes https://github.com/m-lab/prometheus-support/issues/497, but please let me know if not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/534)
<!-- Reviewable:end -->
