### PR TITLE
Fix datasource and panel title

### DIFF
--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -16,8 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 266,
-  "iteration": 1566302867315,
+  "iteration": 1571838575913,
   "links": [],
   "panels": [
     {
@@ -27,6 +26,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -48,7 +48,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 0.5,
       "points": false,
@@ -149,6 +151,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -171,7 +174,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -261,6 +266,7 @@
           "value": "current"
         }
       ],
+      "datasource": "$datasource",
       "description": "Nodes which have been rebooted by Rebot.",
       "fontSize": "100%",
       "gridPos": {
@@ -383,7 +389,7 @@
     {
       "columns": [],
       "datasource": "$datasource",
-      "description": "Nodes that are in GMX maintenance.",
+      "description": "Nodes that are in GMX maintenance and not part of a site under maintenance.",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -432,7 +438,7 @@
         }
       ],
       "timeFrom": null,
-      "title": "Nodes GMX maintenance",
+      "title": "Nodes GMX maintenance (outside sites in GMX)",
       "transform": "timeseries_aggregations",
       "type": "table"
     },
@@ -590,7 +596,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -646,5 +652,5 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
This PR changes the datasource for the "Rebooted nodes" panel to `$datasource` and (hopefully) makes the "Nodes GMX maintenance" panel's title and description clearer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/556)
<!-- Reviewable:end -->
