### PR TITLE
Update recording rules & global dashboard with ndt7 metrics

### DIFF
--- a/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
+++ b/config/federation/grafana/dashboards/NDT_GlobalTestRate.json
@@ -15,11 +15,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1574962384405,
+  "iteration": 1592444440456,
   "links": [],
   "panels": [
     {
       "content": "# Real time",
+      "datasource": null,
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -89,7 +90,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"s2c\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{direction=\"s2c\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{direction=\"download\", result!=\"error-without-rate\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -98,7 +99,7 @@
           "step": 120
         },
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"c2s\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{direction=\"c2s\", result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{direction=\"upload\", result!=\"error-without-rate\"}[5m])) or vector(0))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -107,8 +108,9 @@
           "step": 120
         },
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or vector(0))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Total",
           "refId": "C",
@@ -212,7 +214,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m])) or vector(0)) +\n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m])) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m]))) or absent(machine:ndt5_client_test_results:rpm2m)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m])) or absent(ndt_test_total))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{result!=\"error-without-rate\"}[5m])) or vector(0))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -222,7 +224,7 @@
           "step": 240
         },
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 7d)) or vector(0)) + \n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 7d)) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d))) or absent(machine:ndt5_client_test_results:rpm2m offset 7d)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 7d)) or absent(ndt_test_total offset 7d))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d)) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 7d)) or vector(0))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -231,7 +233,7 @@
           "step": 240
         },
         {
-          "expr": "(60 * sum(rate(inotify_extension_create_total{ext=\".s2c_snaplog\"}[5m] offset 14d)) or vector(0)) +\n(60 * sum(rate(inotify_extension_create_total{ext=\".c2s_snaplog\"}[5m] offset 14d)) or vector(0)) +\n((60 *sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d))) or absent(machine:ndt5_client_test_results:rpm2m offset 14d)) +\n(60 * sum(rate(ndt_test_total{direction=~\"c2s|s2c\"}[5m] offset 14d)) or absent(ndt_test_total offset 14d))",
+          "expr": "(60 * sum(rate(ndt5_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d)) or vector(0))\n+ (60 * sum(rate(ndt7_client_test_results_total{result!=\"error-without-rate\"}[5m] offset 14d)) or vector(0))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -283,15 +285,16 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 19,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "tags": [],
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -301,14 +304,14 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/Prometheus/",
+        "regex": "/Platform/",
         "skipUrlSync": false,
         "type": "datasource"
       }
     ]
   },
   "time": {
-    "from": "now-20d",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -339,5 +342,5 @@
   "timezone": "utc",
   "title": "NDT: Global Test Rate",
   "uid": "Cyq7WeNiz",
-  "version": 142
+  "version": 147
 }

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -334,6 +334,7 @@ scrape_configs:
         - 'kube_pod_status_ready'
         # For recording rules for NDT Early Warning dashboard and Global Test Rates.
         - 'ndt5_client_test_results_total'
+        - 'ndt7_client_test_results_total'
         - 'node_disk_io_time_seconds_total{deployment="node-exporter"}'
         # Aggregate the collectd health status from node-exporter.
         - 'collectd_mlab_success'

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -27,6 +27,11 @@
 #  * Do not overwrite a metric name with itself.
 #  * Do not use 'label_replace' to overwrite a metric name.
 #  * Do not use rate with a range less than 4x the scrape_interval.
+#
+##############################################################################
+# TODO: remove rules that are not actively used.
+##############################################################################
+
 groups:
 - name: rules.yml
   rules:
@@ -53,10 +58,14 @@ groups:
 
 ## NDT Early Warning aggregation rules for Kubernetes platform.
 #
-# Per-machine successful NDT5 tests counted by the server.
-# Units: requests per minute.
+  # Per-machine successful NDT5 tests counted by the server.
+  # Units: requests per minute.
   - record: machine:ndt5_client_test_results:rpm2m
     expr: 60 * sum by(machine) (irate(ndt5_client_test_results_total{result!="error-without-rate"}[4m]))
+  # Per-machine successful NDT7 tests counted by the server.
+  # Units: requests per minute.
+  - record: machine:ndt7_client_test_results:rpm2m
+    expr: 60 * sum by(machine) (irate(ndt7_client_test_results_total{result!="error-without-rate"}[4m]))
   # Per-machine maximum ratio of time spent performing I/O on all devices.
   # Units: none (sec/sec)
   - record: machine:node_disk_io_time_seconds:max2m
@@ -83,14 +92,7 @@ groups:
     expr: irate(ifOutDiscards{ifAlias="uplink"}[4m]) > 0
   - record: switch:ifOutDiscards:irate4m
     expr: irate(ifOutDiscards{ifAlias="uplink"}[4m])
-##############################################################################
-# Candidate recording rules.
-##############################################################################
-# TODO: remove rules that are not actively used.
-#
-# Do not build dependencies on these rules until they have been moved out of
-# this candidate rule area.
-#
+
 ## NDT Early Warning 2x site capacity thresholds.
 #
 # Shorter time ranges are chosen to favor higher sensitivity and longer time
@@ -102,6 +104,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[30m])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[30m])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[30m])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_30m
@@ -113,6 +117,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[1h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[1h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[1h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_1h
@@ -124,6 +130,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[2h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[2h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_2h
@@ -135,6 +143,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[6h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[6h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_6h
@@ -147,6 +157,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[2h])
+  - record: machine:ndt7_client_test_results_rpm:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m[2h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[2h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_2h
@@ -158,6 +170,8 @@ groups:
   # k8s
   - record: machine:ndt5_client_test_results_rpm:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[6h])
+  - record: machine:ndt7_client_test_results_rpm:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m[6h])
   - record: machine:node_disk_io_time_seconds_max:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[6h])
   - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_6h


### PR DESCRIPTION
The Global Test rate dashboard is self-contained.

The recording rules make it possible to additionally update the Early Warning dashboard with ndt7 metrics once the new metrics are available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/706)
<!-- Reviewable:end -->
