### PR TITLE
Set the 'machine' label equal to the 'node' label, if the label 'node' label exists.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -353,6 +353,21 @@ scrape_configs:
         target_label: experiment
         replacement: ndt.iupui
 
+      # Rewrite the machine label to make it easier to join these metrics with
+      # existing metrics that use machine instead of the node label.
+      #
+      # NOTE: Relabeling that happens in the Prometheus instance in the
+      # platform cluster automatically creates a "machine" label from the value
+      # of "__meta_kubernetes_pod_node_name". In some cases, the value of that
+      # label is not representative of the "node" we have in mind, but instead
+      # will be, for example, "prometheus-platform-cluster".  We want the
+      # "machine" and "node" labels to always be the same, to the extent
+      # possible. Overwriting "machine" here with "node" helps to ensure that
+      # _if_ a "node" label exists the "machine" label will always be the same.
+      - source_labels: [node]
+        action: replace
+        target_label: machine
+
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'
     static_configs:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -349,7 +349,7 @@ scrape_configs:
       # favor of some native k8s one (e.g., 'deployment'), or to at the very
       # least shorten the name to just 'ndt'
       - source_labels: [deployment]
-        regex: ^ndt.*
+        regex: ndt.*
         target_label: experiment
         replacement: ndt.iupui
 
@@ -365,6 +365,7 @@ scrape_configs:
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
       - source_labels: [node]
+        regex: (mlab[1-4]\.[a-z]{3}[0-9tc]{2}\.measurement-lab\.org)
         action: replace
         target_label: machine
 


### PR DESCRIPTION
This PR is intended to resolve issue #607.

In summary, in the case where a metric has a `node` label, then the `machine` label should be overwritten with the `node` label's value.

NOTE: I've attempted to spot check this for sanity, and I _believe_ it is the correct thing to do and safe, but a second set of eyes will be good. Hence this  PR, I guess.

An an indirect way this PR is part of PR https://github.com/m-lab/mlab-ns/pull/216, which attempts to resolve https://github.com/m-lab/mlab-ns/issues/215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/608)
<!-- Reviewable:end -->
