### PR TITLE
Modifies the RolloutTooSlowOrStuck alert to actually work as expected.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1285,13 +1285,17 @@ groups:
   # A DaemonSet rollout is progressing too slowly. Unless 95% of a DaemonSet's
   # pods are updated, then fire an alert if the rate of increase over the last
   # hour is less than or equal to 2. This is pretty conservative since NDT pods
-  # should update at something more like ~24 per hour.
+  # should update at something more like ~24 per hour. The somewhat unusual
+  # toleration of 70m is because once a rollout starts, comparing the current
+  # value of updated_scheduled to the value from an hour ago (all pods) will
+  # yield a negative number for roughly the period of the offset (1h in this
+  # case). 70m just gives us a safe window to cross that inversion.
   - alert: PlatformClustser_RolloutTooSlowOrStuck
     expr: |
       kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h) <= 2 unless (
         kube_daemonset_updated_number_scheduled / kube_daemonset_status_desired_number_scheduled > 0.95
       )
-    for: 1h
+    for: 70m
     labels:
       repo: ops-tracker
       severity: ticket

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1282,13 +1282,16 @@ groups:
         pod is scheduled on. Check the status of the pod itself, if it exists.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  # A DaemonSet rollout is progressing too slowly.
+  # A DaemonSet rollout is progressing too slowly. Unless 95% of a DaemonSet's
+  # pods are updated, then fire an alert if the rate of increase over the last
+  # hour is less than or equal to 2. This is pretty conservative since NDT pods
+  # should update at something more like ~24 per hour.
   - alert: PlatformClustser_RolloutTooSlowOrStuck
     expr: |
-      delta(kube_daemonset_updated_number_scheduled[1h]) < 2 unless (
-        (kube_daemonset_status_desired_number_scheduled - kube_daemonset_updated_number_scheduled) < 4
+      kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h) <= 2 unless (
+        kube_daemonset_updated_number_scheduled / kube_daemonset_status_desired_number_scheduled > 0.95
       )
-    for: 30m
+    for: 1h
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
The previous query was just outright wrong and bad, not taking into account the fact `delta(kube_daemonset_updated_number_scheduled[1h])` will be a negative number for a good chunk of a rollout.

The current query takes the present value of `kube_daemonset_updated_number_scheduled` and then subtracts the value for that same metric an hour ago. If that number is less than 2 for an hour, then fire the alert. It needs to be true or tolerated for at least an hour (70m in this PR), since `kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h)` will evaluate to a negative number until our measurement window is near equivalent to the time in the past the rollout began.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/553)
<!-- Reviewable:end -->
