### PR TITLE
Fixes the NodeNotReady alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1141,15 +1141,13 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   # If any node is NotReady for too long, fire an alert, unless the node is in
-  # lame-duck mode, GMX maintenance mode, or the scrape job for the entire node
-  # is down.
+  # lame-duck or GMX maintenance mode.
   - alert: PlatformCluster_NodeNotReady
     expr: |
       kube_node_status_condition{cluster="platform-cluster", condition="Ready", status="false"} == 1
         unless on(node) (
           kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} or
-          gmx_machine_maintenance == 1 or
-          up{job="kubernetes-nodes", cluster="platform-cluster"} == 0
+          gmx_machine_maintenance == 1
         )
     for: 1h
     labels:


### PR DESCRIPTION
Today I discovered that mlab3-bcn01 has been down for a week or so, and we didn't know about it. We have a `PlatformCluster_NodeNotReady` alert that is supposed to alert of us these things, but it didn't. I can't recall why now, but when I originally wrote the alert I added an exception for when "the scrape job for the entire node is down". For mlab3-bcn01, we didn't get an alert because the scrape job for the entire node was down, because the layer2 link to the switch is down. We need to know about these conditions. This PR modifies the alert removing the condition that the scrape job to the node be up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/750)
<!-- Reviewable:end -->
