### PR TITLE
Bump switch-monitoring version to v0.1.2

### DIFF
--- a/k8s/prometheus-federation/deployments/switch-monitoring.yml
+++ b/k8s/prometheus-federation/deployments/switch-monitoring.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: switch-monitoring
-        image: measurementlab/switch-monitoring:v0.1.1
+        image: measurementlab/switch-monitoring:v0.1.2
         args:
           - "-project={{GCLOUD_PROJECT}}"
           - "-ssh.username=switch-monitoring"


### PR DESCRIPTION
This release includes the fix at https://github.com/m-lab/switch-monitoring/pull/19 and no other changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/693)
<!-- Reviewable:end -->
