### PR TITLE
Add experiment label to ndt5_client metrics

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -114,6 +114,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --sites="${sites}" \
       --template_target={{hostname}} \
       --label service=ndt5_client \
+      --label experiment=ndt.iupui \
       --project "${project}" > \
           ${output}/script-targets/ndt5_client.json
 


### PR DESCRIPTION
This change adds the ndt `experiment=ndt.iupui` label needed for the [mlab-ns promql query][prom] to work as intended.

[prom]: https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/util/prometheus_status.py#L33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/682)
<!-- Reviewable:end -->
