### PR TITLE
Prevents AM from sending staging alerts to PagerDuty

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -176,7 +176,6 @@ kubectl create configmap grafana-env \
 SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
 GITHUB_RECEIVER_URL=
 GITHUB_ISSUE_QUERY=
-FAKE_PROJECT_LABEL=
 SHORT_PROJECT=${PROJECT/mlab-/}
 
 if [[ ${PROJECT} = "mlab-oti" ]] ; then
@@ -188,11 +187,6 @@ if [[ ${PROJECT} = "mlab-oti" ]] ; then
 else
   # For other projects, use a fake auth token string.
   AUTH_TOKEN=fake-auth-token
-  # For projects other than mlab-oti, insert a fake project "match" selector
-  # for the PageDuty receiver, which should effectively prevent alerts being
-  # sent to PagerDuty for any project other than mlab-oti, since this match
-  # requirement will never match anything.
-  FAKE_PROJECT_LABEL="project: fake-project"
 fi
 kubectl create secret generic github-secrets \
     "--from-literal=auth-token=${AUTH_TOKEN}" \
@@ -207,7 +201,6 @@ sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
     -e 's|{{SHORT_PROJECT}}|'$SHORT_PROJECT'|g' \
     -e 's|{{GITHUB_ISSUE_QUERY}}|'$GITHUB_ISSUE_QUERY'|g' \
     -e 's|{{PAGERDUTY_SERVICE_KEY}}|'$PAGERDUTY_SERVICE_KEY'|g' \
-    -e 's|{{FAKE_PROJECT_LABEL}}|'$FAKE_PROJECT_LABEL'|g' \
     config/federation/alertmanager/config.yml.template > \
     config/federation/alertmanager/config.yml
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -176,6 +176,7 @@ kubectl create configmap grafana-env \
 SLACK_CHANNEL_URL_NAME=AM_SLACK_CHANNEL_URL_${PROJECT/-/_}
 GITHUB_RECEIVER_URL=
 GITHUB_ISSUE_QUERY=
+FAKE_PROJECT_LABEL=
 SHORT_PROJECT=${PROJECT/mlab-/}
 
 if [[ ${PROJECT} = "mlab-oti" ]] ; then
@@ -187,6 +188,11 @@ if [[ ${PROJECT} = "mlab-oti" ]] ; then
 else
   # For other projects, use a fake auth token string.
   AUTH_TOKEN=fake-auth-token
+  # For projects other than mlab-oti, insert a fake project "match" selector
+  # for the PageDuty receiver, which should effectively prevent alerts being
+  # sent to PagerDuty for any project other than mlab-oti, since this match
+  # requirement will never match anything.
+  FAKE_PROJECT_LABEL="project: fake-project"
 fi
 kubectl create secret generic github-secrets \
     "--from-literal=auth-token=${AUTH_TOKEN}" \

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -207,6 +207,7 @@ sed -e 's|{{SLACK_CHANNEL_URL}}|'${!SLACK_CHANNEL_URL_NAME}'|g' \
     -e 's|{{SHORT_PROJECT}}|'$SHORT_PROJECT'|g' \
     -e 's|{{GITHUB_ISSUE_QUERY}}|'$GITHUB_ISSUE_QUERY'|g' \
     -e 's|{{PAGERDUTY_SERVICE_KEY}}|'$PAGERDUTY_SERVICE_KEY'|g' \
+    -e 's|{{FAKE_PROJECT_LABEL}}|'$FAKE_PROJECT_LABEL'|g' \
     config/federation/alertmanager/config.yml.template > \
     config/federation/alertmanager/config.yml
 

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -37,7 +37,7 @@ route:
     continue: true
     match:
       severity: page
-      page-project: mlab-{{SHORT_PROJECT}}
+      page_project: mlab-{{SHORT_PROJECT}}
   - receiver: 'slack-alerts-ticket'
 
 # When two alerts are firing at the same time, we can "inhibit" one based on

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -37,6 +37,7 @@ route:
     continue: true
     match:
       severity: page
+      {{FAKE_PROJECT_LABEL}}
   - receiver: 'slack-alerts-ticket'
 
 # When two alerts are firing at the same time, we can "inhibit" one based on

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -37,7 +37,7 @@ route:
     continue: true
     match:
       severity: page
-      {{FAKE_PROJECT_LABEL}}
+      page-project: mlab-{{SHORT_PROJECT}}
   - receiver: 'slack-alerts-ticket'
 
 # When two alerts are firing at the same time, we can "inhibit" one based on

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -30,7 +30,7 @@ groups:
     labels:
       repo: dev-tracker
       severity: page
-      page-project: mlab-oti
+      page_project: mlab-oti
     annotations:
       summary: Instance {{ $labels.instance }} down
       description: '{{ $labels.instance }} of job {{ $labels.job }} has been down
@@ -352,7 +352,7 @@ groups:
     labels:
       repo: ops-tracker
       severity: page
-      page-project: mlab-oti
+      page_project: mlab-oti
     annotations:
       summary: Less than 90% of ndt_ssl experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -431,7 +431,7 @@ groups:
     labels:
       repo: dev-tracker
       severity: page
-      page-project: mlab-oti
+      page_project: mlab-oti
     annotations:
       summary: Service {{ $labels.module }} in the mlab-ns project is unavailable.
       description: Stackdriver reports some requests to the {{ $labels.module }}
@@ -1037,7 +1037,7 @@ groups:
     labels:
       repo: ops-tracker
       severity: page
-      page-project: mlab-oti
+      page_project: mlab-oti
     annotations:
       summary: The NDT DaemonSet is missing or has no metrics.
       description: The NDT DaemonSet is missing or has no metrics. Verify that

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -30,6 +30,7 @@ groups:
     labels:
       repo: dev-tracker
       severity: page
+      page-project: mlab-oti
     annotations:
       summary: Instance {{ $labels.instance }} down
       description: '{{ $labels.instance }} of job {{ $labels.job }} has been down
@@ -351,6 +352,7 @@ groups:
     labels:
       repo: ops-tracker
       severity: page
+      page-project: mlab-oti
     annotations:
       summary: Less than 90% of ndt_ssl experiments are online according to mlab-ns.
       description: Make sure that the kubernetes ndt DaemonSet is healthy. Also
@@ -429,6 +431,7 @@ groups:
     labels:
       repo: dev-tracker
       severity: page
+      page-project: mlab-oti
     annotations:
       summary: Service {{ $labels.module }} in the mlab-ns project is unavailable.
       description: Stackdriver reports some requests to the {{ $labels.module }}
@@ -1034,6 +1037,7 @@ groups:
     labels:
       repo: ops-tracker
       severity: page
+      page-project: mlab-oti
     annotations:
       summary: The NDT DaemonSet is missing or has no metrics.
       description: The NDT DaemonSet is missing or has no metrics. Verify that


### PR DESCRIPTION
This is achieved by modifying the AlertManager config for the PagerDuty receiver to insert a 'match' selector for a non-existent label, which should effectively prevent the receive from ever matching, hence it should be skipped.

This is intended to resolve #642.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/643)
<!-- Reviewable:end -->
