### PR TITLE
Normalize disco node name for join

### DIFF
--- a/config/federation/bigquery/bq_ndt_s2c.sql
+++ b/config/federation/bigquery/bq_ndt_s2c.sql
@@ -25,15 +25,14 @@ CREATE TEMPORARY FUNCTION queryDate() AS (
 -- Takes ParseInfo.TaskFileName and returns an M-Lab hostname.
 CREATE TEMPORARY FUNCTION toNodeName(tfn STRING) AS (
   CONCAT(
-    REGEXP_EXTRACT(tfn, r'(mlab[1-4])-[a-z]{3}[0-9]{2}.*'), ".",
-    REGEXP_EXTRACT(tfn, r'mlab[1-4]-([a-z]{3}[0-9]{2}).*'),
-    ".measurement-lab.org"
+    REGEXP_EXTRACT(tfn, r'(mlab[1-4])-[a-z]{3}[0-9]{2}.*'), "-",
+    REGEXP_EXTRACT(tfn, r'mlab[1-4]-([a-z]{3}[0-9]{2}).*')
   )
 );
 
 WITH disco_intervals_with_discards AS (
   SELECT
-    hostname AS node,
+    toNodeName(hostname) AS node,
     TIMESTAMP_SUB(sample.timestamp, INTERVAL 10 SECOND) AS tstart,
     sample.timestamp AS tend,
     sample.value AS discards


### PR DESCRIPTION
Evidently the discard slo stopped working because of the v1 v2 node name migration around May 15th.

This change adds hostname normalization to the switch and ndt5 data so that the join continues to work as intended.

<img width="1912" alt="Screen Shot 2020-07-15 at 7 02 02 PM" src="https://user-images.githubusercontent.com/1085316/87608911-1c16af00-c6cf-11ea-89a2-b209f7d44fe7.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/718)
<!-- Reviewable:end -->
