### PR TITLE
Further reduce number of alerts with severity=page

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -591,7 +591,7 @@ groups:
     for: 2h
     labels:
       repo: dev-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Test data volume today is less than 70% of nominal daily volume.
       description: Are machines online? Is data being collected? Is pusher working?
@@ -869,7 +869,7 @@ groups:
     for: 1m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: The Prometheus persistent disk has less than 5% free space.
       description: The Prometheus persistent disk has less than 5% free space.
@@ -1116,7 +1116,7 @@ groups:
     for: 5m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: At least one etcd cluster member has no leader.
       description: An etcd cluster member is reporting that it has no leader.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -832,7 +832,7 @@ groups:
     for: 4m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Federation scraping of the k8s platform cluster is down.
       description: Scraping of Prometheus on the platform cluster is down.
@@ -852,7 +852,7 @@ groups:
     for: 4m
     labels:
       repo: ops-tracker
-      severity: page
+      severity: ticket
     annotations:
       summary: Federation scraping of the k8s platform cluster is missing.
       description: A scrape job for the k8s platform cluster is missing. This


### PR DESCRIPTION
This further reduces the alerts with `severity=page` to:

- ClusterDown
- TooManyNdtSslIpv4ServersDown
- MlabNSServiceUnavailable
- PlatformCluster_NdtMissing (No metrics at all for deployment="ndt")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/602)
<!-- Reviewable:end -->
