### PR TITLE
Update reboot-api to v0.3.0

### DIFF
--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: reboot-api
-        image: measurementlab/reboot-api:v0.2.2
+        image: measurementlab/reboot-api:v0.3.0
         args:
           - "-datastore.project={{GCLOUD_PROJECT}}"
           - "-reboot.key=/var/secrets/reboot-api-ssh.key"


### PR DESCRIPTION
This PR updates reboot-api to v0.3.0, which introduces Datastore connection reuse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/536)
<!-- Reviewable:end -->
