### PR TITLE
Adjusts the parentheses in the regex to include whole matching pattern

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -380,7 +380,7 @@ scrape_configs:
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
       - source_labels: [node]
-        regex: (mlab[1-4])[.-]([a-z]{3}[0-9tc]{2}).*
+        regex: (mlab[1-4][.-][a-z]{3}[0-9tc]{2}.*)
         action: replace
         target_label: machine
 


### PR DESCRIPTION
The replacement was using only the first matching group of the regex. This PR puts the parenthesis around the entire regex so that the full node name is put into the machine label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/672)
<!-- Reviewable:end -->
