### PR TITLE
Add rollout panel for standard containers

### DIFF
--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1574381395510,
+  "iteration": 1574451020985,
   "links": [],
   "panels": [
     {
@@ -1113,8 +1113,8 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
-        "w": 12,
+        "h": 8,
+        "w": 17,
         "x": 0,
         "y": 31
       },
@@ -1126,7 +1126,7 @@
         "max": false,
         "min": false,
         "rightSide": true,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -1147,7 +1147,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count by (workload, container, commit, controller_revision_hash) (git_short_commit{workload=~\"$workload\", container=~\".*($container)\"})",
+          "expr": "count by (workload, container, commit, controller_revision_hash) (git_short_commit)",
           "legendFormat": "{{commit}} - {{controller_revision_hash}} - {{workload}} {{container}}",
           "refId": "B"
         }
@@ -1156,7 +1156,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Rollout Counts :: $workload  { $container }",
+      "title": "Rollout Counts by (git, k8s revision, workload, and container)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1202,9 +1202,9 @@
     "list": [
       {
         "current": {
-          "tags": [],
-          "text": "Platform Cluster (mlab-staging)",
-          "value": "Platform Cluster (mlab-staging)"
+          "selected": false,
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1217,114 +1217,6 @@
         "regex": "/^Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": "$datasource",
-        "definition": "label_values(git_short_commit, workload)",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": true,
-        "name": "workload",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "host",
-            "value": "host"
-          },
-          {
-            "selected": false,
-            "text": "ndt",
-            "value": "ndt"
-          },
-          {
-            "selected": false,
-            "text": "neubot",
-            "value": "neubot"
-          },
-          {
-            "selected": false,
-            "text": "utilization",
-            "value": "utilization"
-          }
-        ],
-        "query": "label_values(git_short_commit, workload)",
-        "refresh": 0,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "All",
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": "$datasource",
-        "definition": "label_values(git_short_commit, container)",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": true,
-        "name": "container",
-        "options": [
-          {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "tcpinfo",
-            "value": "tcpinfo"
-          },
-          {
-            "selected": false,
-            "text": "ndt-server",
-            "value": "ndt-server"
-          },
-          {
-            "selected": false,
-            "text": "traceroute",
-            "value": "traceroute"
-          },
-          {
-            "selected": false,
-            "text": "pusher",
-            "value": "pusher"
-          }
-        ],
-        "query": "label_values(git_short_commit, container)",
-        "refresh": 0,
-        "regex": "(tcpinfo|ndt-server|traceroute|pusher)",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
       }
     ]
   },
@@ -1360,5 +1252,5 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 100
+  "version": 104
 }

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 261,
-  "iteration": 1572288979434,
+  "iteration": 1574381395510,
   "links": [],
   "panels": [
     {
@@ -1020,6 +1020,7 @@
       "datasource": "$datasource",
       "description": "",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 7,
@@ -1042,7 +1043,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1100,6 +1103,95 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 35,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (workload, container, commit, controller_revision_hash) (git_short_commit{workload=~\"$workload\", container=~\".*($container)\"})",
+          "legendFormat": "{{commit}} - {{controller_revision_hash}} - {{workload}} {{container}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rollout Counts :: $workload  { $container }",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -1110,8 +1202,9 @@
     "list": [
       {
         "current": {
-          "text": "Platform Cluster (mlab-oti)",
-          "value": "Platform Cluster (mlab-oti)"
+          "tags": [],
+          "text": "Platform Cluster (mlab-staging)",
+          "value": "Platform Cluster (mlab-staging)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1124,6 +1217,114 @@
         "regex": "/^Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(git_short_commit, workload)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "workload",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "host",
+            "value": "host"
+          },
+          {
+            "selected": false,
+            "text": "ndt",
+            "value": "ndt"
+          },
+          {
+            "selected": false,
+            "text": "neubot",
+            "value": "neubot"
+          },
+          {
+            "selected": false,
+            "text": "utilization",
+            "value": "utilization"
+          }
+        ],
+        "query": "label_values(git_short_commit, workload)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(git_short_commit, container)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "container",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "tcpinfo",
+            "value": "tcpinfo"
+          },
+          {
+            "selected": false,
+            "text": "ndt-server",
+            "value": "ndt-server"
+          },
+          {
+            "selected": false,
+            "text": "traceroute",
+            "value": "traceroute"
+          },
+          {
+            "selected": false,
+            "text": "pusher",
+            "value": "pusher"
+          }
+        ],
+        "query": "label_values(git_short_commit, container)",
+        "refresh": 0,
+        "regex": "(tcpinfo|ndt-server|traceroute|pusher)",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -1159,5 +1360,5 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 99
+  "version": 100
 }

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -1148,7 +1148,7 @@
       "targets": [
         {
           "expr": "count by (workload, container, commit, controller_revision_hash) (git_short_commit)",
-          "legendFormat": "{{commit}} - {{controller_revision_hash}} - {{workload}} {{container}}",
+          "legendFormat": "{{commit}} - {{controller_revision_hash}} - {{workload}} - {{container}}",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
This change adds a new panel to the k8s: Workload Overview dashboard to observe rollouts progress.

To support viewing individual rollouts this change adds two new variables for "workload" and "container", with default values of "All".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/582)
<!-- Reviewable:end -->
