### PR TITLE
Update bigquery exporter version and bq_ndt_s2c query

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -16,18 +16,16 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:production-0.3
-        args: [ "--project={{GCLOUD_PROJECT}}",
-                "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
-                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_tests.sql",
-                "--type=gauge", "--query=/queries/bq_annotation.sql",
-                "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_server.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_s2c.sql",
+        image: measurementlab/prometheus-bigquery-exporter:v1.0.0
+        args: [ "-project={{GCLOUD_PROJECT}}",
+                "-gauge-query=/queries/bq_mlabns_ratelimit.sql",
+                "-gauge-query=/queries/bq_mlabns_sixhour_requests.sql",
+                "-gauge-query=/queries/bq_annotation.sql",
+                "-gauge-query=/queries/bq_gardener_parse_time.sql",
+                "-gauge-query=/queries/bq_ndt_s2c.sql",
               ]
         ports:
-        - containerPort: 9050
+        - containerPort: 9348
         volumeMounts:
         - mountPath: /queries
           name: bigquery-config


### PR DESCRIPTION
This change includes a fix to the bq_ndt_s2c query and an upgrade of the bqx container version.

The bq_ndt_s2c query used a `DECLARE` statement which evidently isn't supported by default by either the older or newer versions of bqx. This change replaces is it with a function instead.

The version of bqx is updated to v1.0.0. This includes flag changes and use of the canonical port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/600)
<!-- Reviewable:end -->
