### PR TITLE
Adds a new alert for version skew in the API cluster.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1237,6 +1237,36 @@ groups:
         reboot-coordinator namespace to see which node it may be stuck on.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
+  # There is version skew among the core k8s components on one or more API
+  # cluster servers.
+  - alert: PlatformCluster_ApiClusterComponentVersionSkew
+    expr: |
+      count(
+        count by (version) (
+          label_replace(kube_pod_container_info{exported_namespace="kube-system",
+            exported_container=~"(kube-apiserver|kube-controller-manager|kube-scheduler)"},
+            "version", "$1", "image", ".*:(v[0-9.]+$)")
+          or
+          label_replace(kube_node_info{node=~"master-platform-cluster.*"},
+            "version", "$1", "kubelet_version", "(.*)")
+        )
+      ) > 1
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: There is version skew between core k8s components in the API cluster.
+      description: >
+        There are 4 primary Kubernetes components on each API cluster server -
+        kubelet, kube-apiserver, kube-controller-manager, kube-scheduler. The
+        version of all these components should always be the same, since when
+        upgrading the API cluster all these components are supposed to be
+        updated at the same time. Was the upgrade_master_platform_script.sh in
+        the k8s-support repo run recently? Did something go wrong with the
+        upgrade? Perhaps an API server node was incorrectly upgraded _not_
+        using the ugprade script and not all components got updated?
+
   # The desired number of pods for a DaemonSet are not equal to the current
   # number scheduled.
   - alert: PlatformCluster_DaemonSetHasTooFewPods

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -319,6 +319,7 @@ scrape_configs:
         - 'kube_node_labels'
         - 'kube_node_spec_taint{key="lame-duck"}'
         - 'kube_node_status_condition'
+        - 'kube_pod_container_info{exported_namespace="kube-system", exported_container=~"(kube-apiserver|kube-controller-manager|kube-scheduler)"}'
         - 'etcd_server_has_leader'
         - 'etcd_server_leader_changes_seen_total'
         - 'etcd_server_proposals_failed_total'


### PR DESCRIPTION
We had a situation recently where we _thought_ that our staging and production clusters were upgraded from 1.15.10 to 1.16.7. `kubectl get nodes` showed 1.16.7, but while the kubelet, kubeadm, CNI plugins, and crictl were all the version we expected, under the hood the core k8s components (kube-apiserver, kube-controller-manager, kube-scheduler) were all still running 1.15.10. This situation did not become apparent until we went to upgrade the cluster to 1.17.8 and discovered that kubeadm was unhappy with the cluster state.

This PR attempts to add an alert that will notify us of version skew in the API cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/725)
<!-- Reviewable:end -->
