### PR TITLE
Updates SwitchOverview and NDT:EarlyWarning dashboards to use DISCOv2 data

### DIFF
--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 201,
-  "iteration": 1600891265792,
+  "iteration": 1600982368879,
   "links": [],
   "panels": [
     {
@@ -428,7 +428,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "((quantile_over_time(0.9,machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\n  + quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])) > 60)",
+          "expr": "((quantile_over_time(0.9,machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\n  + quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])) > 60)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -437,7 +437,7 @@
           "refId": "G"
         },
         {
-          "expr": "(quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\n + quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])) > 96",
+          "expr": "(quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\n + quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])) > 96",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -446,7 +446,7 @@
           "refId": "H"
         },
         {
-          "expr": "(machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}\n + machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"})\n",
+          "expr": "(machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}\n + machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"})\n",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -455,7 +455,7 @@
           "refId": "I"
         },
         {
-          "expr": "quantile_over_time(0.90, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\n + quantile_over_time(0.90, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.90, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\n + quantile_over_time(0.90, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -464,7 +464,7 @@
           "refId": "J"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\n + quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\n + quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -478,7 +478,7 @@
           "refId": "F"
         },
         {
-          "expr": "(quantile_over_time(0.9,machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 60)\nunless (quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range]))",
+          "expr": "(quantile_over_time(0.9,machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range]) > 60)\nunless (quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range]))",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -487,7 +487,7 @@
           "refId": "A"
         },
         {
-          "expr": "(quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range]) > 96)\nunless quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "(quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range]) > 96)\nunless quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -496,7 +496,7 @@
           "refId": "B"
         },
         {
-          "expr": "machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}\nunless machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}\n",
+          "expr": "machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}\nunless machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}\n",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -505,7 +505,7 @@
           "refId": "C"
         },
         {
-          "expr": "quantile_over_time(0.90, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\nunless quantile_over_time(0.90, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.90, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\nunless quantile_over_time(0.90, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -514,7 +514,7 @@
           "refId": "D"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])\nunless quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])\nunless quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -842,64 +842,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range]) > 0.5",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "warning - {{machine}}",
-          "refId": "B",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range]) > 0.8",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "error - {{machine}}",
-          "refId": "D",
-          "step": 900
-        },
-        {
-          "expr": "machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "raw - {{machine}}",
-          "refId": "A",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range])",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "q90 - {{machine}}",
-          "refId": "C",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_ms:max_ratio2m{machine=~\"$machine.$site.*\"}[$range])",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "q98 - {{machine}}",
-          "refId": "E",
-          "step": 900
-        },
-        {
-          "expr": "/* k8s */",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "F"
-        },
-        {
-          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range]) > 0.5",
+          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine-$site.*\"}[$range]) > 0.5",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -907,7 +850,7 @@
           "refId": "G"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range]) > 0.8",
+          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine-$site.*\"}[$range]) > 0.8",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -915,7 +858,7 @@
           "refId": "H"
         },
         {
-          "expr": "machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}",
+          "expr": "machine:node_disk_io_time_seconds:max2m{machine=~\"$machine-$site.*\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -923,7 +866,7 @@
           "refId": "I"
         },
         {
-          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.90, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -931,7 +874,7 @@
           "refId": "J"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine.$site.*\"}[$range])",
+          "expr": "quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m{machine=~\"$machine-$site.*\"}[$range])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1048,63 +991,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "quantile_over_time(0.90, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .5",
-          "format": "time_series",
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "warning - {{machine}}",
-          "refId": "E",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .8",
-          "format": "time_series",
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "error - {{machine}}",
-          "refId": "F",
-          "step": 900
-        },
-        {
-          "expr": "ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "raw - {{machine}}",
-          "refId": "G",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.90, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "q90 - {{machine}}",
-          "refId": "H",
-          "step": 900
-        },
-        {
-          "expr": "quantile_over_time(0.98, ndt:vdlimit_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
-          "format": "time_series",
-          "hide": false,
-          "interval": "1m",
-          "intervalFactor": 1,
-          "legendFormat": "q98 - {{machine}}",
-          "refId": "A",
-          "step": 900
-        },
-        {
-          "expr": "/* k8s */",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .5",
+          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine-$site.*\"}[3h]) > .5",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1112,7 +999,7 @@
           "refId": "C"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h]) > .8",
+          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine-$site.*\"}[3h]) > .8",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1120,7 +1007,7 @@
           "refId": "D"
         },
         {
-          "expr": "machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}",
+          "expr": "machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine-$site.*\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1128,7 +1015,7 @@
           "refId": "I"
         },
         {
-          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "expr": "quantile_over_time(0.90, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine-$site.*\"}[3h])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1136,7 +1023,7 @@
           "refId": "J"
         },
         {
-          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine.$site.*\"}[3h])",
+          "expr": "quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h{machine=~\"$machine-$site.*\"}[3h])",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -1194,7 +1081,6 @@
     "list": [
       {
         "current": {
-          "tags": [],
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -1452,5 +1338,5 @@
   "timezone": "utc",
   "title": "NDT: Early Warning",
   "uid": "UM67WeHmz",
-  "version": 150
+  "version": 151
 }

--- a/config/federation/grafana/dashboards/NDT_EarlyWarning.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyWarning.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 338,
-  "iteration": 1592574816804,
+  "id": 201,
+  "iteration": 1600891265792,
   "links": [],
   "panels": [
     {
@@ -1194,8 +1194,9 @@
     "list": [
       {
         "current": {
-          "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "tags": [],
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1205,7 +1206,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "Prometheus.*",
+        "regex": "/Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -1222,7 +1223,7 @@
         "name": "machine",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "mlab1",
             "value": "mlab1"
           },
@@ -1387,6 +1388,7 @@
         "allValue": null,
         "current": {
           "selected": true,
+          "tags": [],
           "text": "80",
           "value": "80"
         },
@@ -1450,5 +1452,5 @@
   "timezone": "utc",
   "title": "NDT: Early Warning",
   "uid": "UM67WeHmz",
-  "version": 143
+  "version": 150
 }

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1582921788995,
+  "id": 197,
+  "iteration": 1600807775380,
   "links": [],
   "panels": [
     {
@@ -61,7 +62,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "- quantile(0.99, 8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "- quantile(0.99, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % In",
@@ -69,7 +70,7 @@
           "step": 10
         },
         {
-          "expr": "quantile(0.90, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "quantile(0.90, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -79,7 +80,7 @@
           "step": 10
         },
         {
-          "expr": "- max(8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "- max(8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -89,7 +90,7 @@
           "step": 10
         },
         {
-          "expr": "quantile(0.99, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "quantile(0.99, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % Out",
@@ -97,7 +98,7 @@
           "step": 10
         },
         {
-          "expr": "max(8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "max(8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -107,7 +108,7 @@
           "step": 10
         },
         {
-          "expr": "- quantile(0.90, 8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[2m]))",
+          "expr": "- quantile(0.90, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -203,7 +204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(ifHCOutOctets{ifAlias=\"uplink\", site=\"$site_name\"}[2m])",
+          "expr": "8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2-$site.*\"}[2m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Out",
@@ -211,7 +212,7 @@
           "step": 10
         },
         {
-          "expr": "8 * rate(ifHCInOctets{ifAlias=\"uplink\", site=\"$site_name\"}[2m])",
+          "expr": "8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2-$site.*\"}[2m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "In",
@@ -223,7 +224,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$site_name: uplink traffic (In/Out)",
+      "title": "$site: uplink traffic (In/Out)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -306,7 +307,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[10m]))",
+          "expr": "topk(10, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[10m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -400,7 +401,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, 8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[10m]))",
+          "expr": "topk(10, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[10m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -497,29 +498,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, switch:jnxCosQstatTotalDropPkts:irate4m_gt_0)",
+          "expr": "topk(10, irate(ifOutDiscards{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[4m]) > 0)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{site}} Total (Juniper)",
+          "legendFormat": "{{site}} ({{interface}})",
           "refId": "B",
-          "step": 10
-        },
-        {
-          "expr": "topk(10, switch:ifOutDiscards:irate4m_gt_0)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{site}} Out (HP/Cisco)",
-          "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "topk(10, irate(ifInDiscards{ifAlias=\"uplink\"}[4m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{site}} In (HP/Cisco)",
-          "refId": "C",
           "step": 10
         }
       ],
@@ -609,7 +594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, rate(ifOutErrors{ifAlias=\"uplink\"}[2m]))",
+          "expr": "topk(10, rate(ifOutErrors{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -619,7 +604,7 @@
           "step": 10
         },
         {
-          "expr": "topk(10, rate(ifInErrors{ifAlias=\"uplink\"}[2m]))",
+          "expr": "topk(10, rate(ifInErrors{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -669,190 +654,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 24
-      },
-      "id": 8,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "topk(10, snmp_scrape_duration_seconds)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{site}}",
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "snmp_exporter scrape times: Top 10",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 9,
-      "legend": {
-        "alignAsTable": false,
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "topk(10, snmp_scrape_duration_seconds{site=\"$site_name\"})",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{site}}",
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "$site_name: snmp_exporter scrape times",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
     }
   ],
   "refresh": false,
@@ -864,8 +665,8 @@
       {
         "current": {
           "tags": [],
-          "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "text": "Platform Cluster (mlab-sandbox)",
+          "value": "Platform Cluster (mlab-sandbox)"
         },
         "hide": 0,
         "includeAll": false,
@@ -875,28 +676,27 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/Prometheus/",
+        "regex": "/Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "yyz02",
-          "value": "yyz02"
+          "text": "lga0t",
+          "value": "lga0t"
         },
         "datasource": "$datasource",
-        "definition": "",
+        "definition": "label_values(machine)",
         "hide": 0,
         "includeAll": false,
         "label": "Site",
         "multi": false,
-        "name": "site_name",
+        "name": "site",
         "options": [],
-        "query": "label_values(site)",
+        "query": "label_values(machine)",
         "refresh": 1,
-        "regex": "",
+        "regex": "/mlab[1-4]-([a-z]{3}[0-9t]{2}).*/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
@@ -908,7 +708,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -939,5 +739,5 @@
   "timezone": "utc",
   "title": "Ops: Switch Overview",
   "uid": "SuqnZ6Hiz",
-  "version": 137
+  "version": 139
 }

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 197,
-  "iteration": 1600807775380,
+  "iteration": 1600807775382,
   "links": [],
   "panels": [
     {
@@ -599,7 +599,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Out {{site}}",
+          "legendFormat": "{{site}} Out",
           "refId": "B",
           "step": 10
         },
@@ -609,7 +609,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "In {{site}}",
+          "legendFormat": "{{site}} In",
           "refId": "A",
           "step": 10
         }
@@ -665,8 +665,8 @@
       {
         "current": {
           "tags": [],
-          "text": "Platform Cluster (mlab-sandbox)",
-          "value": "Platform Cluster (mlab-sandbox)"
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -683,8 +683,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "lga0t",
-          "value": "lga0t"
+          "text": "akl01",
+          "value": "akl01"
         },
         "datasource": "$datasource",
         "definition": "label_values(machine)",

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 197,
-  "iteration": 1600980051932,
+  "iteration": 1601049106266,
   "links": [],
   "panels": [
     {
@@ -62,7 +62,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "- max by (site) (quantile(0.99, 8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
+          "expr": "- quantile(0.99, max by (site) (8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % In",
@@ -70,7 +70,7 @@
           "step": 10
         },
         {
-          "expr": "max by (site) (quantile(0.90, 8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
+          "expr": "quantile(0.90, max by (site) (8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -80,7 +80,7 @@
           "step": 10
         },
         {
-          "expr": "- max by (site) (8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m]))",
+          "expr": "- max(8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -90,7 +90,7 @@
           "step": 10
         },
         {
-          "expr": "max by (site) (quantile(0.99, 8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
+          "expr": "quantile(0.99, max by (site) (8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % Out",
@@ -98,7 +98,7 @@
           "step": 10
         },
         {
-          "expr": "max by (site) (8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m]))",
+          "expr": "max(8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -108,7 +108,7 @@
           "step": 10
         },
         {
-          "expr": "- max by (site) (quantile(0.90, 8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
+          "expr": "- quantile(0.90, max by (site) (8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -739,5 +739,5 @@
   "timezone": "utc",
   "title": "Ops: Switch Overview",
   "uid": "SuqnZ6Hiz",
-  "version": 140
+  "version": 141
 }

--- a/config/federation/grafana/dashboards/Ops_SwitchOverview.json
+++ b/config/federation/grafana/dashboards/Ops_SwitchOverview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 197,
-  "iteration": 1600807775382,
+  "iteration": 1600980051932,
   "links": [],
   "panels": [
     {
@@ -62,7 +62,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "- quantile(0.99, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "- max by (site) (quantile(0.99, 8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % In",
@@ -70,7 +70,7 @@
           "step": 10
         },
         {
-          "expr": "quantile(0.90, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "max by (site) (quantile(0.90, 8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -80,7 +80,7 @@
           "step": 10
         },
         {
-          "expr": "- max(8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "- max by (site) (8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -90,7 +90,7 @@
           "step": 10
         },
         {
-          "expr": "quantile(0.99, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "max by (site) (quantile(0.99, 8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "99th % Out",
@@ -98,7 +98,7 @@
           "step": 10
         },
         {
-          "expr": "max(8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "max by (site) (8 * irate(ifHCOutOctets{ifAlias=\"uplink\"}[4m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -108,7 +108,7 @@
           "step": 10
         },
         {
-          "expr": "- quantile(0.90, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "- max by (site) (quantile(0.90, 8 * irate(ifHCInOctets{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -204,7 +204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2-$site.*\"}[2m])",
+          "expr": "max by (site) (8 * irate(ifHCOutOctets{ifAlias=\"uplink\", site=\"$site\"}[4m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Out",
@@ -212,7 +212,7 @@
           "step": 10
         },
         {
-          "expr": "8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2-$site.*\"}[2m])",
+          "expr": "max by (site) (8 * irate(ifHCInOctets{ifAlias=\"uplink\", site=\"$site\"}[4m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "In",
@@ -307,7 +307,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, 8 * rate(ifHCOutOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[10m]))",
+          "expr": "topk(10, max by (site) (8 * rate(ifHCOutOctets{ifAlias=\"uplink\"}[10m])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -401,7 +401,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, 8 * rate(ifHCInOctets{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[10m]))",
+          "expr": "topk(10, max by (site) (8 * rate(ifHCInOctets{ifAlias=\"uplink\"}[10m])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -498,7 +498,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, irate(ifOutDiscards{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[4m]) > 0)",
+          "expr": "topk(10, max by (site) (irate(ifOutDiscards{ifAlias=\"uplink\"}[4m]) > 0))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -594,7 +594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, rate(ifOutErrors{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "topk(10, max by (site) (irate(ifOutErrors{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -604,7 +604,7 @@
           "step": 10
         },
         {
-          "expr": "topk(10, rate(ifInErrors{ifAlias=\"uplink\", machine=~\"mlab2.*\"}[2m]))",
+          "expr": "topk(10, max by (site) (irate(ifInErrors{ifAlias=\"uplink\"}[4m])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -739,5 +739,5 @@
   "timezone": "utc",
   "title": "Ops: Switch Overview",
   "uid": "SuqnZ6Hiz",
-  "version": 139
+  "version": 140
 }

--- a/k8s/data-processing/deployments/kube-state-metrics.yml
+++ b/k8s/data-processing/deployments/kube-state-metrics.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics

--- a/k8s/data-processing/deployments/kube-state-metrics.yml
+++ b/k8s/data-processing/deployments/kube-state-metrics.yml
@@ -4,6 +4,9 @@ metadata:
   name: kube-state-metrics
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      application: kube-state-metrics
   template:
     metadata:
       labels:

--- a/k8s/data-processing/deployments/prometheus.yml
+++ b/k8s/data-processing/deployments/prometheus.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-server

--- a/k8s/prometheus-federation/deployments/bigquery-exporter.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bigquery-exporter

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: github-receiver

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mlabns-stackdriver

--- a/k8s/prometheus-federation/deployments/pushgateway.yml
+++ b/k8s/prometheus-federation/deployments/pushgateway.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pushgateway-server


### PR DESCRIPTION
Now that DISCOv2 is in production we can start making arrangements to retire snmp_exporter. Before doing that, however, we need to modify any dashboards that are currently using metrics from the snmp_exporter. This PR migrates two dashboards to use DISCOv2 metrics.

For the NDT:EarlyWarning dashboard all that was required was to migrate all the custom recording rules from the prometheus-federation cluster and to change the dashboard's datasources to Platform Cluster ones.

For Ops:SwitchOverview the principle change is adding a `machine=~"mlab2.*"` modifier to all queries. The use of mlab2 is arbitrary, as uplink metrics are collected by all 4 machines at a site. The datasources were also changed from prometheus-federation to Platform Cluster. Two panels were outright removed because they dealt with snmp_exporter scrape times, and pretty soon the snmp_exporter will no longer exist in our clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/746)
<!-- Reviewable:end -->
