### PR TITLE
Converts/updates alerts for collectd to DISCOv2.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -87,26 +87,6 @@ groups:
       description: Check the status of Kubernetes clusters on each M-Lab GCP
         project. Look at the travis deployment history for m-lab/downloader.
 
-  # DISCO is reporting too many errors, which likely means errors when scraping
-  # SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
-  # number of errors should be close to zero.
-  - alert: TooManyDiscoErrors
-    expr: |
-      sum_over_time(disco_collect_errors_total[24h]) > 10
-        and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
-        unless on(site) gmx_site_maintenance == 1
-    for: 12h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: DISCO is reporting too many errors.
-      description: >
-        Maybe the switch is down? Is DISCO using the right community
-        string? Is the IP/prefix of the node where DISCO is running
-        whitelisted on the switch?
-      dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
-
 # More than 20% of the reachable switches are up but not providing SNMP metrics.
   - alert: TooManySnmpMetricsMissing
     expr: |
@@ -1034,6 +1014,26 @@ groups:
         the federation job that scrapes the platform cluster down or
         configured incorrectly.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/
+
+  # DISCO is reporting too many errors, which likely means errors when scraping
+  # SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
+  # number of errors should be close to zero.
+  - alert: PlatformCluster_TooManyDiscoCollectionErrors
+    expr: |
+      increase(disco_collect_errors_total[10m]) > 10
+        unless on(site) gmx_site_maintenance == 1
+    for: 24h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: DISCO is reporting too many errors.
+      description: >
+        Maybe the switch is down? Is DISCO using the right community
+        string? Is the IP/prefix of the node where DISCO is running
+        whitelisted on the switch?
+      dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
+
 
 # Check for missing workloads.
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -108,21 +108,21 @@ groups:
 # SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
 # number of errors should be close to zero.
 - alert: TooManyDiscoErrors
-    expr: |
-      sum_over_time(disco_collect_errors_total[24h]) > 10
-        and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
-        unless on(site) gmx_site_maintenance == 1
-    for: 12h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: DISCO is reporting too many errors.
-      description: >
-        Maybe the switch is down? Is DISCO using the right community
-        string? Is the IP/prefix of the node where DISCO is running
-        whitelisted on the switch?
-      dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
+  expr: |
+    sum_over_time(disco_collect_errors_total[24h]) > 10
+      and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
+      unless on(site) gmx_site_maintenance == 1
+  for: 12h
+  labels:
+    repo: ops-tracker
+    severity: ticket
+  annotations:
+    summary: DISCO is reporting too many errors.
+    description: >
+      Maybe the switch is down? Is DISCO using the right community
+      string? Is the IP/prefix of the node where DISCO is running
+      whitelisted on the switch?
+    dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
 
 # More than 20% of the reachable switches are up but not providing SNMP metrics.
   - alert: TooManySnmpMetricsMissing

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -646,10 +646,8 @@ groups:
         changes in configuration, or underlying system delays.
 
 # Too many NDT S2C tests on a node are being impacted by switch discards.
-# max-by is necessary here since DISCOv2 now collections swith uplink metrics
-# from every machine at a site, so we just take the max of the 3 (mlab[1-3]).
   - alert: DataQuality_TooManyNdtS2cTestsWithDiscards
-    expr: max by (site) ((bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05)
+    expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05
     for: 10m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -87,23 +87,6 @@ groups:
       description: Check the status of Kubernetes clusters on each M-Lab GCP
         project. Look at the travis deployment history for m-lab/downloader.
 
-
-# Some SNMP metrics are missing from Prometheus. These should always be present.
-  - alert: SnmpMetricsMissing
-    expr: absent(ifHCOutOctets)
-    for: 30m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: Expected SNMP metrics are missing from Prometheus.
-      description: >
-        Make sure that the DISCO pod in the platform cluster is properly
-        running on all nodes. Is there a problem with the DISCO DaemonSet? Is
-        the federation job that scrapes the platform cluster down or
-        configured incorrectly.
-      dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/
-
   # DISCO is reporting too many errors, which likely means errors when scraping
   # SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
   # number of errors should be close to zero.
@@ -1035,6 +1018,22 @@ groups:
         forget to increase the value in the bootstrap_prometheus.sh script in
         the k8s-support repository.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/sVklmeHik/prometheus-self-monitoring?orgId=1&var-datasource=Platform%20Cluster%20(mlab-oti)
+
+# Some SNMP metrics are missing from Prometheus. These should always be present.
+  - alert: PlatformCluster_SnmpMetricsMissing
+    expr: absent(ifHCOutOctets)
+    for: 30m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: Expected SNMP metrics are missing from Prometheus.
+      description: >
+        Make sure that the DISCO pod in the platform cluster is properly
+        running on all nodes. Is there a problem with the DISCO DaemonSet? Is
+        the federation job that scrapes the platform cluster down or
+        configured incorrectly.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/
 
 # Check for missing workloads.
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -42,24 +42,21 @@ groups:
 #
 # SwitchSLO
 #
-# A switch at a site has been down for too long and we need to contact the site
-# host or transit provider to investigate. If SNMP scraping *and* pings are both
-# failing for a certain period, then this is probaby a reasonable stand-in as an
-# "up"/"aliveness" check.
-  - alert: SwitchDownAtSite
+# A switch at a site has been unpingable for too long and we need to contact
+# the site host or transit provider to investigate.
+  - alert: SwitchUnpingableAtSite
     expr: |
-      up{job="snmp-targets",site!~".*t$"} == 0
-        and on(site) probe_success{instance=~"s1.*",module="icmp"} == 0
-          unless on(site) gmx_site_maintenance == 1
+      probe_success{instance=~"s1.*",module="icmp"} == 0
+        unless on(site) gmx_site_maintenance == 1
     for: 1d
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: The switch at {{ $labels.site }} has been unreachable for too long.
+      summary: The switch at {{ $labels.site }} has been unpingable for too long.
       description: >
-        The SNMP exporter cannot scrape new metrics from the switch. The issue
-        could be with the switch itself, or with the transit provider.
+        The switch has been unpingable for too long. The problem could be with
+        the switch itself, or with the transit provider.
       dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
 
 # DownloaderIsFailingToUpdate: The downloader hasn't successfully retrieved the files in
@@ -90,43 +87,29 @@ groups:
       description: Check the status of Kubernetes clusters on each M-Lab GCP
         project. Look at the travis deployment history for m-lab/downloader.
 
-# Prometheus is unable to get data from the snmp_exporter service.
-  - alert: SnmpExporterDownOrMissing
-    expr: up{container="snmp-exporter"} == 0 or absent(up{container="snmp-exporter"})
-    for: 10m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: The snmp_exporter service is down or missing.
-      description: Check the status of Kubernetes clusters on each M-Lab GCP
-        project. Look at the travis deployment history for
-        m-lab/prometheus-support.
 
 # Some SNMP metrics are missing from Prometheus. These should always be present.
-# The wait period shouuld be longer than that for the SnmpExporterDownOrMissing
-# alert.
-  - alert: SnmpExporterMissingMetrics
+  - alert: SnmpMetricsMissing
     expr: absent(ifHCOutOctets)
     for: 30m
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: Expected SNMP metrics are missing from Prometheus!
+      summary: Expected SNMP metrics are missing from Prometheus.
       description: >
-        If the snmp_exporter service is running, then there may be a
-        target configuration error. Check the target definitions in GCS[1] and
-        the target status in Prometheus[2].
-
-        [1]: https://console.cloud.google.com/storage/browser/operator-mlab-oti/prometheus/snmp-targets
-        [2]: https://prometheus.mlab-oti.measurementlab.net/targets
+        Make sure that the DISCO pod in the platform cluster is properly
+        running on all nodes. Is there a problem with the DISCO DaemonSet? Is
+        the federation job that scrapes the platform cluster down or
+        configured incorrectly.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/
 
-# Scraping SNMP metrics from a switch is failing.
-  - alert: SnmpScrapingDownAtSite
+# DISCO is reporting too many errors, which likely means errors when scraping
+# SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
+# number of errors should be close to zero.
+- alert: TooManyDiscoErrors
     expr: |
-      up{job="snmp-targets",site!~".*t$"} == 0
+      sum_over_time(disco_collect_errors_total[24h]) > 10
         and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
         unless on(site) gmx_site_maintenance == 1
     for: 12h
@@ -134,11 +117,11 @@ groups:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: Prometheus is unable to scrape SNMP metrics from a switch.
+      summary: DISCO is reporting too many errors.
       description: >
-        Maybe the switch is down? Is the snmp_exporter using the right community
-        string? Look in switch-details.json in the m-lab/switch-config repo. Is
-        the IP of the snmp_exporter VM in GCE whitelisted on the switch?
+        Maybe the switch is down? Is DISCO using the right community
+        string? Is the IP/prefix of the node where DISCO is running
+        whitelisted on the switch?
       dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
 
 # More than 20% of the reachable switches are up but not providing SNMP metrics.
@@ -480,25 +463,6 @@ groups:
         means there is a persistent failure in the underlying service. Please
         check the GAE dashboard and logs to determine the cause.
 
-# If no ndt_ssl traffic has been redirected to the staging instance in the past
-# hour, an alert should fire.
-  - alert: MlabNS_NdtSslReverseProxyNotWorking
-    expr: |
-      sum(sum_over_time(stackdriver_gae_app_logging_googleapis_com_user_reverse_proxy_counter{
-        resource="ndt_ssl"}[1h])) == 0
-    for: 1m
-    labels:
-      repo: dev-tracker
-      severity: ticket
-    annotations:
-      summary: mlab-ns' reverse proxy is not redirecting any ndt_ssl traffic.
-      description: >
-        mlab-ns is supposed to send some of the ndt_ssl traffic to the
-        staging instance, and this has not been happening for the past hour.
-        Please check that the probability set on Google Cloud Datastore is
-        not zero for the ndt_ssl experiment and that there are no errors
-        related to reverse proxying in the mlab-ns logs.
-
 # One or more generic (non-experiment specific) mlab-ns metrics is missing.
 # These are metrics that mlab-ns relies on to determine whether an experiment
 # should receive production traffic, so we need to make sure that the metrics
@@ -567,38 +531,6 @@ groups:
         configuration error. Check the target definitions in GCS and the target
         status in Prometheus[1].
         [1]: https://prometheus.mlab-oti.measurementlab.net/targets#job-blackbox-targets
-
-# The collectd container should be present on the platform-cluster.
-  - alert: PlatformCluster_CoreServices_CollectdMlabMissing
-    expr: |
-      absent(collectd_mlab_success{cluster="platform-cluster"})
-    for: 1h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: A collectd-mlab k8s pod is missing.
-      description: The collectd-mlab service runs in the 'utilization'
-        daemonset on the platform-cluster. Is it deployed?
-
-# A collectd service should always be running.
-  - alert: PlatformCluster_CoreServices_CollectdMlabDown
-    expr: |
-      collectd_mlab_success{cluster="platform-cluster"} == 0
-        unless on(node) gmx_machine_maintenance == 1
-        unless on(node) kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"}
-    for: 1h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: A collectd-mlab k8s pod is down.
-      description: The collectd-mlab service in the 'utilization'
-        daemonset on the platform-cluster is failing. Use `kubectl exec` to
-        investigate the container environment on a failing pod.  Run the check
-        script manually to see what the specific error is
-        (/usr/lib/nagios/plugins/check_collectd_mlab.py). If it works, check
-        cron settings, environment, etc.
 
 # One or more of the backend services handled by the nginx proxy is down.
   - alert: Prometheus_NginxProxiedServiceDown
@@ -751,8 +683,10 @@ groups:
         changes in configuration, or underlying system delays.
 
 # Too many NDT S2C tests on a node are being impacted by switch discards.
+# max-by is necessary here since DISCOv2 now collections swith uplink metrics
+# from every machine at a site, so we just take the max of the 3 (mlab[1-3]).
   - alert: DataQuality_TooManyNdtS2cTestsWithDiscards
-    expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05
+    expr: max by (site) ((bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05)
     for: 10m
     labels:
       repo: ops-tracker
@@ -765,8 +699,10 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/ops-switch-overview
 
 # Too many ifInErrors are occuring each day on a switch uplink for too may days in a row.
+# max-by is necessary here since DISCOv2 now collections swith uplink metrics
+# from every machine at a site, so we just take the max of the 3 (mlab[1-3]).
   - alert: DataQuality_TooManySwitchIfInErrors
-    expr: increase(ifInErrors{ifAlias="uplink"}[1d]) > 100
+    expr: max by (site) (increase(ifInErrors{ifAlias="uplink"}[1d]) > 100)
     for: 7d
     labels:
       repo: ops-tracker
@@ -1101,6 +1037,19 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/sVklmeHik/prometheus-self-monitoring?orgId=1&var-datasource=Platform%20Cluster%20(mlab-oti)
 
 # Check for missing workloads.
+
+  - alert: PlatformCluster_DiscoMissing
+    expr: |
+      absent(up{container="disco", cluster="platform-cluster"})
+    for: 15m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The DISCO DaemonSet is missing or has no metrics.
+      description: The DISCO DaemonSet is missing or has no metrics. Verify
+       that the DaemonSet is healthy (`kubectl describe ds disco`).
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   - alert: PlatformCluster_CadvisorMissing
     expr: absent(up{deployment="cadvisor", cluster="platform-cluster"})

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -104,25 +104,25 @@ groups:
         configured incorrectly.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/
 
-# DISCO is reporting too many errors, which likely means errors when scraping
-# SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
-# number of errors should be close to zero.
-- alert: TooManyDiscoErrors
-  expr: |
-    sum_over_time(disco_collect_errors_total[24h]) > 10
-      and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
-      unless on(site) gmx_site_maintenance == 1
-  for: 12h
-  labels:
-    repo: ops-tracker
-    severity: ticket
-  annotations:
-    summary: DISCO is reporting too many errors.
-    description: >
-      Maybe the switch is down? Is DISCO using the right community
-      string? Is the IP/prefix of the node where DISCO is running
-      whitelisted on the switch?
-    dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
+  # DISCO is reporting too many errors, which likely means errors when scraping
+  # SNMP metrics from the local switch. Since DISCO scrapes across the LAN the
+  # number of errors should be close to zero.
+  - alert: TooManyDiscoErrors
+    expr: |
+      sum_over_time(disco_collect_errors_total[24h]) > 10
+        and on(site) probe_success{instance=~"s1.*",module="icmp"} == 1
+        unless on(site) gmx_site_maintenance == 1
+    for: 12h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: DISCO is reporting too many errors.
+      description: >
+        Maybe the switch is down? Is DISCO using the right community
+        string? Is the IP/prefix of the node where DISCO is running
+        whitelisted on the switch?
+      dashboard: 'https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/?orgId=1&var-site_name={{$labels.site}}'
 
 # More than 20% of the reachable switches are up but not providing SNMP metrics.
   - alert: TooManySnmpMetricsMissing

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -316,6 +316,7 @@ scrape_configs:
       'match[]':
         - 'up{job=~".+"}'
         - 'up{container="disco"}'
+        - 'disco_collect_errors_total'
         - 'ifHCOutOctets{deployment="disco"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter"}'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -315,6 +315,8 @@ scrape_configs:
       # this.
       'match[]':
         - 'up{job=~".+"}'
+        - 'up{container="disco"}'
+        - 'ifHCOutOctets{deployment="disco"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_filesystem_size_bytes{deployment="node-exporter"}'
         - 'node_filesystem_avail_bytes{deployment="node-exporter"}'

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -315,7 +315,6 @@ scrape_configs:
       # this.
       'match[]':
         - 'up{job=~".+"}'
-        - 'up{container="disco"}'
         - 'disco_collect_errors_total'
         - 'ifHCOutOctets{deployment="disco"}'
         - 'lame_duck_experiment{job!="node-exporter"}'


### PR DESCRIPTION
This PR updates, removes and adds various alerts having to do with DISCO and SNMP scraping of switches. Currently, we use snmp_exporter to get switch metrics for use in Prometheus and Grafana. Now that DISCOv2 is deployed to production, and exports all those metrics, we can retire snmp_exporter and start using DISCOv2 metrics. This PR is part of that transition.

Old collectd alerts were removed. One new alert for DISCOv2 was added. Various existing alerts for collectd were modified to be appropriate for DISCOv2.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/747)
<!-- Reviewable:end -->
