### PR TITLE
Adds a new alerts for when more than 5% of NDT S2C tests have discards.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -348,20 +348,6 @@ groups:
         monitoring.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
-# Too many NDT S2C tests on a node are being impacted by switch discards.
-  - alert: PlatformCluster_TooManyNdtS2cTestsWithDiscards
-    expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05
-    for: 10m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: More than 5% of NDT tests in a 24h period were affected by discards.
-      description: Too many NDT S2C tests in a 24h period (BQ partition_date)
-        were affected by switch discards on {{ $labels.node }}. The switch may
-        be overloaded, or TCP pacing may be misconfigured on the node.
-      dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/SuqnZ6Hiz/ops-switch-overview
-
 # HTTP per-status response count is exported by stackdriver. By querying
 # stackdriver metrics, we can alert if the server-side errors rate for mlab-ns
 # is too high or if the service is unavailable.
@@ -611,6 +597,20 @@ groups:
       description: Are machines online? Is data being collected? Is pusher working?
         Is mlab-ns working? A new rollout?
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
+
+# Too many NDT S2C tests on a node are being impacted by switch discards.
+  - alert: DataQuality_TooManyNdtS2cTestsWithDiscards
+    expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: More than 5% of NDT tests in a 24h period were affected by discards.
+      description: Too many NDT S2C tests in a 24h period (BQ partition_date)
+        were affected by switch discards on {{ $labels.node }}. The switch may
+        be overloaded, or TCP pacing may be misconfigured on the node.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/ops-switch-overview
 
 # The node_exporter running on eb.measurementlab.net is down.
   - alert: NodeExporterOnEbDownOrMissing

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -348,6 +348,20 @@ groups:
         monitoring.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
+# Too many NDT S2C tests on a node are being impacted by switch discards.
+  - alert: PlatformCluster_TooManyNdtS2cTestsWithDiscards
+    expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: More than 5% of NDT tests in a 24h period were affected by discards.
+      description: Too many NDT S2C tests in a 24h period (BQ partition_date)
+        were affected by switch discards on {{ $labels.node }}. The switch may
+        be overloaded, or TCP pacing may be misconfigured on the node.
+      dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/SuqnZ6Hiz/ops-switch-overview
+
 # HTTP per-status response count is exported by stackdriver. By querying
 # stackdriver metrics, we can alert if the server-side errors rate for mlab-ns
 # is too high or if the service is unavailable.


### PR DESCRIPTION
This alert takes advantage of [a new bq-exporter query](https://github.com/m-lab/prometheus-support/blob/master/config/federation/bigquery/bq_ndt_s2c.sql) that looks for NDT S2C tests affected by switch discards in a 24h period.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/598)
<!-- Reviewable:end -->
