### PR TITLE
Use v2 names for switch-monitoring-targets.

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -165,7 +165,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   ./mlabconfig.py --format=prom-targets-sites \
       --sites "${sites}" \
       --physical \
-      --template_target=s1.{{sitename}}.measurement-lab.org \
+      --template_target=s1-{{sitename}}.measurement-lab.org \
       --label module=icmp > \
           ${output}/blackbox-targets/switches_ping.json
 

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -202,7 +202,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   ./mlabconfig.py --format=prom-targets-sites \
       --sites "${sites}" \
       --physical \
-      --template_target=s1.{{sitename}}.measurement-lab.org \
+      --template_target=s1-{{sitename}}.measurement-lab.org \
       --label service=switch-monitoring > \
           ${output}/switch-monitoring-targets/switch-monitoring.json
 


### PR DESCRIPTION
This PR updates the `switch-monitoring-targets` to use the new v2 hostname format.

I've noticed the ICMP probes were still using the v1 formats, too, and I've updated them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/698)
<!-- Reviewable:end -->
