### PR TITLE
Two small Grafana dashboard fixes

### DIFF
--- a/config/federation/grafana/dashboards/K8s_MasterCluster.json
+++ b/config/federation/grafana/dashboards/K8s_MasterCluster.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 63,
-  "iteration": 1564687572433,
+  "id": 244,
+  "iteration": 1572284157610,
   "links": [],
   "panels": [
     {
@@ -138,6 +138,7 @@
       "datasource": "$datasource",
       "description": "Sum of metrics over all CPU cores.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -158,7 +159,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -176,21 +179,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
+          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
+          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
+          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "system",
@@ -245,6 +248,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -265,7 +269,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -345,6 +351,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -367,7 +374,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -627,6 +636,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -647,7 +657,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
@@ -743,6 +755,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -763,7 +776,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -836,6 +851,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -858,7 +874,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1035,7 +1053,7 @@
       "id": 133,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 95,
       "scopedVars": {
         "master": {
@@ -1101,7 +1119,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 131,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1148,6 +1166,7 @@
       "datasource": "$datasource",
       "description": "Sum of metrics over all CPU cores.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1168,12 +1187,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 129,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1258,6 +1279,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1278,12 +1300,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 110,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1361,6 +1385,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1383,12 +1408,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 108,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1514,7 +1541,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 132,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1606,7 +1633,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1652,6 +1679,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1672,12 +1700,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1771,6 +1801,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1791,12 +1822,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 111,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1867,6 +1900,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -1889,12 +1923,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2022,7 +2058,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2072,7 +2108,7 @@
       "id": 144,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 95,
       "scopedVars": {
         "master": {
@@ -2138,7 +2174,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 131,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2210,7 +2246,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 129,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2320,7 +2356,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 110,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2425,7 +2461,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 108,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2551,7 +2587,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 132,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2643,7 +2679,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2714,7 +2750,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2833,7 +2869,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 111,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2931,7 +2967,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3059,7 +3095,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1564687572433,
+      "repeatIteration": 1572284157610,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3099,7 +3135,7 @@
       "valueName": "current"
     }
   ],
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -3124,7 +3160,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "All",
           "value": "$__all"
         },
@@ -3181,5 +3216,5 @@
   "timezone": "",
   "title": "k8s: Master Cluster",
   "uid": "K8-zAIuik",
-  "version": 8
+  "version": 40
 }

--- a/config/federation/grafana/dashboards/K8s_MasterCluster.json
+++ b/config/federation/grafana/dashboards/K8s_MasterCluster.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 244,
-  "iteration": 1572284157610,
+  "iteration": 1572371401144,
   "links": [],
   "panels": [
     {
@@ -179,21 +179,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"})",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"})",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m])) / count(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"})",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "system",
@@ -1053,7 +1053,7 @@
       "id": 133,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 95,
       "scopedVars": {
         "master": {
@@ -1119,7 +1119,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 131,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1194,7 +1194,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 129,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1210,21 +1210,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "system",
@@ -1307,7 +1307,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 110,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1415,7 +1415,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 108,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1541,7 +1541,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 132,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1633,7 +1633,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1707,7 +1707,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1829,7 +1829,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 111,
       "repeatedByRow": true,
       "scopedVars": {
@@ -1930,7 +1930,7 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2058,7 +2058,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2108,7 +2108,7 @@
       "id": 144,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 95,
       "scopedVars": {
         "master": {
@@ -2174,7 +2174,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 131,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2221,6 +2221,7 @@
       "datasource": "$datasource",
       "description": "Sum of metrics over all CPU cores.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2241,12 +2242,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 129,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2262,21 +2265,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"iowait\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"user\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
+          "expr": "avg(rate(node_cpu_seconds_total{node=~\"master-platform-cluster-$master\", mode=\"system\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "system",
@@ -2331,6 +2334,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2351,12 +2355,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 110,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2434,6 +2440,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2456,12 +2463,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 108,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2587,7 +2596,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 132,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2679,7 +2688,7 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 7,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2725,6 +2734,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2745,12 +2755,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 97,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2844,6 +2856,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2864,12 +2877,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 111,
       "repeatedByRow": true,
       "scopedVars": {
@@ -2940,6 +2955,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 7,
@@ -2962,12 +2978,14 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 107,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3095,7 +3113,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1572284157610,
+      "repeatIteration": 1572371401144,
       "repeatPanelId": 18,
       "repeatedByRow": true,
       "scopedVars": {
@@ -3160,6 +3178,7 @@
       {
         "allValue": null,
         "current": {
+          "tags": [],
           "text": "All",
           "value": "$__all"
         },
@@ -3216,5 +3235,5 @@
   "timezone": "",
   "title": "k8s: Master Cluster",
   "uid": "K8-zAIuik",
-  "version": 40
+  "version": 41
 }

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1565900597479,
+  "iteration": 1572288979434,
   "links": [],
   "panels": [
     {
@@ -27,6 +27,7 @@
       "datasource": "$datasource",
       "description": "Left Y: Aggregate DaemonSet CPU usage expressed as a percentage of the entire cluster CPU capacity in cores.\nRight Y: Aggregate DaemonSet CPU usage as an absolute number of cores.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -43,7 +44,7 @@
         "max": false,
         "min": false,
         "rightSide": true,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -51,7 +52,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -132,6 +135,7 @@
       "datasource": "$datasource",
       "description": "Left Y: Aggregate DaemonSet memory expressed as a percentage of the entire cluster's memory capacity.\n\nRight Y: Aggregate DaemonSet memory usage expressed as an absolute number of bytes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -154,7 +158,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -235,6 +241,7 @@
       "datasource": "$datasource",
       "description": "Left Y: Aggregate DaemonSet CPU usage expressed as a percentage of a node's total CPU cores.\n\nRight Y: Aggregate DaemonSet CPU usage as an absolute number of cores on a node.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -259,7 +266,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -341,6 +350,7 @@
       "datasource": "$datasource",
       "description": "Left Y: Aggregate DaemonSet memory expressed as a percentage of a node's total memory capacity.\n\nRight Y: Aggregate DaemonSet memory usage on a node expressed as an absolute number of bytes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -363,7 +373,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -443,6 +455,7 @@
       "datasource": "$datasource",
       "description": "",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -463,7 +476,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -538,6 +553,7 @@
       "datasource": "$datasource",
       "description": "",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
@@ -560,7 +576,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -912,6 +930,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 7,
@@ -932,7 +951,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1082,15 +1103,13 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "tags": [],
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -1140,5 +1159,5 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 95
+  "version": 99
 }


### PR DESCRIPTION
* k8s:MasterCluster: Fixes the CPU panel to give a more accurate representation of %CPU used. Currently, it sums the CPU usage across all 4 CPUs and uses that number as a % of CPU usage. This is misleading because it will give an exaggerated view of how much CPU is actually used. For example, if each CPU is 20% over a 5m average, the current panel will show an 80% CPU usage, when in actuality the usage across all 4 is only about 20%.
* k8s:WorkloadOverview: Removes an unneeded, bulky legend from the aggregate CPU usage panel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/557)
<!-- Reviewable:end -->
