### PR TITLE
Tolerate one transient error in RateLimiter alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -601,9 +601,7 @@ groups:
     expr: |
       sum_over_time(stackdriver_gae_app_appengine_googleapis_com_http_server_response_count{
         deployment="mlabns-stackdriver", module_id="rate-limiter", loading="false",
-        response_code=~"5.."}[24h]) /
-      sum_over_time(stackdriver_gae_app_appengine_googleapis_com_http_server_response_count{
-        deployment="mlabns-stackdriver", module_id="rate-limiter",loading="false"}[24h]) > 0
+        response_code=~"5.."}[24h]) > 1
     for: 1m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
Sometimes there are transient errors (e.g. a timeout in the BQ query)
and we do not want to immediately alert on those. This change makes
this alert a bit more forgiving by setting the threshold to > 2 err/day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/549)
<!-- Reviewable:end -->
