### PR TITLE
Do not include test sites in switch-monitoring targets

### DIFF
--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -202,6 +202,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   ./mlabconfig.py --format=prom-targets-sites \
       --sites "${sites}" \
       --physical \
+      --select="[a-z]{3}[0-9]{2}" \
       --template_target=s1-{{sitename}}.measurement-lab.org \
       --label service=switch-monitoring > \
           ${output}/switch-monitoring-targets/switch-monitoring.json


### PR DESCRIPTION
This PR prevents Prometheus from monitoring test sites via switch-monitoring. This means we won't get alerts for switch configuration changes on our `0t` and `1t` sites.