### PR TITLE
Lowers lower bound of reported sysmtem RAM to 15000MB.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1396,7 +1396,7 @@ groups:
 
   - alert: PlatformHardware_RamBelowExpected
     expr: |
-      node_memory_MemTotal_bytes{machine=~"^mlab[1-4].[a-z]{3}[0-9]{2}.*"} / 2^20 < 16000
+      node_memory_MemTotal_bytes{machine=~"^mlab[1-4].[a-z]{3}[0-9]{2}.*"} / 2^20 < 15000
     for: 1d
     labels:
       repo: ops-tracker
@@ -1404,7 +1404,7 @@ groups:
     annotations:
       summary: System RAM is below the expected minimum value.
       description: All M-Lab machines have at least 16GB of RAM. The quantity
-        of RAM on one or more machines has gone below 16GB, which may indicate
+        of RAM on one or more machines has gone below 15GB, which may indicate
         a failed RAM module. Login to the machine and double check
         the hardware and/or system messages.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview


### PR DESCRIPTION
 Ubuntu apparently reports memory slightly differently than CoreOS, and the value ends up being ~15938, instead of the ~16005 that CoreOS reports through node_exporter.

I think this change should be safe. The R630s have 16G of RAM comprised of 4 4G modules. Modules are not likely to fail partially, meaning that if a module failed, the RAM should dip to around 12G.

There is currently an alert in mlab-oti for mlab3.lga08, which I converted to Ubuntu yesterday.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/697)
<!-- Reviewable:end -->
