### PR TITLE
Add switch-monitoring-service.yml

### DIFF
--- a/k8s/prometheus-federation/services/switch-monitoring-service.yml
+++ b/k8s/prometheus-federation/services/switch-monitoring-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'false'
+  name: switch-monitoring-service
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    # Pods with labels matching this key/value pair will be accessible
+    # through the service IP and port.
+    run: switch-monitoring
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Creates the switch-monitoring service so that switch-monitoring can be reached via the cluster DNS on the cluster IP.

This change is propaedeutic (!) to monitoring switch-monitoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/661)
<!-- Reviewable:end -->
