### PR TITLE
Update label_replace regex to extract site from v2 machine names

### DIFF
--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1589814529729,
+  "iteration": 1589817861176,
   "links": [],
   "panels": [
     {
@@ -439,7 +439,7 @@
       ],
       "targets": [
         {
-          "expr": "label_replace(gmx_machine_maintenance == 1, \"site\", \"$1\", \"machine\", \"^mlab[1-4]-(.+?)\\\\..+\") unless on(site) gmx_site_maintenance == 1",
+          "expr": "label_replace(gmx_machine_maintenance == 1, \"site\", \"$1\", \"machine\", \"mlab[1-4]-([a-z]{3}[0-9ct]{2}).+\") unless on(site) gmx_site_maintenance == 1",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -662,5 +662,5 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 30
+  "version": 31
 }

--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1583768763383,
+  "iteration": 1589814529729,
   "links": [],
   "panels": [
     {
@@ -439,7 +439,7 @@
       ],
       "targets": [
         {
-          "expr": "label_replace(gmx_machine_maintenance == 1, \"site\", \"$1\", \"machine\", \".+?\\\\.(.+?)\\\\..+\") unless on(site) gmx_site_maintenance == 1",
+          "expr": "label_replace(gmx_machine_maintenance == 1, \"site\", \"$1\", \"machine\", \"^mlab[1-4]-(.+?)\\\\..+\") unless on(site) gmx_site_maintenance == 1",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -662,5 +662,5 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 29
+  "version": 30
 }


### PR DESCRIPTION
This PR updates the `label_replace` that extracts the site name from the machine name so that machines in sites that are in GMX already can be filtered out. 

You'll notice that due to the fact GMX currently exports both v1 and v2 names, the v1 names are still displayed in the table. This will eventually go away when the migration is completed, and at that point this updated regex is all we need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/680)
<!-- Reviewable:end -->
