### PR TITLE
Specify LOCATE_PROJECT for correct app engine URL

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -37,7 +37,7 @@ spec:
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL
-          value: https://locate-dot-{{GCLOUD_PROJECT}}.appspot.com/v2/monitoring/
+          value: https://locate-dot-{{LOCATE_PROJECT}}.appspot.com/v2/monitoring/
         ports:
         - containerPort: 9172
         volumeMounts:

--- a/k8s/prometheus-federation/mlab-oti.yml
+++ b/k8s/prometheus-federation/mlab-oti.yml
@@ -1,6 +1,7 @@
 # Configuration values for mlab-oti
 
 GCLOUD_PROJECT: mlab-oti
+LOCATE_PROJECT: mlab-ns
 PROMETHEUS_RAM: 42Gi
 PROMETHEUS_CPU: 10000m
 PROMETHEUS_VOLUME_SIZE: 400Gi

--- a/k8s/prometheus-federation/mlab-sandbox.yml
+++ b/k8s/prometheus-federation/mlab-sandbox.yml
@@ -1,6 +1,7 @@
 # Configuration values for mlab-sandbox.
 
 GCLOUD_PROJECT: mlab-sandbox
+LOCATE_PROJECT: mlab-sandbox
 PROMETHEUS_RAM: 42Gi
 PROMETHEUS_CPU: 10000m
 PROMETHEUS_VOLUME_SIZE: 200Gi

--- a/k8s/prometheus-federation/mlab-staging.yml
+++ b/k8s/prometheus-federation/mlab-staging.yml
@@ -1,6 +1,7 @@
 # Configuration values for mlab-staging
 
 GCLOUD_PROJECT: mlab-staging
+LOCATE_PROJECT: mlab-staging
 PROMETHEUS_RAM: 42Gi
 PROMETHEUS_CPU: 10000m
 PROMETHEUS_VOLUME_SIZE: 400Gi


### PR DESCRIPTION
The locate service is deployed to App Engine in the mlab-ns project. This change adds a new template variable for the LOCATE_PROJECT to distinguish it from the GCLOUD_PROJECT in which the GKE cluster runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/676)
<!-- Reviewable:end -->
