### PR TITLE
v2 Prom targets for mlab-oti + force node and machine labels to v2 node names.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -361,6 +361,13 @@ scrape_configs:
         target_label: experiment
         replacement: ndt.iupui
 
+      # If the node label is a v1 M-Lab node name, force it to a v2 name.
+      - source_labels: [node]
+        regex: (mlab[1-4])\.([a-z]{3}[0-9tc]{2}).measurement-lab.org
+        action: replace
+        replacement: ${1}-${2}.{{PROJECT}}.measurement-lab.org
+        target_label: node
+
       # Rewrite the machine label to make it easier to join these metrics with
       # existing metrics that use machine instead of the node label.
       #
@@ -372,9 +379,12 @@ scrape_configs:
       # "machine" and "node" labels to always be the same, to the extent
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
+      #
+      # Additionally, force the label to a v2 name.
       - source_labels: [node]
-        regex: (mlab[1-4][.-][a-z]{3}[0-9tc]{2}.*)
+        regex: (mlab[1-4])[.-]([a-z]{3}[0-9tc]{2}).*
         action: replace
+        replacement: ${1}-${2}.{{PROJECT}}.measurement-lab.org
         target_label: machine
 
   # Scrape config for the node_exporter on eb.measurementlab.net.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -379,12 +379,9 @@ scrape_configs:
       # "machine" and "node" labels to always be the same, to the extent
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
-      #
-      # Additionally, force the label to a v2 name.
       - source_labels: [node]
         regex: (mlab[1-4])[.-]([a-z]{3}[0-9tc]{2}).*
         action: replace
-        replacement: ${1}-${2}.{{PROJECT}}.measurement-lab.org
         target_label: machine
 
   # Scrape config for the node_exporter on eb.measurementlab.net.

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -26,18 +26,7 @@ chmod +x ./mlabconfig.py
 
 
 for project in mlab-sandbox mlab-staging mlab-oti ; do
-  # Production uses v1 sites.json, everything else v2. And if an mlabconfig.py
-  # command previously used the flag --use_flatnames, then only keep that in
-  # place in production, since in v2 siteinfo output all names are flat by
-  # default.
-
-  if [[ "${project}" != "mlab-oti" ]]; then
-    sites="https://siteinfo.${project}.measurementlab.net/v2/sites/sites.json"
-    use_flatnames=""
-  else
-    sites="https://siteinfo.${project}.measurementlab.net/v1/sites/sites.json"
-    use_flatnames="--use_flatnames"
-  fi
+  sites="https://siteinfo.${project}.measurementlab.net/v2/sites/sites.json"
 
   output=${BASEDIR}/gen/${project}/prometheus
 
@@ -95,7 +84,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:3010 \
       --label service=ndt_ssl \
       --label module=tcp_v4_tls_online \
-      "${use_flatnames}" \
       --project "${project}" \
       --select "ndt.iupui" > \
           ${output}/blackbox-targets/ndt_ssl.json
@@ -107,7 +95,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=ndt_ssl_ipv6 \
       --label module=tcp_v6_tls_online \
       --label __blackbox_port=${!bbe_port} \
-      "${use_flatnames}" \
       --project "${project}" \
       --select "ndt.iupui" \
       --decoration "v6" > \
@@ -118,7 +105,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --sites "${sites}" \
       --template_target={{hostname}} \
       --label service=ndt_e2e \
-      "${use_flatnames}" \
       --project "${project}" \
       --select "ndt.iupui" > \
           ${output}/script-targets/ndt_e2e.json
@@ -159,7 +145,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:443 \
       --label service=neubot_tls \
       --label module=tcp_v4_tls_online \
-      "${use_flatnames}" \
       --project "${project}" \
       --select "neubot.mlab" > \
           ${output}/blackbox-targets/neubot_tls.json
@@ -171,7 +156,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=neubot_tls_ipv6 \
       --label module=tcp_v6_tls_online \
       --label __blackbox_port=${!bbe_port} \
-      "${use_flatnames}" \
       --decoration "v6" \
       --project "${project}" \
       --select "neubot.mlab" > \


### PR DESCRIPTION
This PR configures the `generate_prometheus_targets.sh` script to use v2 site.json file for all project (including mlab-oti).

Additionally, to help us migrate the platform cluster to v2 node names, this PR introduces a change which should cause all auto-discovered metric node names to wind up with v2 node names in Prometheus, even when the underlying node still knows itself by a v1 name.

This change would need to be applied in conjunction with  with updating mlab-ns to use v2 FQDNs.

**NOTE**: This commit should not be sent to production without a coordination the mlab-ns change mentioned above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/671)
<!-- Reviewable:end -->
