### PR TITLE
Change downloader alert wait threshold

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -66,7 +66,7 @@ groups:
 # at least 21 hours, meaning that at least the last two download attempts have failed.
   - alert: DownloaderIsFailingToUpdate
     expr: time() - downloader_last_success_time_seconds > (21 * 60 * 60)
-    for: 5m
+    for: 1h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
After downloader restarts and before a successful download, the LastSuccessTime metric is initialized to zero and the alert using that metric can fire when it does not need to.

A pod restart can occur as a result of normal k8s node restarts and pod migration between nodes.

1h should allow enough time for the download to attempt and succeed after a restart.

Fixes https://github.com/m-lab/dev-tracker/issues/571

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/654)
<!-- Reviewable:end -->
