### PR TITLE
Rollback bqx version

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -16,16 +16,16 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.0.0
+        image: measurementlab/prometheus-bigquery-exporter:production-0.3
         args: [ "-project={{GCLOUD_PROJECT}}",
-                "-gauge-query=/queries/bq_mlabns_ratelimit.sql",
-                "-gauge-query=/queries/bq_mlabns_sixhour_requests.sql",
-                "-gauge-query=/queries/bq_annotation.sql",
-                "-gauge-query=/queries/bq_gardener_parse_time.sql",
-                "-gauge-query=/queries/bq_ndt_s2c.sql",
+                "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
+                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
+                "--type=gauge", "--query=/queries/bq_annotation.sql",
+                "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
+                "--type=gauge", "--query=/queries/bq_ndt_s2c.sql",
               ]
         ports:
-        - containerPort: 9348
+        - containerPort: 9050
         volumeMounts:
         - mountPath: /queries
           name: bigquery-config

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: bigquery-exporter
         image: measurementlab/prometheus-bigquery-exporter:production-0.3
-        args: [ "-project={{GCLOUD_PROJECT}}",
+        args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
                 "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
                 "--type=gauge", "--query=/queries/bq_annotation.sql",


### PR DESCRIPTION
Evidently something is off about the v1.0.0 version -- it repeatedly logs that it's Registering the queries instead of updating them. As a result, the metrics collected end up with gaps.

This change rollsback the bqx version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/601)
<!-- Reviewable:end -->
