### PR TITLE
Updates the GMX image to v1.3.2.

### DIFF
--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -23,7 +23,7 @@ spec:
         run: gmx-server
     spec:
       containers:
-      - image: measurementlab/github-maintenance-exporter:v1.3.1
+      - image: measurementlab/github-maintenance-exporter:v1.3.2
         name: gmx-server
         args:
         - --storage.state-file=/var/lib/gmx/gmx-state


### PR DESCRIPTION
This deploys the version of GMX with the v1->v2 name logic removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/686)
<!-- Reviewable:end -->
