### PR TITLE
Update sx to include random mtime change

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -28,7 +28,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: measurementlab/script-exporter-support:v0.0.5
+        image: measurementlab/script-exporter-support:v0.1.0
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:


### PR DESCRIPTION
This change updates the script-exporter image built by the script-exporter-support repo to include recent improvements to the cache mtime randomization to be resilient to accidental sychronization. The result of that change is that the expected frequency of ndt measurements is every 5min rather than 10min.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/684)
<!-- Reviewable:end -->
