### PR TITLE
Make the pusher alert less spammy

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -673,7 +673,7 @@ groups:
       repo: dev-tracker
       severity: ticket
     annotations:
-      summary: Pusher max file mtime is too old.
+      summary: Data on disk are too old and should have been uploaded already
       description: The min file mtime seen by pusher has been older than 16
         hours for at least 8 hours. If uploads are failing then data will be lost
         if the node reboots.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -665,17 +665,18 @@ groups:
 # The alert excludes nodes in maintenance or lame-duck.
   - alert: PusherFinderMtimeLowerBoundIsTooOld
     expr: |
-      (time() - pusher_finder_mtime_lower_bound) > (12 * 60 * 60)
+      (time() - pusher_finder_mtime_lower_bound) > (16 * 60 * 60)
         unless on(machine) gmx_machine_maintenance == 1
         unless on(machine) kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"}
-    for: 3h
+    for: 8h
     labels:
       repo: dev-tracker
       severity: ticket
     annotations:
       summary: Pusher max file mtime is too old.
-      description: Max file mtime is older than 12 hours. If uploads are failing
-        then data will be lost if the node reboots.
+      description: The min file mtime seen by pusher has been older than 16
+        hours for at least 8 hours. If uploads are failing then data will be lost
+        if the node reboots.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
 # GCS Transfer SLO


### PR DESCRIPTION
The old alert was spammy. 

finder (the thing that does a cleanup job if inotify events were missed) runs every hour in expectation. But it could be arbitrarily far in the future with ever-decreasing likelihood.  Also, it will only trigger on files that are at least 4 hours old. Also, it will only update the metrics when it runs.  This means that the following sequence of events could occur:
1. An inotify event was missed. Wait 4 hours before finder could even possibly find the file.
2. Now that the file is eligible for upload, wait up to 1-4 or more hours for finder to run.
3. Now wait until the file is actually uploaded and removed, up to 2 hours.
4. Now wait 1-4 or more hours for finder to run again to notice that the file has been removed.

Our alert is firing spam because 4 + exprandom(1) + 2 + exprandom(1) can apparently be greater than 12 an appreciable percentage of the time. I just did a simulation and discovered that the answer is: Things can be too big 1.756500% of the time.

Simulation code is:
```go
package main
import (
	"log"
	"math/rand"
)
func main() {
	ok := 0
	toobig := 0
	for i := 0; i < 1000000; i++ {
		total := 4 + rand.ExpFloat64() + 2 + rand.ExpFloat64()
		if total > 12 {
			toobig++
		} else {
			ok++
		}
	}
	log.Printf("Thing were too big %f%% of the time\n", float64(toobig)*100/float64(toobig+ok))
}
```

Output was:
```txt
2020/01/24 13:56:17 Thing were too big 1.756500% of the time
```

We have clamped the pusher inter-finder run time to be 4 hours max. This means that, in the ordinary course of events, the metrics could be 4+4+2+4 = 14 hours old, not counting the time it takes to upload the files.  So 16 hours seems like a good time to start alerting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/624)
<!-- Reviewable:end -->
