### PR TITLE
Omits DaemonSets in RolloutTooSlowOrStuck that a desired_scheduled of 0.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1292,9 +1292,11 @@ groups:
   # case). 70m just gives us a safe window to cross that inversion.
   - alert: PlatformClustser_RolloutTooSlowOrStuck
     expr: |
-      kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h) <= 2 unless (
-        kube_daemonset_updated_number_scheduled / kube_daemonset_status_desired_number_scheduled > 0.95
-      )
+      kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h) <= 2
+        unless (
+          kube_daemonset_updated_number_scheduled / kube_daemonset_status_desired_number_scheduled > 0.95 or
+          kube_daemonset_status_desired_number_scheduled == 0
+        )
     for: 70m
     labels:
       repo: ops-tracker


### PR DESCRIPTION
For example, the Bismark experiment caused this alert to fire because we have a nodeSelector on those pods that will only schedule them on sandbox nodes, so the alert thought it was stuck when 0 - 0 was < 2 for 70m. This PR should fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/554)
<!-- Reviewable:end -->
