### PR TITLE
Update scan times to correspond to new daily archive transfers

### DIFF
--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -24,9 +24,9 @@ spec:
         - -source=pusher-{{GCLOUD_PROJECT}}
         - -time=2h30m
         - -source=archive-{{GCLOUD_PROJECT}}
-        - -time=3h30m
+        - -time=6h30m
         - -source=archive-measurement-lab
-        - -time=4h30m
+        - -time=10h30m
         ports:
         - containerPort: 9990
           name: metrics


### PR DESCRIPTION
This change updates the gcs-exporter scan times to correspond to the expected end times of the GCS transfers from the daily-archive-transfer config in gcp-config. https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml#L48

We expect new archives to stop uploading to a date at 02:30. That the archive-mlab-oti transfer will be complete by 06:30, and the archive-measurement-lab transfer will be complete by 10:30 (which is when gardener is scheduled to begin the daily reprocessing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/719)
<!-- Reviewable:end -->
