### PR TITLE
Modifies 'mlab-ns' alerts to try to not factor in nodes at sites that don't exist

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -272,8 +272,13 @@ groups:
 # determine the state of NDT services.
 # https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/util/prometheus_status.py
 #
+# The expression in the denominator of the queries can be read as:
+# count `probe_success`es _unless_ the node is in GMX _and_ the node does not
+# exist in the cluster. We want nodes in GMX in the denominator, but not for
+# sites that don't even exist yet.
+#
 # TODO(kinkade): The rewrite of mlab-ns should export these types of metrics
-# such that we con't have to duplicate the queries here in the alerts.
+# such that we don't have to duplicate the queries here in the alerts.
 
   # "ndt" mlab-ns query
   - alert: TooManyNdtIpv4ServersDown
@@ -290,7 +295,11 @@ groups:
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
           )
-        ) / count(probe_success{service="ndt_raw"})
+        ) /
+        count(
+          probe_success{service="ndt_raw"} unless on(machine)
+            (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)
+        )
       ) < 0.90
     for: 10m
     labels:
@@ -318,7 +327,11 @@ groups:
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
           )
-        ) / count(probe_success{service="ndt_raw_ipv6"})
+        ) /
+        count(
+          probe_success{service="ndt_raw_ipv6"} unless on(machine)
+            (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)
+        )
       ) < 0.75
     for: 10m
     labels:
@@ -346,8 +359,12 @@ groups:
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
           )
-        ) / count(probe_success{service="ndt_ssl"})
-      ) < 0.50
+        ) /
+        count(
+          probe_success{service="ndt_ssl"} unless on(machine)
+            (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)
+        )
+      ) < 0.90
     for: 10m
     labels:
       repo: ops-tracker
@@ -374,7 +391,11 @@ groups:
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
           )
-        ) / count(probe_success{service="ndt_ssl_ipv6"})
+        ) /
+        count(
+          probe_success{service="ndt_ssl_ipv6"} unless on(machine)
+            (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)
+        )
       ) < 0.75
     for: 10m
     labels:


### PR DESCRIPTION
Currently, the so-called "mlab-ns" queries are including sites that don't yet physically exist in the denominator of the expression, causing the result to always be lower than it should be, and to hover not much above the alert threshold. This PR attempts to not include nodes in the denominator if they are in GMX mode _and_ do not exist in the cluster. This is pretty close, but perhaps not 100% precise, since it's possible that we could have a node that physically exists, but is not the cluster and is in GMX mode. As I write this, this is true for mlab2.iad03, [a node that has been down for months](https://github.com/m-lab/ops-tracker/issues/1013). However, I think that situation will be sufficiently rare that it won't be material for the purposes of these alerts, and that the benefits of these modifications outweigh the possible effect of this issue.

This PR also addresses a small but that was in the ndt_ssl query. The comment said 90%, but the query was evaluating against `0.50`. I've raised this number of up `0.90`.

This PR aims to address #689.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/690)
<!-- Reviewable:end -->
