### PR TITLE
Makes regexp used to populate the machine label be v2-name-compatible.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -373,7 +373,7 @@ scrape_configs:
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
       - source_labels: [node]
-        regex: (mlab[1-4]\.[a-z]{3}[0-9tc]{2}\.measurement-lab\.org)
+        regex: (mlab[1-4][.-][a-z]{3}[0-9tc]{2}.*)
         action: replace
         target_label: machine
 


### PR DESCRIPTION
NOTE: I don't think there is a need to match on the entire FQDN. If the `node` label begins with a short node name, then we can safely assume the value is what we want in the `machine` label too.

Fixes #665.
Fixes #667.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/668)
<!-- Reviewable:end -->
