### PR TITLE
Inhibit BMC_ConnectionFailed alerts if switch is down at site.

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -86,6 +86,13 @@ inhibit_rules:
     alertname: 'PlatformCluster_.+Missing'
   equal: ['cluster']
 
+# Don't alert on BMC connection failures if the switch is down.
+- source_match:
+    alertname: 'SwitchDownAtSite'
+  target_match_re:
+    alertname: 'BMC_ConnectionFailed'
+  equal: []
+
 receivers:
 # For M-Lab Slack, visit:
 #   https://measurementlab.slack.com/apps/manage/custom-integrations

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1458,7 +1458,6 @@ groups:
   - alert: BMC_CredentialsNotFound
     expr: |
         reboot_e2e_result{status="credentials_not_found"}
-        unless on(site) gmx_site_maintenance == 1
         unless on(machine) gmx_machine_maintenance == 1
     for: 5m
     labels:
@@ -1473,7 +1472,6 @@ groups:
   - alert: BMC_ConnectionFailed
     expr: |
       reboot_e2e_result{status="connection_failed"}
-      unless on(site) gmx_site_maintenance == 1
       unless on(machine) gmx_machine_maintenance == 1
     for: 1d
     labels:


### PR DESCRIPTION
Additionally, removes two query criteria that did not make sense: metric `reboot_e2e_result` has no label `site`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/701)
<!-- Reviewable:end -->
