### PR TITLE
Fixes Ops:OamOverview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Ops_OamOverview.json
+++ b/config/federation/grafana/dashboards/Ops_OamOverview.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1560447495922,
+  "id": 209,
+  "iteration": 1567793821774,
   "links": [],
   "panels": [
     {
@@ -109,9 +110,9 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "refId": "A"
         }
@@ -225,6 +226,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -245,7 +247,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -263,7 +267,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -329,6 +333,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -349,7 +354,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -367,7 +374,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -375,7 +382,7 @@
           "refId": "A"
         },
         {
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -435,7 +442,7 @@
       "id": 108,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -501,7 +508,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -520,9 +527,9 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "refId": "A"
         }
@@ -593,7 +600,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -639,6 +646,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -659,12 +667,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -680,7 +690,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -744,7 +754,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -765,12 +777,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -786,7 +800,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -794,7 +808,7 @@
           "refId": "A"
         },
         {
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -854,7 +868,7 @@
       "id": 113,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -920,7 +934,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -939,9 +953,9 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "refId": "A"
         }
@@ -1012,7 +1026,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1058,6 +1072,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -1078,12 +1093,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1099,7 +1116,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -1163,7 +1180,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -1184,12 +1203,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1205,7 +1226,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1213,7 +1234,7 @@
           "refId": "A"
         },
         {
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1273,7 +1294,7 @@
       "id": 118,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 95,
       "scopedVars": {
         "vm": {
@@ -1339,7 +1360,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1358,9 +1379,9 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_filesystem_free_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"})\n/ node_filesystem_size_bytes{mountpoint=\"/\", fstype=\"ext4\", instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "refId": "A"
         }
@@ -1431,7 +1452,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1477,6 +1498,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -1497,12 +1519,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1518,7 +1542,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(node_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal{instance=~\"^$vm.+measurementlab.net:9100\"}",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"} -\n    node_memory_MemFree_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}) / \nnode_memory_MemTotal_bytes{instance=~\"^$vm.+measurementlab.net:9100\"}",
           "format": "time_series",
           "instant": false,
           "interval": "60s",
@@ -1582,7 +1606,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 9,
@@ -1603,12 +1629,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1560447495922,
+      "repeatIteration": 1567793821774,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1624,7 +1652,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(node_network_receive_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_receive_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1632,7 +1660,7 @@
           "refId": "A"
         },
         {
-          "expr": "8 * rate(node_network_transmit_bytes{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
+          "expr": "8 * rate(node_network_transmit_bytes_total{device=\"eth0\", instance=~\"^$vm.+measurementlab.net:9100\"}[4m])",
           "format": "time_series",
           "interval": "60s",
           "intervalFactor": 1,
@@ -1682,15 +1710,16 @@
       }
     }
   ],
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "default",
-          "value": "default"
+          "selected": false,
+          "text": "Prometheus (mlab-oti)",
+          "value": "Prometheus (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1707,6 +1736,7 @@
       {
         "allValue": "",
         "current": {
+          "selected": false,
           "tags": [],
           "text": "All",
           "value": "$__all"
@@ -1781,5 +1811,5 @@
   "timezone": "",
   "title": "Ops: OA&M Overview",
   "uid": "gJ8d46Oik",
-  "version": 131
+  "version": 132
 }


### PR DESCRIPTION
After updating OA&M machines (dsn, mirror, eb, etc.) to Debian Buster, this dashboard broke because metric names had changed in the newer version of Prometheus. This PR uses updated Prometheus metric names, and sets rootfs singlestat panel to instant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/543)
<!-- Reviewable:end -->
