### PR TITLE
Adds an alert to notify us if a DaemonSet rollout is stuck

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1284,6 +1284,28 @@ groups:
         pod is scheduled on. Check the status of the pod itself, if it exists.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
+  # A DaemonSet rollout is progressing too slowly.
+  - alert: PlatformClustser_RolloutTooSlowOrStuck
+    expr: |
+      delta(kube_daemonset_updated_number_scheduled[1h]) < 2 unless (
+        kube_daemonset_updated_number_scheduled == kube_daemonset_status_desired_number_scheduled
+      )
+    for: 5m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: A {{ $labels.daemonset }} DaemonSet rollout is going too slowly
+        or is stuck.
+      description: Not enough pods were updated in the past hour for a
+        {{ $labels.daemonset }} DaemonSet rollout, which indicates that the
+        rollout is stuck in some way. Usually this occurs when errors occur
+        when updating a pod on a node, and the number of nodes on which this
+        happens exceeds the maxUnavailable setting for a RollingUpdate. Look
+        for {{ $labels.daemonset }} pods with a status other than Running and
+        inspect them to figure out why they are in that state.
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
+
   # The desired number of pods for a DaemonSet are not equal to the current
   # number scheduled.
   - alert: PlatformCluster_DaemonSetHasTooFewPods

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1295,12 +1295,11 @@ groups:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: A {{ $labels.daemonset }} DaemonSet rollout is going too slowly
-        or is stuck.
+      summary: A {{ $labels.daemonset }} DaemonSet rollout is going too slowly.
       description: Not enough pods were updated in the past hour for a
         {{ $labels.daemonset }} DaemonSet rollout, which indicates that the
-        rollout is stuck in some way. Usually this occurs when errors occur
-        when updating a pod on a node, and the number of nodes on which this
+        rollout is stuck in some way. Usually this happens when errors occur
+        updating a pod on a node, and the number of nodes on which this error
         happens exceeds the maxUnavailable setting for a RollingUpdate. Look
         for {{ $labels.daemonset }} pods with a status other than Running and
         inspect them to figure out why they are in that state.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -320,6 +320,7 @@ scrape_configs:
         - 'etcd_disk_backend_commit_duration_seconds_bucket'
         - 'kube_daemonset_status_current_number_scheduled'
         - 'kube_daemonset_status_desired_number_scheduled'
+        - 'kube_daemonset_updated_number_scheduled'
         - 'kube_deployment_status_replicas'
         - 'kube_deployment_spec_replicas'
         - 'kube_pod_info'


### PR DESCRIPTION
This PR is meant to resolve this issue: https://github.com/m-lab/k8s-support/issues/281

This PR conservatively considers that if at least 2 pods have not updated in the last hour that something is wrong. The alert looks for the `delta()` of `kube_daemonset_updated_number_scheduled` over the last hour and if the number is less than 2 for 5m, an alert will fire. The reasoning for the small toleration window (5m) is that the query is already looking back over the past hour. So by the time the query is true, the issue has already been present for an hour. The alert will then only tolerate this condition for ~5 scrape cycles after that.

I've requested a review of this PR from @gfr10598, but want to also flag @pboothe and @robertodauria, in case either of them has any concerns about the configuration of this alert (e.g., maybe it is too conservative?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/547)
<!-- Reviewable:end -->
