### PR TITLE
Changes metric node_filesystem_free_bytes to node_filesystem_avail_bytes

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -304,7 +304,7 @@ groups:
             probe_success{service="ndt_raw"} OR
             script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
-              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+              node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
                 "experiment", "ndt.iupui", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"},
@@ -337,7 +337,7 @@ groups:
             probe_success{service="ndt_raw_ipv6"} OR
             script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
-              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+              node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
                 "experiment", "ndt.iupui", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"},
@@ -370,7 +370,7 @@ groups:
             probe_success{service="ndt_ssl"} OR
             script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
-              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+              node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
                 "experiment", "ndt.iupui", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"},
@@ -403,7 +403,7 @@ groups:
             probe_success{service="ndt_ssl_ipv6"} OR
             script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
-              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+              node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
                 "experiment", "ndt.iupui", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"},


### PR DESCRIPTION
This is a case where the metric used by mlab-ns was update and is correct but the alert metric was never updated to query the same/correct metric.

This should resolve one of the action items on https://github.com/m-lab/ops-tracker/issues/1123.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/712)
<!-- Reviewable:end -->
