### PR TITLE
Add switch-monitoring scraping and alerts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1451,3 +1451,52 @@ groups:
         The E2E test is failing because the Reboot API could't connect to this
         BMC. Please check that the BMC is enabled on this machine and the
         credentials in Datastore are correct.
+
+# switch-monitoring alerts.
+# The switch-monitoring tool checks that the switch configurations match
+# what is currently stored in a GCS bucket and warns us if that's not the case.
+- alert: SwitchMonitoring_ConfigMismatch
+  expr: |
+    switch_monitoring_config_match{status="config_mismatch"} == 1
+  for: 2m
+  labels:
+    repo: ops-tracker
+    severity: ticket
+  annotations:
+    summary: The configuration for {{ $labels.target }} does not match.
+    description: >
+      The configuration on this switch does not match the version that's
+      currently stored in the switch-config GCS bucket. Please inspect
+      switch-monitoring's logs for a full diff and re-apply the standard
+      configuration by using genconfig.py and ansible.
+
+
+- alert: SwitchMonitoring_ConfigNotFoundGCS
+  expr: |
+    switch_monitoring_config_match{status="config_not_found_gcs"} == 1
+  for: 2m
+  labels:
+    repo: ops-tracker
+    severity: ticket
+  annotations:
+    summary: The config file for {{ $labels.target }} does not exist on GCS.
+    description: >
+      There is no configuration file for this switch on GCS. It should be
+      generated when deploying the switch-config repository, provided that
+      this site existed on siteinfo at deployment time. Please check that the
+      site has been added to siteinfo and trigger a switch-config deployment.
+
+- alert: SwitchMonitoring_ConnectionFailed
+  expr: |
+    switch_monitoring_config_match{status="config_not_found_switch"} == 1
+  for: 2m
+  labels:
+    repo: ops-tracker
+    severity: ticket
+  annotations:
+    summary: Could not retrieve the configuration for {{ $labels.target }}.
+    description: >
+      Connection to this switch failed, or the configuration could not be
+      retrieved due to permission issues. Please check that the switch is
+      currently reachable and the switch-monitoring user exists and has the
+      right privileges.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1455,6 +1455,18 @@ groups:
 # switch-monitoring alerts.
 # The switch-monitoring tool checks that the switch configurations match
 # what is currently stored in a GCS bucket and warns us if that's not the case.
+  - alert: SwitchMonitoring_DownOrMissing
+    expr: up{job="switch-monitoring"} == 0 or absent(up{job="switch-monitoring"})
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The switch-monitoring service is down or missing.
+      description: Check the status of the switch-monitoring deployment on GKE.
+        Make sure the switch-monitoring service is reachable and /v1/check is
+        returning 200.
+
   - alert: SwitchMonitoring_ConfigMismatch
     expr: |
       switch_monitoring_config_match{status="config_mismatch"} == 1
@@ -1469,8 +1481,7 @@ groups:
         The configuration on this switch does not match the version that's
         currently stored in the switch-config GCS bucket. Please inspect
         switch-monitoring's logs for a full diff and re-apply the standard
-        configuration by using genconfig.py and ansible.
-
+        configuration by using genconfig.py and ansible
 
   - alert: SwitchMonitoring_ConfigNotFoundGCS
     expr: |

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1458,6 +1458,7 @@ groups:
   - alert: SwitchMonitoring_ConfigMismatch
     expr: |
       switch_monitoring_config_match{status="config_mismatch"} == 1
+      unless on(site) gmx_site_maintenance == 1
     for: 2m
     labels:
       repo: ops-tracker
@@ -1474,6 +1475,7 @@ groups:
   - alert: SwitchMonitoring_ConfigNotFoundGCS
     expr: |
       switch_monitoring_config_match{status="config_not_found_gcs"} == 1
+      unless on(site) gmx_site_maintenance == 1
     for: 2m
     labels:
       repo: ops-tracker
@@ -1489,6 +1491,7 @@ groups:
   - alert: SwitchMonitoring_ConfigNotFoundSwitch
     expr: |
       switch_monitoring_config_match{status="config_not_found_switch"} == 1
+      unless on(site) gmx_site_maintenance == 1
     for: 2m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1455,48 +1455,48 @@ groups:
 # switch-monitoring alerts.
 # The switch-monitoring tool checks that the switch configurations match
 # what is currently stored in a GCS bucket and warns us if that's not the case.
-- alert: SwitchMonitoring_ConfigMismatch
-  expr: |
-    switch_monitoring_config_match{status="config_mismatch"} == 1
-  for: 2m
-  labels:
-    repo: ops-tracker
-    severity: ticket
-  annotations:
-    summary: The configuration for {{ $labels.target }} does not match.
-    description: >
-      The configuration on this switch does not match the version that's
-      currently stored in the switch-config GCS bucket. Please inspect
-      switch-monitoring's logs for a full diff and re-apply the standard
-      configuration by using genconfig.py and ansible.
+  - alert: SwitchMonitoring_ConfigMismatch
+    expr: |
+      switch_monitoring_config_match{status="config_mismatch"} == 1
+    for: 2m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The configuration for {{ $labels.target }} does not match.
+      description: >
+        The configuration on this switch does not match the version that's
+        currently stored in the switch-config GCS bucket. Please inspect
+        switch-monitoring's logs for a full diff and re-apply the standard
+        configuration by using genconfig.py and ansible.
 
 
-- alert: SwitchMonitoring_ConfigNotFoundGCS
-  expr: |
-    switch_monitoring_config_match{status="config_not_found_gcs"} == 1
-  for: 2m
-  labels:
-    repo: ops-tracker
-    severity: ticket
-  annotations:
-    summary: The config file for {{ $labels.target }} does not exist on GCS.
-    description: >
-      There is no configuration file for this switch on GCS. It should be
-      generated when deploying the switch-config repository, provided that
-      this site existed on siteinfo at deployment time. Please check that the
-      site has been added to siteinfo and trigger a switch-config deployment.
+  - alert: SwitchMonitoring_ConfigNotFoundGCS
+    expr: |
+      switch_monitoring_config_match{status="config_not_found_gcs"} == 1
+    for: 2m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The config file for {{ $labels.target }} does not exist on GCS.
+      description: >
+        There is no configuration file for this switch on GCS. It should be
+        generated when deploying the switch-config repository, provided that
+        this site existed on siteinfo at deployment time. Please check that the
+        site has been added to siteinfo and trigger a switch-config deployment.
 
-- alert: SwitchMonitoring_ConfigNotFoundSwitch
-  expr: |
-    switch_monitoring_config_match{status="config_not_found_switch"} == 1
-  for: 2m
-  labels:
-    repo: ops-tracker
-    severity: ticket
-  annotations:
-    summary: Could not retrieve the configuration for {{ $labels.target }}.
-    description: >
-      Connection to this switch failed, or the configuration could not be
-      retrieved due to permission issues. Please check that the switch is
-      currently reachable and the switch-monitoring user exists and has the
-      right privileges.
+  - alert: SwitchMonitoring_ConfigNotFoundSwitch
+    expr: |
+      switch_monitoring_config_match{status="config_not_found_switch"} == 1
+    for: 2m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Could not retrieve the configuration for {{ $labels.target }}.
+      description: >
+        Connection to this switch failed, or the configuration could not be
+        retrieved due to permission issues. Please check that the switch is
+        currently reachable and the switch-monitoring user exists and has the
+        right privileges.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1486,7 +1486,7 @@ groups:
       this site existed on siteinfo at deployment time. Please check that the
       site has been added to siteinfo and trigger a switch-config deployment.
 
-- alert: SwitchMonitoring_ConnectionFailed
+- alert: SwitchMonitoring_ConfigNotFoundSwitch
   expr: |
     switch_monitoring_config_match{status="config_not_found_switch"} == 1
   for: 2m

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -875,6 +875,7 @@ scrape_configs:
   # Scrape switch-monitoring targets every minute.
   - job_name: 'switch-monitoring-targets'
     scrape_timeout: 40s
+    metrics_path: "/v1/check"
     file_sd_configs:
       - files:
           - /switch-monitoring-targets/*.json
@@ -901,8 +902,6 @@ scrape_configs:
         regex: .*
         target_label: __address__
         replacement: switch-monitoring-service.default.svc.cluster.local:8080
-
-      - metrics_path: "/v1/check"
 
   # Scrape config for legacy targets.
   #

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -872,6 +872,49 @@ scrape_configs:
         target_label: site
         replacement: $1
 
+  # Scrape switch-monitoring targets every minute.
+  - job_name: 'switch-monitoring-targets'
+    scrape_timeout: 40s
+    file_sd_configs:
+      - files:
+          - /snmp-targets/*.json
+        # Attempt to re-read files every five minutes.
+        refresh_interval: 5m
+    scheme: http
+
+    # This relabel config is necessary. The relabel config redefines the address
+    # to scrape and sets the correct parameters to pass to the scrape target.
+    relabel_configs:
+
+      # The default __address__ value is a target host from the config file.
+      # Here, we set (i.e. "replace") a request parameter "target" equal to the
+      # host value.
+      - source_labels: [__address__]
+        regex: (.*)
+        target_label: __param_target
+        replacement: ${1}
+
+      # Since __address__ is the target that prometheus will contact,
+      # unconditionally reset the __address__ label to the script_exporter
+      # address.
+      - source_labels: []
+        regex: .*
+        target_label: __address__
+        replacement: switch-monitoring-service.default.svc.cluster.local:8080
+
+      - source_labels: []
+        regex: .*
+        target_label: __metrics_path__
+        replacement: /v1/check
+
+    # This metric relabel config adds the "site" label on
+    # switch-monitoring-targets.
+    metric_relabel_configs:
+      - source_labels: [target]
+        regex: s1\.([a-z]{3}[0-9tc]{2}).+
+        target_label: site
+        replacement: $1
+
   # Scrape config for legacy targets.
   #
   # Using an out-of-band process, generated configs can be copied into the

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -877,7 +877,7 @@ scrape_configs:
     scrape_timeout: 40s
     file_sd_configs:
       - files:
-          - /snmp-targets/*.json
+          - /switch-monitoring-targets/*.json
         # Attempt to re-read files every five minutes.
         refresh_interval: 5m
     scheme: http

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -902,18 +902,7 @@ scrape_configs:
         target_label: __address__
         replacement: switch-monitoring-service.default.svc.cluster.local:8080
 
-      - source_labels: []
-        regex: .*
-        target_label: __metrics_path__
-        replacement: /v1/check
-
-    # This metric relabel config adds the "site" label on
-    # switch-monitoring-targets.
-    metric_relabel_configs:
-      - source_labels: [target]
-        regex: s1\.([a-z]{3}[0-9tc]{2}).+
-        target_label: site
-        replacement: $1
+      - metrics_path: "/v1/check"
 
   # Scrape config for legacy targets.
   #

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -7,7 +7,7 @@ BASEDIR=${PWD}
 
 # Create all output directories.
 for project in mlab-sandbox mlab-staging mlab-oti ; do
-  mkdir -p ${BASEDIR}/gen/${project}/prometheus/{legacy-targets,blackbox-targets,blackbox-targets-ipv6,snmp-targets,script-targets,bmc-targets}
+  mkdir -p ${BASEDIR}/gen/${project}/prometheus/{legacy-targets,blackbox-targets,blackbox-targets-ipv6,snmp-targets,script-targets,bmc-targets,switch-monitoring-targets}
 done
 
 # GCP doesn't support IPv6, so we have a Linode VM running three instances of

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -222,4 +222,12 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --project "${project}" \
       --decoration "d" > ${output}/bmc-targets/bmc_e2e.json
 
+  # switch configuration monitoring via switch-monitoring.
+  ./mlabconfig.py --format=prom-targets-sites \
+      --sites "${sites}" \
+      --physical \
+      --template_target=s1.{{sitename}}.measurement-lab.org \
+      --label service=switch-monitoring > \
+          ${output}/switch-monitoring-targets/switch-monitoring.json
+
 done

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -110,6 +110,9 @@ spec:
         - mountPath: /bmc-targets
           name: prometheus-storage
           subPath: bmc-targets
+        - mountPath: /switch-monitoring-targets
+          name: prometheus-storage
+          subPath: switch-monitoring-targets
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -205,6 +208,8 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/switches_ping.json",
                 "--http-target=/targets/bmc-targets/bmc_e2e.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/bmc-targets/bmc_e2e.json",
+                "--http-target=/targets/switch-monitoring-targets/switch-monitoring.json",
+                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/switch-monitoring-targets/switch-monitoring.json",
                 "--project={{GCLOUD_PROJECT}}"]
         ports:
           - containerPort: 9373


### PR DESCRIPTION
This PR adds scraping and alerting for switch-monitoring.

In particular, it adds a new switch-monitoring-targets list of targets and a corresponding scraping job targeted at switch-monitoring's internal IP address.

The targets are scraped every minute, but switch-monitoring will return a result cached for 24 hours.

The alerts are for the following conditions:
- Configuration file not found on GCS
- Configuration file not found on the switch (connection failed or wrong permissions)
- The config on the switch and the one in GCS are not the same

They all ignore sites in GMX.

Closes https://github.com/m-lab/prometheus-support/issues/652.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/663)
<!-- Reviewable:end -->
