### PR TITLE
Add BBE port explicitly on neubot ipv6 targets

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -127,6 +127,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:80 \
       --label service=neubot_ipv6 \
       --label module=tcp_v6_online \
+      --label __blackbox_port=${!bbe_port} \
       --decoration "v6" \
       --select "neubot.mlab.(${!pattern})" > \
           ${output}/blackbox-targets-ipv6/neubot_ipv6.json
@@ -146,6 +147,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:443 \
       --label service=neubot_tls_ipv6 \
       --label module=tcp_v6_tls_online \
+      --label __blackbox_port=${!bbe_port} \
       --use_flatnames \
       --decoration "v6" \
       --select "neubot.mlab.(${!pattern})" > \


### PR DESCRIPTION
This PR adds the blackbox-exporter port explicitly to the neubot IPv6 targets. It's currently using port 80 and failing to connect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/578)
<!-- Reviewable:end -->
