### PR TITLE
Sums archive file count increase differences

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -730,8 +730,8 @@ groups:
 # This alert enforces that daily transfers are working for all datatypes.
   - alert: GCSTransfers_ArchiveFilesDoNotMatchOrMissing
     expr: |
-      increase(gcs_archive_files_total{bucket="archive-mlab-oti"}[1d]) - ignoring(bucket)
-         increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d]) != 0
+      sum(increase(gcs_archive_files_total{bucket="archive-mlab-oti"}[1d]) - ignoring(bucket)
+         increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d]) != 0)
       OR
       absent(gcs_archive_files_total)
     for: 1d


### PR DESCRIPTION
Modifies `GCSTransfers_ArchiveFilesDoNotMatchOrMissing` alert to sum difference so that we don't get separate alerts for every experiment/datatype combination, but instead one lump sum indicating a non-zero value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/720)
<!-- Reviewable:end -->
