### PR TITLE
New alert for when the persistent disk on platform cluster Prometheus gets too full

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -831,7 +831,7 @@ groups:
 # disk mounted on the Prometheus VM gets too full (less than 5% free).
   - alert: PlatformCluster_PrometheusPersistentDiskTooFull
     expr: |
-      node_filesystem_avail_bytes{job="platform-cluster", node="prometheus-platform-cluster", mountpoint="/mnt/local"}
+      node_filesystem_avail_bytes{cluster="platform-cluster", node="prometheus-platform-cluster", mountpoint="/mnt/local"}
         / node_filesystem_size_bytes < 0.05
     for: 1m
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -827,6 +827,28 @@ groups:
         using - `kubectl get pods`. Check pod logs.
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/K8-zAIuik/k8s-master-cluster
 
+# PlatformCluster_PrometheusPersistentDiskTooFull fires when the persistent
+# disk mounted on the Prometheus VM gets too full (less than 5% free).
+  - alert: PlatformCluster_PrometheusPersistentDiskTooFull
+    expr: |
+      node_filesystem_free_bytes{job="platform-cluster", node="prometheus-platform-cluster", mountpoint="/mnt/local"}
+        / node_filesystem_size_bytes < 0.05
+    for: 1m
+    labels:
+      repo: ops-tracker
+      severity: page
+    annotations:
+      summary: The Prometheus persistent disk has less than 5% free space.
+      description: The Prometheus persistent disk has less than 5% free space.
+        Investigate filesystem usage on the VM, but most likely if this alert
+        fires it means that the size of the persistent disk is too small and
+        may need to be increased. GCE persistent disks can be resized, even on
+        a running VM. Increase the size of the disk as necessary, then unmount
+        the disk on the machine and run `resize2fs`, then mount it again. Don't
+        forget to increase the value in the bootstrap_prometheus.sh script in
+        the k8s-support repository.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/sVklmeHik/prometheus-self-monitoring?orgId=1&var-datasource=Platform%20Cluster%20(mlab-oti)
+
 # Check for missing workloads.
 
   - alert: PlatformCluster_CadvisorMissing

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -831,7 +831,7 @@ groups:
 # disk mounted on the Prometheus VM gets too full (less than 5% free).
   - alert: PlatformCluster_PrometheusPersistentDiskTooFull
     expr: |
-      node_filesystem_free_bytes{job="platform-cluster", node="prometheus-platform-cluster", mountpoint="/mnt/local"}
+      node_filesystem_avail_bytes{job="platform-cluster", node="prometheus-platform-cluster", mountpoint="/mnt/local"}
         / node_filesystem_size_bytes < 0.05
     for: 1m
     labels:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -305,8 +305,8 @@ scrape_configs:
       'match[]':
         - 'up{job=~".+"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
-        - 'node_filesystem_size_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
-        - 'node_filesystem_avail_bytes{deployment="node-exporter", mountpoint="/cache/data"}'
+        - 'node_filesystem_size_bytes{deployment="node-exporter"}'
+        - 'node_filesystem_avail_bytes{deployment="node-exporter"}'
         - 'node_memory_MemTotal_bytes'
         - 'node_edac_correctable_errors_total'
         - 'node_edac_uncorrectable_errors_total'


### PR DESCRIPTION
We just had a scenario where the PD on the production platform cluster instance of Prometheus filled up and started causing the prometheus pod to crash loop. We didn't know until it became obvious when others things we used started failing. This PR adds a new alerts to warn us when the PD on a platform cluster instance of Prometheus has less than 5% free.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/581)
<!-- Reviewable:end -->
