### PR TITLE
Add default cluster label to pod metrics in federation cluster

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -206,7 +206,13 @@ scrape_configs:
         action: replace
         regex: gke-(.*)(-[^-]+){2}
         replacement: $1
+        target_label: nodepool
+
+      # Add explicit cluster label to pod metrics.
+      - source_labels: []
+        regex: .*
         target_label: cluster
+        replacement: prometheus-federation
 
       # Identify the deployment name for replica set or daemon set.  Pods
       # created by deployments or daemon sets are processed here. The


### PR DESCRIPTION
To match the change from https://github.com/m-lab/prometheus-support/pull/739 this change makes a similar change to the prometheus-federation configuration. The original cluster+nodepool value is set to "nodepool=" and a static "cluster=prometheus-federation" is now set for all pod metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/740)
<!-- Reviewable:end -->
