### PR TITLE
Update gcs-exporter & Add pusher SLO alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -634,6 +634,30 @@ groups:
         Is mlab-ns working? A new rollout?
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
+# PusherSLO
+#
+# Pusher uploads archives for a machine every few hours. After every boot, a
+# machine starts with a "lower bound" mtime equal to the current time. As data
+# is written to disk, we expect the "lower bound" to gradually move forward in
+# time. If it does not, then data is not being successfully uploaded and
+# removed. That is a problem.
+#
+# The alert excludes nodes in maintenance or lame-duck.
+  - alert: PusherFinderMtimeLowerBoundIsTooOld
+    expr: |
+      (time() - pusher_finder_mtime_lower_bound) > (24 * 60 * 60)
+        unless on(machine) gmx_machine_maintenance == 1
+        unless on(machine) kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"}
+    for: 5m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      summary: Pusher max file mtime is too old.
+      description: Max file mtime is older than 24 hours. Uploads may be failing
+        and data could be lost if the node is rebooted before a successful upload.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
+
 # Too many NDT S2C tests on a node are being impacted by switch discards.
   - alert: DataQuality_TooManyNdtS2cTestsWithDiscards
     expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -645,7 +645,7 @@ groups:
 # The alert excludes nodes in maintenance or lame-duck.
   - alert: PusherFinderMtimeLowerBoundIsTooOld
     expr: |
-      (time() - pusher_finder_mtime_lower_bound) > (24 * 60 * 60)
+      (time() - pusher_finder_mtime_lower_bound) > (12 * 60 * 60)
         unless on(machine) gmx_machine_maintenance == 1
         unless on(machine) kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"}
     for: 5m
@@ -654,8 +654,8 @@ groups:
       severity: ticket
     annotations:
       summary: Pusher max file mtime is too old.
-      description: Max file mtime is older than 24 hours. Uploads may be failing
-        and data could be lost if the node is rebooted before a successful upload.
+      description: Max file mtime is older than 24 hours. If uploads are failing
+        then data will be lost if the node reboots.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
 # Too many NDT S2C tests on a node are being impacted by switch discards.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -654,7 +654,7 @@ groups:
       severity: ticket
     annotations:
       summary: Pusher max file mtime is too old.
-      description: Max file mtime is older than 24 hours. If uploads are failing
+      description: Max file mtime is older than 12 hours. If uploads are failing
         then data will be lost if the node reboots.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -336,6 +336,8 @@ scrape_configs:
         # Systemd metrics
         - 'node_systemd_units'
         - 'node_systemd_unit_state{state="failed"}'
+        # PusherSLO
+        - 'pusher_finder_mtime_lower_bound'
     static_configs:
       - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
         labels:

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -17,14 +17,16 @@ spec:
     spec:
       containers:
       - name: gcs-exporter
-        image: measurementlab/gcs-exporter:v0.1
+        image: measurementlab/gcs-exporter:v0.2
         args:
         # NOTE: -time must not be less than the scheduled transfer times from:
         # https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml
-        - -time=4h30m
         - -source=pusher-{{GCLOUD_PROJECT}}
+        - -time=2h30m
         - -source=archive-{{GCLOUD_PROJECT}}
+        - -time=3h30m
         - -source=archive-measurement-lab
+        - -time=4h30m
         ports:
         - containerPort: 9990
           name: metrics


### PR DESCRIPTION
This change includes two updates:

* Update the version of gcs-exporter to support multiple bucket times
* Add a new Pusher SLO alert using the new metric available in pusher:v1.14.

The Pusher SLO expects `pusher_finder_mtime_lower_bound` to be less than 24h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/618)
<!-- Reviewable:end -->
