### PR TITLE
New NodeNotReady alert + small improvement to K8s:SiteOverview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 246,
-  "iteration": 1566852896018,
+  "iteration": 1567705647027,
   "links": [],
   "panels": [
     {
@@ -1100,6 +1100,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1120,7 +1121,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1198,6 +1201,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1218,7 +1222,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
@@ -1317,6 +1323,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1337,7 +1344,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1417,6 +1426,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1437,7 +1447,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1533,6 +1545,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1553,7 +1566,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1626,6 +1641,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -1648,7 +1664,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1666,7 +1684,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
+          "expr": "container_memory_working_set_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{container_label_io_kubernetes_pod_name}})",
@@ -1721,6 +1739,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
@@ -1743,7 +1762,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1830,7 +1851,7 @@
       "id": 48,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 34,
       "scopedVars": {
         "node": {
@@ -1896,7 +1917,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 26,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1991,12 +2012,12 @@
           "to": "1000"
         },
         {
-          "from": "null",
+          "from": "0",
           "text": "OK",
-          "to": "null"
+          "to": "0"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2015,11 +2036,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kube_pod_info{node=\"$node.$site.measurement-lab.org\"} == 1 and on(exported_pod) kube_pod_status_ready{condition=\"true\"}) != \n  count(kube_daemonset_status_desired_number_scheduled{daemonset!~\"(kube-flannel-ds-cloud|update-agent)\"})",
+          "expr": "count(kube_pod_info{node=\"$node.$site.measurement-lab.org\"} == 1 and on(exported_pod) kube_pod_status_ready{condition=\"true\"}) != \n  count(kube_daemonset_status_desired_number_scheduled{daemonset!~\"(kube-flannel-ds-cloud)\"} > 0) OR vector(0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "Running",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -2098,7 +2119,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 43,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2202,7 +2223,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 47,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2305,7 +2326,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 36,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2398,7 +2419,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 21,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2492,7 +2513,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 35,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2586,7 +2607,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 38,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2632,6 +2653,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -2652,12 +2674,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 32,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2733,6 +2757,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -2753,12 +2778,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 31,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2855,6 +2882,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -2875,12 +2903,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 28,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2958,6 +2988,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -2978,12 +3009,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 30,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3077,6 +3110,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -3097,12 +3131,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 15,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3173,6 +3209,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -3195,12 +3232,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 17,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3216,7 +3255,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
+          "expr": "container_memory_working_set_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{container_label_io_kubernetes_pod_name}})",
@@ -3271,6 +3310,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
@@ -3293,12 +3333,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 19,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3383,7 +3425,7 @@
       "id": 64,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 34,
       "scopedVars": {
         "node": {
@@ -3449,7 +3491,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 26,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3544,12 +3586,12 @@
           "to": "1000"
         },
         {
-          "from": "null",
+          "from": "0",
           "text": "OK",
-          "to": "null"
+          "to": "0"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3568,11 +3610,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kube_pod_info{node=\"$node.$site.measurement-lab.org\"} == 1 and on(exported_pod) kube_pod_status_ready{condition=\"true\"}) != \n  count(kube_daemonset_status_desired_number_scheduled{daemonset!~\"(kube-flannel-ds-cloud|update-agent)\"})",
+          "expr": "count(kube_pod_info{node=\"$node.$site.measurement-lab.org\"} == 1 and on(exported_pod) kube_pod_status_ready{condition=\"true\"}) != \n  count(kube_daemonset_status_desired_number_scheduled{daemonset!~\"(kube-flannel-ds-cloud)\"} > 0) OR vector(0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "Running",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -3651,7 +3693,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 43,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3755,7 +3797,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 47,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3858,7 +3900,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 36,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3951,7 +3993,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 21,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4045,7 +4087,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 35,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4139,7 +4181,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 38,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4185,6 +4227,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4205,12 +4248,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 32,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4286,6 +4331,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4306,12 +4352,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 31,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4408,6 +4456,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4428,12 +4477,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 28,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4511,6 +4562,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4531,12 +4583,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 30,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4630,6 +4684,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4650,12 +4705,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 15,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4726,6 +4783,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 6,
@@ -4748,12 +4806,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 17,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4769,7 +4829,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
+          "expr": "container_memory_working_set_bytes{\n    container_label_io_kubernetes_pod_name=~\"$pod-.*\",\n    container_label_io_kubernetes_container_name!=\"POD\",\n    machine=~\"$node.$site.*\"\n}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{container_label_io_kubernetes_container_name}} ({{container_label_io_kubernetes_pod_name}})",
@@ -4824,6 +4884,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 12,
@@ -4846,12 +4907,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1566852896018,
+      "repeatIteration": 1567705647027,
       "repeatPanelId": 19,
       "repeatedByRow": true,
       "scopedVars": {
@@ -4928,7 +4991,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -4978,6 +5041,7 @@
       {
         "allValue": null,
         "current": {
+          "tags": [],
           "text": "All",
           "value": "$__all"
         },
@@ -5059,5 +5123,5 @@
   "timezone": "",
   "title": "k8s: Site Overview",
   "uid": "rJ7z2Suik",
-  "version": 23
+  "version": 28
 }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1239,12 +1239,13 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   # If any pod is down or otherwise broken, fire an alert, unless the node is
-  # in lame-duck mode, GMX maintenance mode, or the scrape job for the entire
-  # node is down.
+  # in lame-duck mode, the node is NotReady, GMX maintenance mode, or the
+  # scrape job for the entire node is down.
   - alert: PlatformCluster_PodDown
     expr: |
       kube_pod_info == 1 and on(exported_pod) kube_pod_status_ready{condition="true"} == 0 unless on(node) (
           kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} or
+          kube_node_status_condition{condition="Ready", status="false"} == 1 or
           label_replace(gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
           up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
         )

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1238,6 +1238,30 @@ groups:
         host`).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
+  # If any node is NotReady for too long, fire an alert, unless the node is in
+  # lame-duck mode, GMX maintenance mode, or the scrape job for the entire node
+  # is down.
+  - alert: PlatformCluster_NodeNotReady
+    expr: |
+      kube_node_status_condition{cluster="platform-cluster", condition="Ready", status="false"} == 1
+        unless on(node) (
+          kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} or
+          label_replace(gmx_machine_maintenance == 1, "node", "$1", "machine", "(.*)") or
+          up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
+        )
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: A node has had a NotReady condition for too long.
+      description: A node has had a NotReady condition for too long. Generally
+        this is caused when the kubelet on the node is unable to communicate
+        with the API. Is the machine booted? Does the machine have network
+        connectivity? Check the status of the kubelet on the machine. Look at
+        the kubelet logs (journalctl -u kubelet).
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
   # If any pod is down or otherwise broken, fire an alert, unless the node is
   # in lame-duck mode, the node is NotReady, GMX maintenance mode, or the
   # scrape job for the entire node is down.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -311,6 +311,7 @@ scrape_configs:
         - 'node_edac_correctable_errors_total'
         - 'node_edac_uncorrectable_errors_total'
         - 'kube_node_spec_taint{key="lame-duck"}'
+        - 'kube_node_status_condition'
         - 'etcd_server_has_leader'
         - 'etcd_server_leader_changes_seen_total'
         - 'etcd_server_proposals_failed_total'


### PR DESCRIPTION
This PR has two unrelated changes:

1) A new alert for the case where a node is in a NotReady state for too long. Additionally, now the PodDown alert will not fire if the node is NotReady.

1) A small update and improvement to the SiteOverview dashboard, which now uses the metric `container_memory_working_set_bytes` instead of `container_memory_usage_bytes`. The former does  not include cached and buffered memory, both of which can be evicted under memory pressure, but instead gives active memory usage (RSS?). This is also the metric that the WorkloadOverview dashboard uses, so this change will make the two dashboards more consistent with one another.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/541)
<!-- Reviewable:end -->
