### PR TITLE
Add gcs-exporter deployment

### DIFF
--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -19,9 +19,9 @@ spec:
       - name: gcs-exporter
         image: measurementlab/gcs-exporter:latest
         args:
-        - -source pusher-{{GCLOUD_PROJECT}}
-        - -source archive-{{GCLOUD_PROJECT}}
-        - -source archive-measurement-lab
+        - -source=pusher-{{GCLOUD_PROJECT}}
+        - -source=archive-{{GCLOUD_PROJECT}}
+        - -source=archive-measurement-lab
         ports:
         - containerPort: 9990
           name: metrics

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: gcs-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: gcs-exporter
+  template:
+    metadata:
+      labels:
+        run: gcs-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9990'
+    spec:
+      containers:
+      - name: gcs-exporter
+        image: measurementlab/gcs-exporter:latest
+        args:
+        - -source pusher-{{GCLOUD_PROJECT}}
+        - -source archive-{{GCLOUD_PROJECT}}
+        - -source archive-measurement-lab
+        ports:
+        - containerPort: 9990
+          name: metrics

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -19,6 +19,8 @@ spec:
       - name: gcs-exporter
         image: measurementlab/gcs-exporter:v0.1
         args:
+        # NOTE: -time must not be less than the scheduled transfer times from:
+        # https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml
         - -time=4h30m
         - -source=pusher-{{GCLOUD_PROJECT}}
         - -source=archive-{{GCLOUD_PROJECT}}

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gcs-exporter

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -17,8 +17,9 @@ spec:
     spec:
       containers:
       - name: gcs-exporter
-        image: measurementlab/gcs-exporter:latest
+        image: measurementlab/gcs-exporter:v0.1
         args:
+        - -time=4h30m
         - -source=pusher-{{GCLOUD_PROJECT}}
         - -source=archive-{{GCLOUD_PROJECT}}
         - -source=archive-measurement-lab


### PR DESCRIPTION
This change adds the gcs-exporter to the federation cluster to monitor daily archive transfers as part of the "Codified Daily Archive Transfers" design.

The exporter scans the named buckets every day at 04:30:00 UTC. This time corresponds to the schedules defined in https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/606)
<!-- Reviewable:end -->
