### PR TITLE
Filter systemd units with state="failed"

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -335,7 +335,7 @@ scrape_configs:
         - 'datatype:pusher_bytes_per_tarfile:increase24h'
         # Systemd metrics
         - 'node_systemd_units'
-        - 'node_systemd_unit_state{state="failed"} == 1'
+        - 'node_systemd_unit_state{state="failed"}'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -335,7 +335,7 @@ scrape_configs:
         - 'datatype:pusher_bytes_per_tarfile:increase24h'
         # Systemd metrics
         - 'node_systemd_units'
-        - 'node_systemd_unit_state'
+        - 'node_systemd_unit_state{state="failed"} == 1'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:


### PR DESCRIPTION
This PR further reduces the number of metrics we collect from the Platform Cluster Prometheus by filtering for `{state="failed"}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/588)
<!-- Reviewable:end -->
