### PR TITLE
Export user/requests_counter and update stackdriver-exporter

### DIFF
--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter"
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter,logging.googleapis.com/user/requests-counter"
         ]
         ports:
         - containerPort: 9255

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter,logging.googleapis.com/user/requests-by-resource",
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter,logging.googleapis.com/user/requests-by-resource-counter",
         ]
         ports:
         - containerPort: 9255

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -15,7 +15,7 @@ spec:
         prometheus-node: 'true'
       containers:
       - name: stackdriver
-        image: frodenas/stackdriver-exporter:v0.5.1
+        image: frodenas/stackdriver-exporter:v0.6.0
         args: [
           # Metrics are available with some delay, so look 5 minutes in the past.
           "--monitoring.metrics-offset=5m",

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter",
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter,logging.googleapis.com/user/requests-by-resource",
         ]
         ports:
         - containerPort: 9255

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -23,7 +23,7 @@ spec:
           "--monitoring.metrics-interval=1m",
           "--google.project-id=mlab-ns",
           # Metrics are gauges, representing counts over the sampled interval.
-          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter,logging.googleapis.com/user/requests-by-resource-counter",
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/log_entry_count,appengine.googleapis.com/system/network/sent_bytes_count,appengine.googleapis.com/system/instance_count,appengine.googleapis.com/system/cpu/usage,appengine.googleapis.com/memcache/operation_count,appengine.googleapis.com/http/server/response_count,appengine.googleapis.com/http/server/response_latencies,appengine.googleapis.com/system/memory/usage,datastore.googleapis.com/api/request_count,datastore.googleapis.com/entity/read_sizes,datastore.googleapis.com/entity/write_sizes,logging.googleapis.com/user/reverse-proxy-counter"
         ]
         ports:
         - containerPort: 9255


### PR DESCRIPTION
This PR changes the stackdriver-exporter configuration to:
- Export the new `user/requests_counter`, counting the number of mlab-ns requests by resource (experiment)
- Use the latest version of stackdriver-exporter, which seems to solve some issues I've seen with the `/metrics` endpoint returning 500 and nothing being written in the logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/542)
<!-- Reviewable:end -->
