### PR TITLE
Generate switch-targets using v2 names (e.g., s1-den04)

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -157,7 +157,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   ./mlabconfig.py --format=prom-targets-sites \
       --sites "${sites}" \
       --physical \
-      --template_target=s1.{{sitename}}.measurement-lab.org \
+      --template_target=s1-{{sitename}}.measurement-lab.org \
       --label service=snmp > \
           ${output}/snmp-targets/snmpexporter.json
 


### PR DESCRIPTION
This was an oversight in the migration process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/695)
<!-- Reviewable:end -->
