### PR TITLE
Deploy script-exporter in production

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -168,24 +168,15 @@ kubectl create configmap grafana-env \
     --dry-run -o json | kubectl apply -f -
 
 # Script exporter.
-# TODO: enable deployment to production once locate is in production.
-# Until then, temporarily disable deployment in production.
-if [[ "${PROJECT}" != "mlab-oti" ]] ; then
-  kubectl create configmap script-exporter-config \
-    --from-file=config/federation/script-exporter/script_exporter.yml \
-    --dry-run -o json | kubectl apply -f -
+kubectl create configmap script-exporter-config \
+  --from-file=config/federation/script-exporter/script_exporter.yml \
+  --dry-run -o json | kubectl apply -f -
 
-  ( set +x; echo "${MONITORING_SIGNER_KEY}" | base64 -d \
-      > /tmp/monitoring-signer-key.json )
-  kubectl create secret generic script-exporter-secret \
-    "--from-file=/tmp/monitoring-signer-key.json" \
-    --dry-run -o json | kubectl apply -f -
-
-else
-  # NOTE: disable for mlab-oti until we're deploying there also.
-  mv k8s/prometheus-federation/deployments/script-exporter.yml \
-     k8s/prometheus-federation/deployments/script-exporter.yml.disabled
-fi
+( set +x; echo "${MONITORING_SIGNER_KEY}" | base64 -d \
+    > /tmp/monitoring-signer-key.json )
+kubectl create secret generic script-exporter-secret \
+  "--from-file=/tmp/monitoring-signer-key.json" \
+  --dry-run -o json | kubectl apply -f -
 
 
 ## Alertmanager


### PR DESCRIPTION
This change enables deployment of the ndt5_client script exporter configuration in production.

Now that the locate/v2 api is running in production as a result of https://github.com/m-lab/dev-tracker/issues/587 and k8s-support includes a new version of the ndt-server which increases the success rate of the e2e monitoring, this should be safe to deploy now.

Part of https://github.com/m-lab/dev-tracker/issues/574

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/673)
<!-- Reviewable:end -->
