### PR TITLE
Update switch-monitoring to v0.1.3

### DIFF
--- a/k8s/prometheus-federation/deployments/switch-monitoring.yml
+++ b/k8s/prometheus-federation/deployments/switch-monitoring.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: switch-monitoring
-        image: measurementlab/switch-monitoring:v0.1.2
+        image: measurementlab/switch-monitoring:v0.1.3
         args:
           - "-project={{GCLOUD_PROJECT}}"
           - "-ssh.username=switch-monitoring"


### PR DESCRIPTION
This updates the switch-monitoring deployment to v0.1.3, which accepts the v2 hostname format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/700)
<!-- Reviewable:end -->
