### PR TITLE
Increases alert threshold for SnmpScrapingDownAtSite from 2h to 12h.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -129,7 +129,7 @@ groups:
       up{job="snmp-targets",site!~".*t$"} == 0
         and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
         unless on(site) gmx_site_maintenance == 1
-    for: 2h
+    for: 12h
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
We don't alert for an entire switch being down for 24h, so alerting when SNMP scraping is down for only 2h seems too soon, especially considering that we have identified that SNMP scraping can sometimes (though not often) be flaky  for short intervals and sometimes slightly more extended stretches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/692)
<!-- Reviewable:end -->
