### PR TITLE
Tolerates PlatformCluster_RolloutTooSlowOrStuck for 30m instead of just 5m

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1288,7 +1288,7 @@ groups:
       delta(kube_daemonset_updated_number_scheduled[1h]) < 2 unless (
         (kube_daemonset_status_desired_number_scheduled - kube_daemonset_updated_number_scheduled) < 4
       )
-    for: 5m
+    for: 30m
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
[Apparently it can take more than 5m to ramp up a rollout](https://grafana.mlab-staging.measurementlab.net/explore?orgId=1&left=%5B%221569357775368%22,%221569362136906%22,%22Platform%20Cluster%20(mlab-staging)%22,%7B%22expr%22:%22%20%20%20%20%20%20delta(kube_daemonset_updated_number_scheduled%5B1h%5D)%20%3C%202%20unless%20(%5Cn%20%20%20%20%20%20%20%20(kube_daemonset_status_desired_number_scheduled%20-%20kube_daemonset_updated_number_scheduled)%20%3C%204%5Cn%20%20%20%20%20%20)%22,%22context%22:%22explore%22%7D,%7B%22mode%22:%22Metrics%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D). Tolerating this condition for only 5m doesn't take into account the 55m before the rollout starts. This PR just tolerates the condition for a bit longer. Hopefully this will be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/550)
<!-- Reviewable:end -->
