### PR TITLE
Retire script-exporter VM configurations

### DIFF
--- a/config/federation/grafana/dashboards/Ops_PlatformOverview.json
+++ b/config/federation/grafana/dashboards/Ops_PlatformOverview.json
@@ -141,7 +141,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)\n/\ncount(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n)",
+          "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt5_client\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)\n/\ncount(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n)",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -225,7 +225,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)",
+          "expr": "count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1 AND ON(machine)\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt5_client\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n)",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"
@@ -307,7 +307,7 @@
       "tableColumn": "Value",
       "targets": [
         {
-          "expr": "scalar(count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n  )\n))",
+          "expr": "scalar(count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt5_client\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.95\n  )\n))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -834,7 +834,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "scalar(count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n    UNLESS ON(machine) (\n      probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n      probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n      script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n      vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n    )\n))",
+          "expr": "scalar(count(\n  probe_success{service=\"ndt_ssl\"} AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n    UNLESS ON(machine) (\n      probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n      probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n      script_success{service=\"ndt5_client\"} == 1 AND ON(machine)\n      vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n    )\n))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -843,7 +843,7 @@
           "step": 240
         },
         {
-          "expr": "probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt_e2e\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n  )",
+          "expr": "probe_success{service=\"ndt_ssl\"} AND ON(machine)\n    up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n    lame_duck_node{} == 1\n  UNLESS ON(machine) (\n    probe_success{service=\"ndt_ssl\"} == 1 AND ON(machine)\n    probe_success{service=\"ndt_raw\"} == 1 AND ON(machine)\n    script_success{service=\"ndt5_client\"} == 1 AND ON(machine)\n    vdlimit_used{experiment=\"ndt.iupui\"} / vdlimit_total{experiment=\"ndt.iupui\"} < 0.8\n  )",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -866,10 +866,10 @@
           "refId": "F"
         },
         {
-          "expr": "scalar(count(\n  script_success{service=\"ndt_e2e\"} == 0 AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n))",
+          "expr": "scalar(count(\n  script_success{service=\"ndt5_client\"} == 0 AND ON(machine)\n      up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n      lame_duck_node{} == 1\n))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Down ndt_e2e",
+          "legendFormat": "Down ndt5_client",
           "refId": "G"
         },
         {
@@ -1114,7 +1114,7 @@
           "refId": "B"
         },
         {
-          "expr": "script_success{service=\"ndt_e2e\", machine=~\".*$site.*\"} AND ON(machine)\n  up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n  lame_duck_node{} == 1",
+          "expr": "script_success{service=\"ndt5_client\", machine=~\".*$site.*\"} AND ON(machine)\n  up{service=\"nodeexporter\"} == 1 UNLESS ON(machine)\n  lame_duck_node{} == 1",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -282,7 +282,7 @@ groups:
         sum(
           min by (experiment, machine) (
             probe_success{service="ndt_raw"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -310,7 +310,7 @@ groups:
         sum(
           min by (experiment, machine) (
             probe_success{service="ndt_raw_ipv6"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -338,7 +338,7 @@ groups:
         sum(
           min by (experiment, machine) (
             probe_success{service="ndt_ssl"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -366,7 +366,7 @@ groups:
         sum(
           min by (experiment, machine) (
             probe_success{service="ndt_ssl_ipv6"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -485,7 +485,7 @@ groups:
 # One or more NDT-specific metrics is missing. These are the NDT metrics that
 # mlab-ns relies on to determine whether NDT is up and running, so we need to
 # make sure that the metrics are always present. NOTE: mlab-ns additionally
-# relies on the script_exporter metric 'script_success{service="ndt_e2e"}', but
+# relies on the script_exporter metric 'script_success{service="ndt5_client"}', but
 # alerting for that metric is already handled by the
 # ScriptExporterMissingMetrics alert.
   - alert: MlabNS_NdtMetricsMissing

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -669,59 +669,9 @@ scrape_configs:
         replacement: ${1}
 
 
-  # Scrape config for the script_exporter. There is one script_exporter service
-  # running in a Docker container on a GCE VM in each GCP project.
-  #
-  # The script_exporter generates its own labels.
-  - job_name: 'script-exporter'
-    static_configs:
-      - targets:
-        - script-exporter.c.{{PROJECT}}.internal:9172
-        - script-exporter.c.{{PROJECT}}.internal:9100
-
-
-  # script_exporter configurations. The scrape_timeout is set very high because
-  # the NDT end-to-end test will take around 35 seconds.
-  - job_name: 'script-targets'
-    metrics_path: /probe
-    scrape_timeout: 45s
-
-    file_sd_configs:
-      - files:
-          - /script-targets/*.json
-        # Attempt to re-read files every five minutes.
-        refresh_interval: 5m
-
-    # This relabel config is necessary. The relabel config redefines the address
-    # to scrape and sets the correct parameters to pass to the scrape target.
-    relabel_configs:
-      # The value of the source label named "service" must match the name of a
-      # configured script in the script_exporter configuration. See this file:
-      # https://github.com/m-lab/script-exporter-support/blob/master/script_exporter.yml
-      - source_labels: [service]
-        regex: (.*)
-        target_label: __param_name
-        replacement: ${1}
-
-      # The default __address__ value is a target host from the config file.
-      # Here, we set (i.e. "replace") a request parameter "target" equal to the
-      # host value.
-      - source_labels: [__address__]
-        regex: (.*)
-        target_label: __param_target
-        replacement: ${1}
-
-      # Since __address__ is the target that prometheus will contact,
-      # unconditionally reset the __address__ label to the script_exporter
-      # address.
-      - source_labels: []
-        regex: .*
-        target_label: __address__
-        replacement: script-exporter.c.{{PROJECT}}.internal:9172
-
-
-  # script-exporter configuration for federation cluster. The scrape_timeout is
-  # set very high because the NDT end-to-end test takes around 30 seconds.
+  # Scrape config for the script_exporter for federation cluster. The
+  # scrape_timeout is set very high because the NDT end-to-end test takes
+  # around 30 seconds.
   - job_name: 'script-targets-federation'
     metrics_path: /probe
     scrape_timeout: 50s

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -100,15 +100,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --decoration "v6" > \
           ${output}/blackbox-targets-ipv6/ndt_ssl_ipv6.json
 
-  # script_exporter for NDT end-to-end monitoring
-  ./mlabconfig.py --format=prom-targets \
-      --sites "${sites}" \
-      --template_target={{hostname}} \
-      --label service=ndt_e2e \
-      --project "${project}" \
-      --select "ndt.iupui" > \
-          ${output}/script-targets/ndt_e2e.json
-
   # script-exporter for e2e monitoring with access tokens.
   ./mlabconfig.py --format=prom-targets-nodes \
       --sites="${sites}" \

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -167,7 +167,6 @@ spec:
                 "--http-target=/targets/snmp-targets/snmpexporter.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/snmp-targets/snmpexporter.json",
                 # NOTE: the output directory is different to use different target service.
-                # TODO: once the federation scriptx replaces the gce VM, remove ndt_e2e and rename directory.
                 "--http-target=/targets/script-targets-federation/ndt5_client.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/script-targets/ndt5_client.json",
                 "--http-target=/targets/blackbox-targets/ndt_raw.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -91,10 +91,6 @@ spec:
         - mountPath: /snmp-targets
           name: prometheus-storage
           subPath: snmp-targets
-        # /script-targets should contain script_exporter target config files.
-        - mountPath: /script-targets
-          name: prometheus-storage
-          subPath: script-targets
         - mountPath: /script-targets-federation
           name: prometheus-storage
           subPath: script-targets-federation
@@ -170,8 +166,6 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets-ipv6/ssh_ipv6.json",
                 "--http-target=/targets/snmp-targets/snmpexporter.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/snmp-targets/snmpexporter.json",
-                "--http-target=/targets/script-targets/ndt_e2e.json",
-                "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/script-targets/ndt_e2e.json",
                 # NOTE: the output directory is different to use different target service.
                 # TODO: once the federation scriptx replaces the gce VM, remove ndt_e2e and rename directory.
                 "--http-target=/targets/script-targets-federation/ndt5_client.json",


### PR DESCRIPTION
This change removes the script-exporter VM configurations and targets from the prometheus deployment.

Locations found using `grep ndt_e2e` and `grep script-exporter`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/688)
<!-- Reviewable:end -->
