### PR TITLE
Adds configs for PagerDuty to AM, and appropriately sets alert severity label

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -194,6 +194,7 @@ sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
     -e 's|{{GITHUB_RECEIVER_URL}}|'$GITHUB_RECEIVER_URL'|g' \
     -e 's|{{SHORT_PROJECT}}|'$SHORT_PROJECT'|g' \
     -e 's|{{GITHUB_ISSUE_QUERY}}|'$GITHUB_ISSUE_QUERY'|g' \
+    -e 's|{{PAGERDUTY_SERVICE_KEY}}|'$PAGERDUTY_SERVICE_KEY'|g' \
     config/federation/alertmanager/config.yml.template > \
     config/federation/alertmanager/config.yml
 

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -32,6 +32,11 @@ route:
   # When no other routes match, use the default receiver.
   receiver: slack-alerts-ticket
 
+  routes:
+  - receiver: 'pagerduty-pages'
+    continue: true
+    match:
+      severity: page
 
 # When two alerts are firing at the same time, we can "inhibit" one based on
 # the other. For example, a host is offline and a service on that host is not
@@ -134,3 +139,8 @@ receivers:
   # All alerts sent to slack are also sent to the github webhook receiver.
   webhook_configs:
   - url: '{{GITHUB_RECEIVER_URL}}'
+
+- name: 'pagerduty-pages'
+  pagerduty_configs:
+  - send_resolved: true
+    service_key: {{PAGERDUTY_SERVICE_KEY}}

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -80,7 +80,7 @@ inhibit_rules:
 # platform cluster scrape job is down.
 - source_match:
     alertname: 'PlatformCluster_FederationScrapeJobFailing'
-  taret_match_re:
+  target_match_re:
     alertname: 'PlatformCluster_.+Missing'
   equal: ['cluster']
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -309,11 +309,11 @@ groups:
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
           )
         ) / count(probe_success{service="ndt_ssl"})
-      ) < 0.90
+      ) < 0.50
     for: 10m
     labels:
       repo: ops-tracker
-      severity: ticket
+      severity: page
     annotations:
       summary: Less than 90% of ndt_ssl experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -591,7 +591,7 @@ groups:
     for: 2h
     labels:
       repo: dev-tracker
-      severity: ticket
+      severity: page
     annotations:
       summary: Test data volume today is less than 70% of nominal daily volume.
       description: Are machines online? Is data being collected? Is pusher working?
@@ -899,7 +899,7 @@ groups:
     for: 5m
     labels:
       repo: ops-tracker
-      severity: ticket
+      severity: page
     annotations:
       summary: The NDT DaemonSet is missing or has no metrics.
       description: The NDT DaemonSet is missing or has no metrics. Verify that

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -68,7 +68,7 @@ groups:
     for: 5m
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Neither of the last two attempts to download the maxmind or
         routeviews feeds were successful.
@@ -110,7 +110,7 @@ groups:
     for: 30m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Expected SNMP metrics are missing from Prometheus!
       description: >
@@ -131,7 +131,7 @@ groups:
     for: 2h
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Prometheus is unable to scrape SNMP metrics from a switch.
       description: >
@@ -148,7 +148,7 @@ groups:
       count(up{job="snmp-targets",site!~".*t$"}) > 0.2
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: More than 20% of reachable switches are not providing SNMP metrics.
       description: >
@@ -185,7 +185,7 @@ groups:
     for: 30m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Expected script_exporter metrics are missing from Prometheus!
       description: >
@@ -257,7 +257,7 @@ groups:
     for: 10m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Less than 90% of ndt experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -285,7 +285,7 @@ groups:
     for: 10m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Less than 75% of ndt_ipv6 experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -313,7 +313,7 @@ groups:
     for: 10m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Less than 90% of ndt_ssl experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -340,7 +340,7 @@ groups:
     for: 10m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Less than 75% of ndt_ssl_ipv6 experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -361,7 +361,7 @@ groups:
     for: 2m
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Server-side errors rate for mlab-ns is over 1%.
       description: Stackdriver reports more than 1% of the HTTP requests to mlab-ns are
@@ -377,7 +377,7 @@ groups:
     for: 1m
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Server-side errors rate for rate-limiter is not zero.
       description: Stackdriver reports some of the HTTP requests to
@@ -438,7 +438,7 @@ groups:
     for: 30m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: A metric for an NDT service is missing.
       description: >
@@ -563,7 +563,7 @@ groups:
     for: 2h
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Today's test volume is less than 70% of nominal daily volume.
       description: Are machines online? Is data being collected? Is the parser working?
@@ -591,7 +591,7 @@ groups:
     for: 2h
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Test data volume today is less than 70% of nominal daily volume.
       description: Are machines online? Is data being collected? Is pusher working?


### PR DESCRIPTION
We've all agreed that we are at the point of needing some sort of paging with regard to the most severe problems that can occur on the platform. This PR is a first test at implementing this using a service called [PagerDuty](https://www.pagerduty.com/). One nice thing about PagerDuty is that [support of it is already built into AlertManager](https://prometheus.io/docs/alerting/configuration/#pagerduty_config).

It appears that PagerDuty is flexible enough to allow us to be sure that only the Google person on call for a given week would receive pages.

This PR also more appropriately sets the `severity` label for alerts to only have a value of `page` for the alerts that are the most serious. With this PR the only alerts with a severity=page are:

```
ClusterDown
MlabNSServiceUnavailable
PlatformCluster_FederationScrapeJobFailing
PlatformCluster_FederationScrapeJobMissing
PlatformCluster_PrometheusPersistentDiskTooFull
PlatformCluster_EtcdHasNoLeader
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/597)
<!-- Reviewable:end -->
