### PR TITLE
Delay daily discard calculation to 6 hours later

### DIFF
--- a/config/federation/bigquery/bq_ndt_s2c.sql
+++ b/config/federation/bigquery/bq_ndt_s2c.sql
@@ -8,14 +8,14 @@
 -- NDT S2C start or end time that falls within the SNMP polling interval.
 -- For faster queries we use `partition_date` boundaries. And, to
 -- guarantee the partition_date data is "complete" (all data collected
--- and parsed) we should wait 36 hours after start of a given day.
+-- and parsed) we should wait 42 hours after start of a given day.
 -- The following is equivalent to the pseudo code:
---     date(now() - 12h) - 1d
+--     date(now() - 18h) - 1d
 CREATE TEMPORARY FUNCTION queryDate() AS (
   DATE(
     TIMESTAMP_SUB(
       TIMESTAMP_TRUNC(
-        TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 12 HOUR),
+        TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 18 HOUR),
         DAY),
       INTERVAL 24 HOUR
     )


### PR DESCRIPTION
The combination of these two PRs move the expected data availability time 4-6 hours later than previously assumed by the `bq_ndt_s2c.sql` query. This change delays using the disco data by 18hrs rather than 12 to adjust to this later data availability.

* https://github.com/m-lab/gcp-config/pull/33
* https://github.com/m-lab/etl-gardener/pull/299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/717)
<!-- Reviewable:end -->
