### PR TITLE
Removes scraping of node_exporter on dns.measurementlab.net

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -794,18 +794,6 @@ groups:
       description: Login to EB to see if it is in fact crashed. If so, look
         through the logs.
 
-# The node_exporter running on dns.measurementlab.net is down.
-  - alert: NodeExporterOnDnsDownOrMissing
-    expr: up{job="dns-node-exporter"} == 0 or absent(up{job="dns-node-exporter"})
-    for: 10m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: The node_exporter running on dns.measurementlab.net is down.
-      description: Login to to see if it is in fact crashed. If so, look
-        through the logs.
-
 # GardenerDownOrMissing fires when the etl-gardener is down or absent.
 # TODO: enable annotations to ignore some container ports, and simplify this query.
 # https://github.com/m-lab/prometheus-support/issues/48

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -383,11 +383,6 @@ scrape_configs:
     static_configs:
       - targets: ['eb.measurementlab.net:9100']
 
-  # Scrape config for the node_exporter on dns.measurementlab.net.
-  - job_name: 'dns-node-exporter'
-    static_configs:
-      - targets: ['dns.measurementlab.net:9100']
-
   # Scrape config for the epoxy-boot-api.
   - job_name: 'epoxy-boot-api'
     static_configs:


### PR DESCRIPTION
Also removes the alert for when scraping of that instance of node_exporter is down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/716)
<!-- Reviewable:end -->
