### PR TITLE
Update reboot-api deployment to v0.4.0 and change scrape_interval

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -786,9 +786,8 @@ scrape_configs:
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
 
-  # Scrape BMC targets every 5m.
+  # Scrape BMC targets every minute.
   - job_name: 'bmc-targets'
-    scrape_interval: 5m
     scrape_timeout: 60s
     file_sd_configs:
       - files:

--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: reboot-api
-        image: measurementlab/reboot-api:v0.3.0
+        image: measurementlab/reboot-api:v0.4.0
         args:
           - "-datastore.project={{GCLOUD_PROJECT}}"
           - "-reboot.key=/var/secrets/reboot-api-ssh.key"


### PR DESCRIPTION
This PR updates the reboot-api version to v0.4.0, which changes the `/v1/e2e` endpoint to cache results for an hour. That makes it possible to set the `scrape_interval` for the bmc-targets to the default (1m). 

Closes https://github.com/m-lab/prometheus-support/issues/630.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/631)
<!-- Reviewable:end -->
