### PR TITLE
Use HTTPS and basic authentication to scrape platform-cluster Prometheus

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -63,6 +63,8 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH}}|'${!REBOOTAPI_BASIC_AUTH_USER}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH_PASS}}|'${!REBOOTAPI_BASIC_AUTH_PASS}'|g' \
+    -e 's|{{PLATFORM_PROM_AUTH_USER}}|'${!PLATFORM_PROM_AUTH_USER}'|g' \
+    -e 's|{{PLATFORM_PROM_AUTH_PASS}}|'${!PLATFORM_PROM_AUTH_PASS}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1094,7 +1094,7 @@ groups:
   # value of updated_scheduled to the value from an hour ago (all pods) will
   # yield a negative number for roughly the period of the offset (1h in this
   # case). 70m just gives us a safe window to cross that inversion.
-  - alert: PlatformClustser_RolloutTooSlowOrStuck
+  - alert: PlatformCluster_RolloutTooSlowOrStuck
     expr: |
       kube_daemonset_updated_number_scheduled - (kube_daemonset_updated_number_scheduled offset 1h) <= 2
         unless (

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -289,8 +289,8 @@ scrape_configs:
     metrics_path: '/federate'
     scheme: https
     basic_auth:
-      username: {{PLATFORM_PROMETHEUS_BASIC_AUTH_USER}}
-      password: {{PLATFORM_PROMETHEUS_BASIC_AUTH_PASS}}
+      username: {{PLATFORM_PROM_AUTH_USER}}
+      password: {{PLATFORM_PROM_AUTH_PASS}}
     params:
       # Scrape the status of all jobs. This should allow us determine
       # whether, for example, node_exporter is failing to be scraped

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -287,6 +287,10 @@ scrape_configs:
   - job_name: 'platform-cluster'
     honor_labels: true
     metrics_path: '/federate'
+    scheme: https
+    basic_auth:
+      username: {{PLATFORM_PROMETHEUS_BASIC_AUTH_USER}}
+      password: {{PLATFORM_PROMETHEUS_BASIC_AUTH_PASS}}
     params:
       # Scrape the status of all jobs. This should allow us determine
       # whether, for example, node_exporter is failing to be scraped
@@ -339,7 +343,7 @@ scrape_configs:
         # PusherSLO
         - 'pusher_finder_mtime_lower_bound'
     static_configs:
-      - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:9090']
+      - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:443']
         labels:
           cluster: "platform-cluster"
 


### PR DESCRIPTION
This PR changes the Prometheus configuration to scrape the platform-cluster Prometheus over HTTPS and by authenticating via HTTP Basic Authentication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/626)
<!-- Reviewable:end -->
