### PR TITLE
Runs slack-alerts-ticket receiver even if PagerDuty receiver fires first

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -37,6 +37,7 @@ route:
     continue: true
     match:
       severity: page
+  - receiver: 'slack-alerts-ticket'
 
 # When two alerts are firing at the same time, we can "inhibit" one based on
 # the other. For example, a host is offline and a service on that host is not


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/641)
<!-- Reviewable:end -->
