### PR TITLE
Updates instructions on setting up the IPv6 monitoring VM.

### DIFF
--- a/IPV6_MONITORING.md
+++ b/IPV6_MONITORING.md
@@ -23,12 +23,14 @@ Below are first-time setup instructions and requirements for the VM:
   found in the M-Lab *shared_data* repository in the *ssh-keys/* directory.
 * Create the file _/etc/docker/daemon.json_ with the following content, and then
   restart Docker (`# systemctl restart docker`):
-```
+
+```json
 {
     "ipv6": true,
     "fixed-cidr-v6": "2600:3c02:e000:0185::/64"
 }
 ```
+
 * Pull the blackbox\_exporter Docker image: `$ docker pull
   prom/blackbox-exporter:v0.12.0`.
 
@@ -40,16 +42,19 @@ Below are first-time setup instructions and requirements for the VM:
   Later, these files will be [pushed to the VM automatically on
   builds](https://github.com/m-lab/prometheus-support/blob/master/deploy_bbe_config.sh)
   of m-lab/prometheus-support repo.
-```
+
+```text
 blackbox-exporter-config-mlab-sandbox.yml
 blackbox-exporter-config-mlab-staging.yml
 blackbox-exporter-config-mlab-oti.yml
 ```
+
 * Instantiate the Docker containers (as the user mlab, `pwd` must be /home/mlab).
   **NOTE**: it is very important to include the `--restart always` flag and argument.
   Without it, if the machine is rebooted or the container crashes, then it won't
   start again automatically.
-```
+
+```shell
 $ docker run --detach --publish 7115:9115 --volume `pwd`:/config \
     --restart always --name mlab-sandbox prom/blackbox-exporter:v0.12.0 \
     --config.file=/config/blackbox-exporter-config-mlab-sandbox.yml
@@ -62,6 +67,7 @@ $ docker run --detach --publish 9115:9115 --volume `pwd`:/config \
     --restart always --name mlab-oti prom/blackbox-exporter:v0.12.0 \
     --config.file=/config/blackbox-exporter-config-mlab-oti.yml
 ```
+
 * Install node\_exporter so that we can scrape metrics from this machine.
 
 $ sudo apt install prometheus-node-exporter

--- a/IPV6_MONITORING.md
+++ b/IPV6_MONITORING.md
@@ -8,55 +8,25 @@ IPv6. Since we are already using Linode.com for a few other things, we deployed
 the VM on Linode.
 
 Any base Linux distribution would probably be just fine, but this deployment is
-using Debian 9.
+using Debian 10.
 
 Below are first-time setup instructions and requirements for the VM:
 
-* Request a `/116` IPv6 pool from Linode by opening a support ticket. In our
-  case, we were given this prefix `2600:3c02::17:d000/116`.
-
-* Through the Linode Manager (Web interface), select the Linode, then select
-  "Edit" for the configuration profile in use. Disable `Auto-Configure
-  Networking`.
-
+* Request a `/64` IPv6 pool from Linode by opening a support ticket. In our
+  case, we were given this prefix `2600:3c02:e000:0185::/64`.
 * [Install Docker](https://docs.docker.com/install/linux/docker-ce/debian/),
   since the blackbox\_exporter will be running in a Docker container.
-
 * Create a new user named "mlab" (`# adduser mlab`) and it to the group `docker`
   (`# adduser mlab docker`).
-
 * Add the public SSH key for the Travis deployer to mlab's
   *~/.ssh/authorized_keys* file. The public key, and the private one, can be
   found in the M-Lab *shared_data* repository in the *ssh-keys/* directory.
-
-* [Enable NDP
-  proxying](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/#using-ndp-proxying)
-  for the `eth0` interface: `# sysctl net.ipv6.conf.eth0.proxy_ndp=1`. Add this
-  to _/etc/sysctl.conf_ to persist the change across reboots. **NOTE**: Having
-  to enable NDP proxying is a consequence of using a `/116` IPv6 prefix. If we
-  were using a fully routable `/64` prefix, this wouldn't be necessary.
-
-* Configure IPv6 for the `eth0` interface in _/etc/network/interfaces_ using the
-  prefix we got. We are going to subnet our prefix into two subnets, one for the
-  VM and one for Docker containers. After this change, restart networking (`#
-  systemctl restart networking`). 
-
-```
-iface eth0 inet6 static
-    address 2600:3c02::17:d001/117 
-    gateway fe80::1
-    # These are the IPs of the three Docker containers.
-    post-up ip -6 neigh add proxy 2600:3c02::17:d802 dev eth0
-    post-up ip -6 neigh add proxy 2600:3c02::17:d803 dev eth0
-    post-up ip -6 neigh add proxy 2600:3c02::17:d804 dev eth0
-```
 * Create the file _/etc/docker/daemon.json_ with the following content, and then
   restart Docker (`# systemctl restart docker`):
-
 ```
 {
     "ipv6": true,
-    "fixed-cidr-v6": "2600:3c02::17:d800/117"
+    "fixed-cidr-v6": "2600:3c02:e000:0185::/64"
 }
 ```
 * Pull the blackbox\_exporter Docker image: `$ docker pull


### PR DESCRIPTION
Linode will soon no longer support /116 IPv6 prefixes in their Atlanta datacenter. We have to migrate to a /64, which turns out to be much easier to configure... just give the whole prefix to Docker. This PR updates the readme file for setting up the IPv6 monitoring VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/748)
<!-- Reviewable:end -->
