### PR TITLE
Fix queries used by NDT Global dashboard

### DIFF
--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -40,7 +40,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 1,
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 11,
@@ -69,7 +69,21 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Total",
+          "color": "#56A64B",
+          "linewidth": 2
+        },
+        {
+          "alias": "Download",
+          "color": "#5794F2"
+        },
+        {
+          "alias": "Upload",
+          "color": "#FADE2A"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -149,7 +163,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 1,
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 12,
@@ -178,7 +192,21 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Current",
+          "color": "#37872D",
+          "linewidth": 2
+        },
+        {
+          "alias": "One Week",
+          "color": "rgba(117, 207, 105, 0.53)"
+        },
+        {
+          "alias": "Two Week",
+          "color": "rgba(135, 150, 132, 0.67)"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -311,5 +339,5 @@
   "timezone": "utc",
   "title": "NDT: Global Test Rate",
   "uid": "Cyq7WeNiz",
-  "version": 141
+  "version": 142
 }

--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -14,8 +14,8 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
-  "iteration": 1565889514091,
+  "graphTooltip": 1,
+  "iteration": 1574962384405,
   "links": [],
   "panels": [
     {
@@ -41,6 +41,7 @@
       "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 11,
         "w": 24,
@@ -61,7 +62,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -147,6 +150,7 @@
       "datasource": "$datasource",
       "decimals": 1,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 12,
         "w": 24,
@@ -167,7 +171,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -178,8 +184,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0)) +\n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Current",
@@ -187,16 +194,18 @@
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) or vector(0)) + \n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
           "legendFormat": "One Week",
           "refId": "A",
           "step": 240
         },
         {
-          "expr": "60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) + 60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) + ((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d))  + (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
+          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) or vector(0)) +\n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Two Week",
           "refId": "B",
@@ -246,7 +255,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -302,5 +311,5 @@
   "timezone": "utc",
   "title": "NDT: Global Test Rate",
   "uid": "Cyq7WeNiz",
-  "version": 140
+  "version": 141
 }


### PR DESCRIPTION
This change fixes the queries that rely on now-obsolete metrics causing the graph to render incompletely. As well, this change updates the colors to avoid confusion between the upper and lower panels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/587)
<!-- Reviewable:end -->
