### PR TITLE
Use locate v2 "platform" target

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -37,7 +37,7 @@ spec:
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL
-          value: https://locate-dot-{{LOCATE_PROJECT}}.appspot.com/v2/monitoring/
+          value: https://locate-platform-dot-{{LOCATE_PROJECT}}.appspot.com/v2/platform/monitoring/
         ports:
         - containerPort: 9172
         volumeMounts:


### PR DESCRIPTION
This change updates the script-exporter service address used to allocate monitoring access tokens.

This change is the second step of https://github.com/m-lab/dev-tracker/issues/600

While the service specifies locate-platform-* the `/v2/platform/*` URL will be routed to the locate-* service until the mlab-ns [dispatch.yaml file](https://github.com/m-lab/mlab-ns/blob/master/dispatch.yaml) is updated (3rd step).


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/714)
<!-- Reviewable:end -->
