### PR TITLE
Update ConfigNotFoundSwitch's "for" value

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1533,11 +1533,15 @@ groups:
         this site existed on siteinfo at deployment time. Please check that the
         site has been added to siteinfo and trigger a switch-config deployment.
 
+  # A switch can be offline for 24hrs before a corresponding SwitchDownAtSite
+  # alert fires. This sets a lower bound for how long the switch can be unreachable
+  # before we care about being notified. This alert's "for" value should always be
+  # longer than that.
   - alert: SwitchMonitoring_ConfigNotFoundSwitch
     expr: |
       switch_monitoring_config_match{status="config_not_found_switch"} == 1
       unless on(site) gmx_site_maintenance == 1
-    for: 2m
+    for: 2d
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
This PR changes how long a switch can be unreachable by switch-monitoring before the alert is triggered. This prevents `ConfigNotFoundSwitch` from notifying us too soon -- and before the `SwitchDownAtSite` alert is triggered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/694)
<!-- Reviewable:end -->
