### PR TITLE
Update metrics relabeling to the v2 hostname format.

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -507,7 +507,7 @@ scrape_configs:
     # TODO: retire this in favor of adding the label at target generation time.
     metric_relabel_configs:
       - source_labels: [machine]
-        regex: mlab[1-4]\.([a-z]{3}[0-9tc]{2}).+
+        regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).+
         target_label: site
         replacement: $1
 
@@ -801,7 +801,7 @@ scrape_configs:
     # TODO: retire this in favor of adding the label at target generation time.
     metric_relabel_configs:
       - source_labels: [machine]
-        regex: mlab[1-4]\.([a-z]{3}[0-9tc]{2}).+
+        regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).+
         target_label: site
         replacement: $1
 
@@ -835,4 +835,3 @@ scrape_configs:
         regex: .*
         target_label: __address__
         replacement: switch-monitoring-service.default.svc.cluster.local:8080
-


### PR DESCRIPTION
This PR fixes the incorrect generation of the `site` label due to an old regex. I believe this fixes https://github.com/m-lab/rebot/issues/30 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/713)
<!-- Reviewable:end -->
