### PR TITLE
Change ConfigNotFoundSwitch's "for" value to 5d

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1536,12 +1536,12 @@ groups:
   # A switch can be offline for 24hrs before a corresponding SwitchDownAtSite
   # alert fires. This sets a lower bound for how long the switch can be unreachable
   # before we care about being notified. This alert's "for" value should always be
-  # longer than that.
+  # significantly longer than that.
   - alert: SwitchMonitoring_ConfigNotFoundSwitch
     expr: |
       switch_monitoring_config_match{status="config_not_found_switch"} == 1
       unless on(site) gmx_site_maintenance == 1
-    for: 2d
+    for: 5d
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
This should prevent the alert from firing on transient network issues like we're seeing at TPE01.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/699)
<!-- Reviewable:end -->
