### PR TITLE
Remove unused bqx queries

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -21,11 +21,8 @@ spec:
                 "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
                 "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
-                "--type=gauge", "--query=/queries/bq_ipv6_bias.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_annotation.sql",
                 "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_worldmap_server.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_geohash_client.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_server.sql",
               ]
         ports:


### PR DESCRIPTION
This change removes bigquery exporter queries that we no longer use.

Four queries "bq_ndt_tests.sql", "bq_ndt_annotation.sql", "bq_gardener_parse_time.sql", "bq_ndt_server.sql" should be updated to use the new ndt5, tcpinfo and/or traceroute tables.

Only the gardener parse times and ndt_annotation rates have alerts that depend on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/568)
<!-- Reviewable:end -->
