### PR TITLE
Make the RateLimiterTooManyServerSideErrors more tolerant

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -601,7 +601,7 @@ groups:
     expr: |
       sum_over_time(stackdriver_gae_app_appengine_googleapis_com_http_server_response_count{
         deployment="mlabns-stackdriver", module_id="rate-limiter", loading="false",
-        response_code=~"5.."}[24h]) > 1
+        response_code=~"5.."}[24h]) > 5
     for: 1m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
We have discovered that two transient errors when accessing BigQuery over a period of 24 hours is not uncommon. This change makes the corresponding alert a bit more forgiving, changing the threshold to 6 errors (corresponding to an error rate of 12.5%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/559)
<!-- Reviewable:end -->
