### PR TITLE
Add new alert: PlatformCluster_PusherDailyDataVolumeTooLow

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -947,6 +947,8 @@ groups:
             label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "ndt5", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "ndt5", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "pcap", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "pcap", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "switch", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "switch", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "tcpinfo", "", ".*") or

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -937,6 +937,32 @@ groups:
       description: Are machines online? Is data being collected? Is the parser working?
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/PKqnWeNmz/
 
+  - alert: PlatformCluster_PusherDailyDataVolumeTooLow
+    expr: |
+      datatype:pusher_bytes_per_tarfile:increase24h
+        < (0.7 * quantile by(datatype)(0.5,
+          label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1d, "delay", "1d", "", ".*") or
+          label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 3d, "delay", "3d", "", ".*") or
+          label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 5d, "delay", "5d", "", ".*") or
+            label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "ndt5", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "ndt5", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "switch", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "switch", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "tcpinfo", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "tcpinfo", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "traceroute", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "traceroute", "", ".*")
+            ))
+    for: 2h
+    labels:
+      repo: dev-tracker
+      severity: page
+    annotations:
+      summary: Test data volume today is less than 70% of nominal daily volume.
+      description: Are machines online? Is data being collected? Is pusher working?
+        Is mlab-ns working? A new rollout?
+
 # The node_exporter running on eb.measurementlab.net is down.
   - alert: NodeExporterOnEbDownOrMissing
     expr: |

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -945,14 +945,14 @@ groups:
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 3d, "delay", "3d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 5d, "delay", "5d", "", ".*") or
             label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "ndt5", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "ndt5", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "switch", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "switch", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "tcpinfo", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "tcpinfo", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "traceroute", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "traceroute", "", ".*")
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "ndt5", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "ndt5", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "switch", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "switch", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "tcpinfo", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "tcpinfo", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "traceroute", "", ".*") or
+            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "traceroute", "", ".*")
             ))
     for: 2h
     labels:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -330,6 +330,8 @@ scrape_configs:
         - 'node_disk_io_time_seconds_total{deployment="node-exporter"}'
         # Aggregate the collectd health status from node-exporter.
         - 'collectd_mlab_success'
+        # Used by PlatformCluster_PusherDailyDataVolumeTooLow alert.
+        - 'datatype:pusher_bytes_per_tarfile:increase24h'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION
This change adds a new alert that fires whenever total pusher daily data volume drops below 70% of normal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/567)
<!-- Reviewable:end -->
