### PR TITLE
Import node_systemd_* metrics from platform cluster prometheus

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -332,6 +332,9 @@ scrape_configs:
         - 'collectd_mlab_success'
         # Used by PlatformCluster_PusherDailyDataVolumeTooLow alert.
         - 'datatype:pusher_bytes_per_tarfile:increase24h'
+        # Systemd metrics
+        - 'node_systemd_units'
+        - 'node_systemd_unit_state'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION
This PR reads some additional systemd-related metrics from the Platform Cluster Prometheus instance so we can alert on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/583)
<!-- Reviewable:end -->
