### PR TITLE
A new alert to detect 'zombie' nodes. Intended to resolve issue #620.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -245,6 +245,26 @@ groups:
         pod for errors.  Check the reason that the scrape failed[1].
         [1]: https://prometheus.mlab-oti.measurementlab.net/targets#job-nginx-proxied-services
 
+  # Blackbox exporter probes to a machine are succeeding to a node that
+  # kubernetes does not know about (not joined to the k8s cluster).
+  - alert: MachineRunningWithoutK8sNode
+    expr: probe_success{service="ndt_ssl"} == 1 unless on(machine) kube_node_status_condition
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: A machine is running that is not part of the k8s cluster.
+      description: >
+        Blackbox exporter probes (for ndt_ssl) are succeeding to a node that
+        kubernetes does not know about. This can happen when a machine gets
+        segmented from the network, then gets manually deleted from kubernetes,
+        then at some point the machine has its network connectivity restored.
+        In this situation all of the containers on the machine are still
+        running, but the node is no longer known to kubernetes. It becomes like
+        a zombie node, possibly continuing to upload data to GCS and serve
+        experiment tests. The simple fix is to reboot the zombie node.
+
 ## mlab-ns queries.
 #
 # The following alerts are based on the exact queries that mlab-ns runs to


### PR DESCRIPTION
The query in this alert was tested like this in mlab-sandbox:

1. Login to mlab4.lga0t and `systemctl stop kubelet`.
2. When the node becomes `NotReady` in k8s, delete the node.
3. Verify that this query returns mlab4.lga0t.
4. Reboot mlab4.lga0t and verify that the query returns nothing.

I chose to use `service="ndt_ssl"` under the assumption that that is a blackbox_exporter probe service that should always exist on the platform, though it is mildly arbitrary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/623)
<!-- Reviewable:end -->
