### PR TITLE
Tweaks RolloutTooSlowOrStuck alert to be less chatty

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1288,7 +1288,7 @@ groups:
   - alert: PlatformClustser_RolloutTooSlowOrStuck
     expr: |
       delta(kube_daemonset_updated_number_scheduled[1h]) < 2 unless (
-        kube_daemonset_updated_number_scheduled == kube_daemonset_status_desired_number_scheduled
+        (kube_daemonset_status_desired_number_scheduled - kube_daemonset_updated_number_scheduled) < 4
       )
     for: 5m
     labels:


### PR DESCRIPTION
Upgraded pod counts apparently become flaky when you are down to around less than `maxUnavailable` pods remaining to be upgraded. All of the following commands were run within minutes of each other.

```
# kubectl rollout status ds host
daemon set "host" successfully rolled out
# kubectl rollout status ds host
Waiting for daemon set "host" rollout to finish: 121 out of 122 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 121 out of 123 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 120 out of 122 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 120 out of 121 new pods have been updated...
daemon set "host" successfully rolled out
# kubectl rollout status ds host
Waiting for daemon set "host" rollout to finish: 121 out of 122 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 121 out of 123 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 120 out of 122 new pods have been updated...
Waiting for daemon set "host" rollout to finish: 120 out of 121 new pods have been updated...
daemon set "host" successfully rolled out
```

One minute `rollout status` tells you the rollout is complete. The next minute it tells you that 121/123 are updated, then that 120/122. In actuality there were two `host` experiments stuck. I'm not at all sure why the numbers are so unreliable. The unreliability of the numbers was causing the `PlatformCluster_RolloutTooSlowOrStuck` to flap.  The alert would fire, then a few minutes later `kube_daemonset_updated_number_scheduled == kube_daemonset_status_desired_number_scheduled` would evaluate to true, clearing the alert. Rinse. Lather. Repeat. 

The PR configures the alert to ignore a possibly stuck rollout when less than 4 pods remain to be upgraded. This is something of a hack, but by that point pretty much everything has been successfully upgraded anyway, and it's likely not a big deal to wait for an operator to notice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/548)
<!-- Reviewable:end -->
