### PR TITLE
Add basic bq billing information

### DIFF
--- a/config/federation/bigquery/bq_billing_hourly.sql
+++ b/config/federation/bigquery/bq_billing_hourly.sql
@@ -29,7 +29,7 @@ WITH recent_billing AS (
 , net_hourly_billing AS (
   SELECT
     CONCAT(service.description, ":", sku.description) AS service,
-    SUBSTR(CAST(SHA1(billing_account_id) AS STRING), 0, 8) AS billing, -- obscure the actual ids.
+    SUBSTR(TO_BASE64(md5(billing_account_id)), 0, 8) AS billing, -- obscure the actual ids.
     project.id AS project,
     location.location AS location,
     invoice.month AS month,

--- a/config/federation/bigquery/bq_billing_hourly.sql
+++ b/config/federation/bigquery/bq_billing_hourly.sql
@@ -1,0 +1,60 @@
+#standardSQL
+-- bq_billing_hourly calculates the hourly GCP billing costs and credits from
+-- two days prior. Because GCP billing information is exported to BigQuery
+-- periodically, it may take up to 1.6 days after a given billing hour before
+-- all billing information is available in BigQuery. To keep the offset simple,
+-- we round up to 2days.
+--
+-- This query exports two values:
+--   bq_billing_hourly_costs - total real costs.
+--   bq_billing_hourly_credits - total credits that offset costs, this includes
+--     the sum of billing credits and "sustained usage" discounts.
+--
+-- Each metric above has multiple labels that allow aggregation across various
+-- dimensions.
+
+WITH recent_billing AS (
+  SELECT
+    -- Calculate the most recent hour boundary where we're confident all data is up to date.
+    TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), HOUR), INTERVAL 2 DAY) AS start_hour_minus_2d,
+    *
+  FROM
+    `mlab-oti.billing.unified`
+  WHERE
+    -- Rows for a given billing hour may be exported up to 1.6 days later.
+    -- So, only look for updates over the last two days.
+    partition_time >= TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY))
+)
+
+, net_hourly_billing AS (
+  SELECT
+    CONCAT(service.description, ":", sku.description) AS service,
+    FARM_FINGERPRINT(billing_account_id) AS billing, -- obscure the actual ids.
+    project.id AS project,
+    location.location AS location,
+    invoice.month AS month,
+    -- Multiple credits are possible. i.e. "sustained use" discounts and billing account credits.
+    -- This calcluates the effective, net credits for a given row by grouping on all other fields.
+    SUM(credits.amount) AS net_credits,
+    cost
+  FROM
+    recent_billing, UNNEST(credits) AS credits
+  WHERE
+    -- Select only rows from "recent_billing" that match the current usage hour from 2 days ago.
+    start_hour_minus_2d = usage_start_time
+  GROUP BY
+    service, billing, project, location, month, cost
+)
+
+SELECT
+  -- metric labels.
+  service, billing, project, location, month,
+  -- metric values.
+  SUM(net_credits) AS value_credits,
+  SUM(cost) AS value_costs
+FROM
+  net_hourly_billing
+GROUP BY
+  service, billing, project, location, month
+ORDER BY
+  value_costs DESC

--- a/config/federation/bigquery/bq_billing_hourly.sql
+++ b/config/federation/bigquery/bq_billing_hourly.sql
@@ -29,7 +29,7 @@ WITH recent_billing AS (
 , net_hourly_billing AS (
   SELECT
     CONCAT(service.description, ":", sku.description) AS service,
-    CAST(FARM_FINGERPRINT(billing_account_id) AS STRING) AS billing, -- obscure the actual ids.
+    SUBSTR(CAST(SHA1(billing_account_id) AS STRING), 0, 8) AS billing, -- obscure the actual ids.
     project.id AS project,
     location.location AS location,
     invoice.month AS month,

--- a/config/federation/bigquery/bq_billing_hourly.sql
+++ b/config/federation/bigquery/bq_billing_hourly.sql
@@ -29,7 +29,7 @@ WITH recent_billing AS (
 , net_hourly_billing AS (
   SELECT
     CONCAT(service.description, ":", sku.description) AS service,
-    FARM_FINGERPRINT(billing_account_id) AS billing, -- obscure the actual ids.
+    CAST(FARM_FINGERPRINT(billing_account_id) AS STRING) AS billing, -- obscure the actual ids.
     project.id AS project,
     location.location AS location,
     invoice.month AS month,

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -19,10 +19,10 @@ spec:
         image: measurementlab/prometheus-bigquery-exporter:production-0.3
         args: [ "--project={{GCLOUD_PROJECT}}",
                 "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
-                "--type=gauge", "--query=/queries/bq_mlabns_sixhour_requests.sql",
                 "--type=gauge", "--query=/queries/bq_annotation.sql",
                 "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
                 "--type=gauge", "--query=/queries/bq_ndt_s2c.sql",
+                "--type=gauge", "--query=/queries/bq_billing_hourly.sql",
               ]
         ports:
         - containerPort: 9050


### PR DESCRIPTION
This change introduces a new bigquery-exporter query to report service-level aggregate GCP billing and credit usage.

Because data exported to bigquery may be delayed for up to 1.6days (by observation) and because prometheus can only report "current" values, this change exports the hourly billing from two day prior to the current hour.

As well, this query uses a manually created view that unifies the staging and oti tables. There may be permission adjustments necessary to the default GKE user so that it can query that view in staging and oti projects.

I am also considering one or two additional queries that would aggregate by day, and another that would export only by GCE VMs, because there is machine type information that could help identify unnecessary costs.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/703)
<!-- Reviewable:end -->
