### PR TITLE
Add script-exporter to federation cluster with access-token e2e monitoring

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -180,6 +180,11 @@ if [[ "${PROJECT}" != "mlab-oti" ]] ; then
   kubectl create secret generic script-exporter-secret \
     "--from-file=/tmp/monitoring-signer-key.json" \
     --dry-run -o json | kubectl apply -f -
+
+else
+  # NOTE: disable for mlab-oti until we're deploying there also.
+  mv k8s/prometheus-federation/deployments/script-exporter.yml \
+     k8s/prometheus-federation/deployments/script-exporter.yml.disabled
 fi
 
 

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -175,7 +175,8 @@ if [[ "${PROJECT}" != "mlab-oti" ]] ; then
     --from-file=config/federation/script-exporter/script_exporter.yml \
     --dry-run -o json | kubectl apply -f -
 
-  ( set +x; echo "${MONITORING_SIGNER_KEY}" > /tmp/monitoring-signer-key.json )
+  ( set +x; echo "${MONITORING_SIGNER_KEY}" | base64 -d \
+      > /tmp/monitoring-signer-key.json )
   kubectl create secret generic script-exporter-secret \
     "--from-file=/tmp/monitoring-signer-key.json" \
     --dry-run -o json | kubectl apply -f -

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -167,6 +167,20 @@ kubectl create configmap grafana-env \
     "--from-literal=gf_auth_google_client_id=${!GF_CLIENT_ID_NAME}" \
     --dry-run -o json | kubectl apply -f -
 
+# Script exporter.
+# TODO: enable deployment to production once locate is in production.
+# Until then, temporarily disable deployment in production.
+if [[ "${PROJECT}" != "mlab-oti" ]] ; then
+  kubectl create configmap script-exporter-config \
+    --from-file=config/federation/script-exporter/script_exporter.yml \
+    --dry-run -o json | kubectl apply -f -
+
+  ( set +x; echo "${MONITORING_SIGNER_KEY}" > /tmp/monitoring-signer-key.json )
+  kubectl create secret generic script-exporter-secret \
+    "--from-file=/tmp/monitoring-signer-key.json" \
+    --dry-run -o json | kubectl apply -f -
+fi
+
 
 ## Alertmanager
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -725,6 +725,46 @@ scrape_configs:
         replacement: script-exporter.c.{{PROJECT}}.internal:9172
 
 
+  # script-exporter configuration for federation cluster. The scrape_timeout is
+  # set very high because the NDT end-to-end test takes around 30 seconds.
+  - job_name: 'script-targets-federation'
+    metrics_path: /probe
+    scrape_timeout: 50s
+
+    file_sd_configs:
+      - files:
+          - /script-targets-federation/*.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+
+    # This relabel config is necessary. The relabel config redefines the address
+    # to scrape and sets the correct parameters to pass to the exporter target.
+    relabel_configs:
+      # The value of the source label named "service" must match the name of a
+      # configured script in the script_exporter configuration. See this file:
+      # https://github.com/m-lab/prometheus-support/blob/master/config/federation/script-exporter/script_exporter.yml
+      - source_labels: [service]
+        regex: (.*)
+        target_label: __param_name
+        replacement: ${1}
+
+      # The default __address__ value is a target host from the config file.
+      # Here, we set (i.e. "replace") a request parameter "target" equal to the
+      # host value.
+      - source_labels: [__address__]
+        regex: (.*)
+        target_label: __param_target
+        replacement: ${1}
+
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the script_exporter
+      # address.
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: script-exporter.default.svc.cluster.local:9172
+
+
   # Scrape config for pushgateway.
   #
   # Push gateways allow services to publish metrics for later collection by

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -3,7 +3,7 @@ scripts:
     # NOTE: monitoring-token requires these variables in the environment.
     # MONITORING_SIGNER_KEY=<path to signing key>
     # LOCATE_URL=<locate service url>
-    script: cache_exit_code.sh 600 monitoring-token
-      -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 --
-        ndt5-client -exit-on-error=1 -exit-on-warning=1 -throttle=131072 -protocol=ndt5+wss
+    script: cache_exit_code.sh 600
+      monitoring-token -machine=${TARGET} -service=ndt/ndt5 --
+      ndt5-client -exit-on-error=1 -exit-on-warning=1 -throttle=131072 -protocol=ndt5+wss
     timeout: 50

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -5,5 +5,5 @@ scripts:
     # LOCATE_URL=<locate service url>
     script: cache_exit_code.sh 600
       monitoring-token -machine=${TARGET} -service=ndt/ndt5 --
-      ndt5-client -exit-on-error=1 -exit-on-warning=1 -throttle=131072 -protocol=ndt5+wss
+      ndt5-client -exit-on-error=1 -exit-on-warning=1 -throttle=196608 -protocol=ndt5+wss
     timeout: 50

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -3,5 +3,5 @@ scripts:
     # NOTE: monitoring-token requires these variables in the environment.
     # MONITORING_SIGNER_KEY=<path to signing key>
     # LOCATE_URL=<locate service url>
-    script: monitoring-token -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 -- ndt5-client -throttle=131072 -protocol=ndt5+wss
+    script: cache_exit_code.sh 600 monitoring-token -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 -- ndt5-client -throttle=131072 -protocol=ndt5+wss
     timeout: 50

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -1,0 +1,7 @@
+scripts:
+  - name: 'ndt5_client'
+    # NOTE: monitoring-token requires these variables in the environment.
+    # MONITORING_SIGNER_KEY=<path to signing key>
+    # LOCATE_URL=<locate service url>
+    script: monitoring-token -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 -- ndt5-client -throttle=131072 -protocol=ndt5+wss
+    timeout: 50

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -3,5 +3,7 @@ scripts:
     # NOTE: monitoring-token requires these variables in the environment.
     # MONITORING_SIGNER_KEY=<path to signing key>
     # LOCATE_URL=<locate service url>
-    script: cache_exit_code.sh 600 monitoring-token -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 -- ndt5-client -throttle=131072 -protocol=ndt5+wss
+    script: cache_exit_code.sh 600 monitoring-token
+      -logx.debug=true -machine=${TARGET} -service=ndt/ndt5 --
+        ndt5-client -exit-on-error=1 -exit-on-warning=1 -throttle=131072 -protocol=ndt5+wss
     timeout: 50

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -123,6 +123,14 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --select "ndt.iupui" > \
           ${output}/script-targets/ndt_e2e.json
 
+  # script-exporter for e2e monitoring with access tokens.
+  ./mlabconfig.py --format=prom-targets-nodes \
+      --sites="${sites}" \
+      --template_target={{hostname}} \
+      --label service=ndt5_client \
+      --project "${project}" > \
+          ${output}/script-targets/ndt5_client.json
+
   # neubot on port 80 over IPv4
   ./mlabconfig.py --format=prom-targets \
       --sites "${sites}" \

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -99,6 +99,9 @@ spec:
         - mountPath: /script-targets
           name: prometheus-storage
           subPath: script-targets
+        - mountPath: /script-targets-federation
+          name: prometheus-storage
+          subPath: script-targets-federation
         # /slow-targets should contain slow target config files.
         - mountPath: /slow-targets
           name: prometheus-storage

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -174,6 +174,10 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/snmp-targets/snmpexporter.json",
                 "--http-target=/targets/script-targets/ndt_e2e.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/script-targets/ndt_e2e.json",
+                # NOTE: the output directory is different to use different target service.
+                # TODO: once the federation scriptx replaces the gce VM, remove ndt_e2e and rename directory.
+                "--http-target=/targets/script-targets-federation/ndt5_client.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/script-targets/ndt5_client.json",
                 "--http-target=/targets/blackbox-targets/ndt_raw.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/ndt_raw.json",
                 "--http-target=/targets/blackbox-targets-ipv6/ndt_raw_ipv6.json",

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -55,10 +55,10 @@ spec:
       # do not require a static IP aren't scheduled to that node. This
       # deployment, however, will tolerate that taint.
       tolerations:
+      # TODO: something about this prevents the pods from updating.
       - key: "outbound-ip"
         value: "static"
-        effect: "NoExecute"
-        tolerationSeconds: 60
+        effect: "NoSchedule"
       volumes:
       - name: script-exporter-config
         configMap:

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -62,4 +62,4 @@ spec:
           name: script-exporter-config
       - name: script-exporter-keys
         secret:
-          secretName: script-exporter-secrets
+          secretName: script-exporter-secret

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -58,6 +58,7 @@ spec:
       - key: "outbound-ip"
         value: "static"
         effect: "NoSchedule"
+        tolerationSeconds: 60s
       volumes:
       - name: script-exporter-config
         configMap:

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -58,7 +58,7 @@ spec:
       - key: "outbound-ip"
         value: "static"
         effect: "NoSchedule"
-        tolerationSeconds: 60s
+        tolerationSeconds: 60
       volumes:
       - name: script-exporter-config
         configMap:

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -57,7 +57,7 @@ spec:
       tolerations:
       - key: "outbound-ip"
         value: "static"
-        effect: "NoSchedule"
+        effect: "NoExecute"
         tolerationSeconds: 60
       volumes:
       - name: script-exporter-config

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -28,7 +28,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: soltesz/script-exporter-support:v0.0.3
+        image: measurementlab/script-exporter-support:v0.0.5
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -28,7 +28,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: soltesz/script-exporter-support:v0.0.1
+        image: soltesz/script-exporter-support:v0.0.2
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: script-exporter
+spec:
+  # Run two so that we can make sure we have failover.
+  replicas: 2
+  selector:
+    matchLabels:
+      run: script-exporter
+  template:
+    metadata:
+      labels:
+        run: script-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: run
+                operator: In
+                values:
+                - script-exporter
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: script-exporter
+        image: soltesz/script-exporter-support:v0.0.1
+        args:
+        - -config.file=/etc/script_exporter/script_exporter.yml
+        env:
+        - name: MONITORING_SIGNER_KEY
+          valueFrom:
+            secretKeyRef:
+              name: script-exporter-secrets
+              key: monitoring-signer-key.json
+        - name: LOCATE_URL
+          value: https://locate-dot-{{GCLOUD_PROJECT}}.appspot.com/v2/monitoring/
+        ports:
+        - containerPort: 9172
+        volumeMounts:
+        - mountPath: /etc/script_exporter
+          name: script-exporter-config
+
+      # The script-exporter will only be scheduled onto nodes that we labeled
+      # as having a static outbound IP.
+      nodeSelector:
+        outbound-ip: static
+
+      # We can also taint nodes with static outbound IPs so that services that
+      # do not require a static IP aren't scheduled to that node. This
+      # deployment, however, will tolerate that taint.
+      tolerations:
+      - key: "outbound-ip"
+        value: "static"
+        effect: "NoSchedule"
+      volumes:
+      - name: script-exporter-config
+        configMap:
+          name: script-exporter-config

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -28,10 +28,12 @@ spec:
 
       containers:
       - name: script-exporter
-        image: soltesz/script-exporter-support:v0.0.2
+        image: soltesz/script-exporter-support:v0.0.3
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:
+        - name: LOGX_DEBUG
+          value: 'true'
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -33,10 +33,7 @@ spec:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:
         - name: MONITORING_SIGNER_KEY
-          valueFrom:
-            secretKeyRef:
-              name: script-exporter-secrets
-              key: monitoring-signer-key.json
+          value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL
           value: https://locate-dot-{{GCLOUD_PROJECT}}.appspot.com/v2/monitoring/
         ports:
@@ -44,6 +41,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/script_exporter
           name: script-exporter-config
+        - mountPath: /keys
+          name: script-exporter-keys
 
       # The script-exporter will only be scheduled onto nodes that we labeled
       # as having a static outbound IP.
@@ -61,3 +60,6 @@ spec:
       - name: script-exporter-config
         configMap:
           name: script-exporter-config
+      - name: script-exporter-keys
+        secret:
+          secretName: script-exporter-secrets

--- a/k8s/prometheus-federation/services/script-exporter.yml
+++ b/k8s/prometheus-federation/services/script-exporter.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  name: script-exporter
+  namespace: default
+spec:
+  ports:
+  - port: 9172
+    protocol: TCP
+    targetPort: 9172
+  selector:
+    run: script-exporter
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
This PR adds several changes to the prometheus federation cluster to support access-token enabled e2e monitoring using the locate service.

This change adds a new script exporter deployment with configuration to target ndt5 servers using the ndt5-client. When ndt5-client runs it is invoked by the monitoring-token command, which uses the LOCATE_URL and MONITOR_SIGNING_KEY from the environment to request a valid monitoring token from the locate service in the current project. (projects mlab-oti/mlab-ns are not yet supported).

We are adding a second script exporter. Normally target files are read from a directory `/script-targets/*.json`. Because the config also targets a static script exporter, this PR adds a second directory `/script-targets-federation/*.json` and script exporter target within the federation cluster.

The script exporter is assigned to the static "outbound-ip" node pool so that the set of source IPs for the e2e tests remains small and static.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/658)
<!-- Reviewable:end -->
