### PR TITLE
Removes relabel_config forcing all v1 names to v2 names

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -361,13 +361,6 @@ scrape_configs:
         target_label: experiment
         replacement: ndt.iupui
 
-      # If the node label is a v1 M-Lab node name, force it to a v2 name.
-      - source_labels: [node]
-        regex: (mlab[1-4])\.([a-z]{3}[0-9tc]{2}).measurement-lab.org
-        action: replace
-        replacement: ${1}-${2}.{{PROJECT}}.measurement-lab.org
-        target_label: node
-
       # Rewrite the machine label to make it easier to join these metrics with
       # existing metrics that use machine instead of the node label.
       #
@@ -380,7 +373,7 @@ scrape_configs:
       # possible. Overwriting "machine" here with "node" helps to ensure that
       # _if_ a "node" label exists the "machine" label will always be the same.
       - source_labels: [node]
-        regex: (mlab[1-4][.-][a-z]{3}[0-9tc]{2}.*)
+        regex: (mlab[1-4]-[a-z]{3}[0-9tc]{2}.*)
         action: replace
         target_label: machine
 


### PR DESCRIPTION
v1 names no longer exist on the platform in any project!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/685)
<!-- Reviewable:end -->
