### PR TITLE
Fix job name in SwitchMonitoring_DownOrMissing alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1469,7 +1469,7 @@ groups:
 # The switch-monitoring tool checks that the switch configurations match
 # what is currently stored in a GCS bucket and warns us if that's not the case.
   - alert: SwitchMonitoring_DownOrMissing
-    expr: up{job="switch-monitoring"} == 0 or absent(up{job="switch-monitoring"})
+    expr: up{job="switch-monitoring-targets"} == 0 or absent(up{job="switch-monitoring-targets"})
     for: 10m
     labels:
       repo: ops-tracker


### PR DESCRIPTION
The name was previously incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/666)
<!-- Reviewable:end -->
