### PR TITLE
Modifies neubot target service names so there is a distinct service name for each target

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -156,7 +156,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   # neubot on port 80 over IPv6
   ./mlabconfig.py --format=prom-targets \
       --template_target={{hostname}}:80 \
-      --label service=neubot \
+      --label service=neubot_ipv6 \
       --label module=tcp_v6_online \
       --decoration "v6" \
       --select "neubot.mlab.(${!pattern})" > \
@@ -175,7 +175,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   # neubot TLS on port 443 over IPv6
   ./mlabconfig.py --format=prom-targets \
       --template_target={{hostname}}:443 \
-      --label service=neubot_tls \
+      --label service=neubot_tls_ipv6 \
       --label module=tcp_v6_tls_online \
       --use_flatnames \
       --decoration "v6" \


### PR DESCRIPTION
We decided that it would be easiest to only have `/neubot` and `/neubot_ipv6` mlab-ns tools. However, we still want to check whether the TLS port (443) is listening to verify the health of these paths. In order to do this we need a separate, distinct service name for each type of target.

This PR is related to PR https://github.com/m-lab/mlab-ns/pull/214.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/573)
<!-- Reviewable:end -->
