### PR TITLE
Fix MlabNSNdtSslReverseProxyNotWorking alert firing too often

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -633,8 +633,8 @@ groups:
 # hour, an alert should fire.
   - alert: MlabNSNdtSslReverseProxyNotWorking
     expr: |
-      sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
-        resource="ndt_ssl"}[1h]) == 0
+      sum(sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
+        resource="ndt_ssl"}[1h])) == 0
     for: 1m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
This alert was incorrectly firing due to multiple time series with different url labels, some of them being sometimes zero. A better way to write the query is summing them together, since they all refer to the same resource (ndt_ssl). 

With this revised query, the metric value has almost never gone under 30 in the past week, and has never been zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/544)
<!-- Reviewable:end -->
