### PR TITLE
Inhibits alert MachineRunningWithoutK8sNode if the platform cluster scrape job is down

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -83,7 +83,7 @@ inhibit_rules:
 - source_match:
     alertname: 'PlatformCluster_FederationScrapeJobFailing'
   target_match_re:
-    alertname: 'PlatformCluster_.+Missing'
+    alertname: 'PlatformCluster_.+Missing|MachineRunningWithoutK8sNode'
   equal: ['cluster']
 
 # Don't alert on BMC connection failures if the switch is down.


### PR DESCRIPTION
This is intended to resolve #683

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/708)
<!-- Reviewable:end -->
