### PR TITLE
Removes metrics from mlab-ns generic query that might reasonably not exist

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -426,9 +426,7 @@ groups:
     expr: |
       absent(node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"})
         or absent(node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"})
-        or absent(kube_node_spec_taint{cluster="platform-cluster"})
         or absent(lame_duck_experiment{cluster="platform-cluster"})
-        or absent(gmx_machine_maintenance)
     for: 30m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -227,20 +227,22 @@ groups:
         BBE container running in the VM. Domains for VMs are like
         blackbox-exporter-ipv6.<project>.measurementlab.net.
 
-# Unable to scrape the Github Maintenance exporter.
-  - alert: GithubMaintenanceExporterDown
-    expr: up{job="nginx-proxied-services", service="gmx"} == 0
+# Unable to scrape the Github Maintenance exporter or the job is missing.
+  - alert: GithubMaintenanceExporterDownOrMissing
+    expr: |
+      up{job="nginx-proxied-services", service="gmx"} == 0
+        or absent(up{job="nginx-proxied-services", service="gmx"})
     for: 10m
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: Scraping of the Github Maintenance Exporter is failing.
+      summary: Scraping of the Github Maintenance Exporter is failing or missing.
       description: >
-        Scraping of the Github Maintenance Exporter is failing. Check that the
-        gmx-server deployment is healthy and that a pod for it exists. Check
-        the status of the pod for errors. Check the logs of the pod for errors.
-        Check the reason that the scrape failed[1].
+        Scraping of the Github Maintenance Exporter is failing or missing.
+        Check that the gmx-server deployment is healthy and that a pod for it
+        exists. Check the status of the pod for errors. Check the logs of the
+        pod for errors.  Check the reason that the scrape failed[1].
         [1]: https://prometheus.mlab-oti.measurementlab.net/targets#job-nginx-proxied-services
 
 ## mlab-ns queries.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -227,6 +227,21 @@ groups:
         BBE container running in the VM. Domains for VMs are like
         blackbox-exporter-ipv6.<project>.measurementlab.net.
 
+# Unable to scrape the Github Maintenance exporter.
+  - alert: GithubMaintenanceExporterDown
+    expr: up{job="nginx-proxied-services", service="gmx"} == 0
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Scraping of the Github Maintenance Exporter is failing.
+      description: >
+        Scraping of the Github Maintenance Exporter is failing. Check that the
+        gmx-server deployment is healthy and that a pod for it exists. Check
+        the status of the pod for errors. Check the logs of the pod for errors.
+        Check the reason that the scrape failed[1].
+        [1]: https://prometheus.mlab-oti.measurementlab.net/targets#job-nginx-proxied-services
 
 ## mlab-ns queries.
 #


### PR DESCRIPTION
The metric `kube_node_spec_taint` will only exist if a node has been tainted. In many cases no nodes will have taints, and this metric will not exist, causing a false positing on the `MlabNS_GenericMetricsMissing` alerts. This PR also removes the `absent()` check on `gmx_machine_maintenance`, since that metric could also reasonably be missing if there are no active GMX entries and the pod was recently restarted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/611)
<!-- Reviewable:end -->
