### PR TITLE
add ndt7 and annotation to bq_gardener_parse_time

### DIFF
--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -34,4 +34,10 @@ FROM (
   UNION ALL
     SELECT "ndt/ndt5" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
     FROM   `{{PROJECT}}.ndt.ndt5`
+  UNION ALL
+    SELECT "ndt/ndt7" AS datatype, MIN(Parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.ndt7`
+  UNION ALL
+    SELECT "ndt/annotation" AS datatype, MIN(Parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.annotation`
 )


### PR DESCRIPTION
The travis build triggered one deployment, but looking at BQ logs, it doesn't seem to have changed the query that was run.

https://pantheon.corp.google.com/bigquery?project=mlab-sandbox&page=queries&queryFilter=%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22union_5C_22_22%257D%255D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/732)
<!-- Reviewable:end -->
