### PR TITLE
Adds NDT7 test results to bq_ndt_s2c.sql query

### DIFF
--- a/config/federation/bigquery/bq_ndt_s2c.sql
+++ b/config/federation/bigquery/bq_ndt_s2c.sql
@@ -1,36 +1,23 @@
 #standardSQL
--- bq_ndt_discards returns the number NDT S2C tests with a time window that
--- overlaps with a switch utilization time windows in which there were a
--- non-zero number of uplink discards measured. DISCO polls switch SNMP data
--- every 10s. For every 10s SNMP data polling interval, if discards were
--- observed, then this query looks for all NDT S2C test with a start or end
--- time equivalent to the start or end time of the SNMP polling interval, or an
--- NDT S2C start or end time that falls within the SNMP polling interval.
--- For faster queries we use `partition_date` boundaries. And, to
--- guarantee the partition_date data is "complete" (all data collected
--- and parsed) we should wait 42 hours after start of a given day.
--- The following is equivalent to the pseudo code:
---     date(now() - 18h) - 1d
-CREATE TEMPORARY FUNCTION queryDate() AS (
-  DATE(
-    TIMESTAMP_SUB(
-      TIMESTAMP_TRUNC(
-        TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 18 HOUR),
-        DAY),
-      INTERVAL 24 HOUR
-    )
-  )
-);
-
--- Takes ParseInfo.TaskFileName and returns an M-Lab hostname.
-CREATE TEMPORARY FUNCTION toNodeName(tfn STRING) AS (
-  CONCAT(
-    REGEXP_EXTRACT(tfn, r'(mlab[1-4])-[a-z]{3}[0-9]{2}.*'), "-",
-    REGEXP_EXTRACT(tfn, r'mlab[1-4]-([a-z]{3}[0-9]{2}).*')
-  )
-);
-
-WITH disco_intervals_with_discards AS (
+  -- bq_ndt_discards returns the number NDT S2C tests with a time window that
+  -- overlaps with a switch utilization time windows in which there were a
+  -- non-zero number of uplink discards measured. DISCO polls switch SNMP data
+  -- every 10s. For every 10s SNMP data polling interval, if discards were
+  -- observed, then this query looks for all NDT S2C test with a start or end
+  -- time equivalent to the start or end time of the SNMP polling interval, or an
+  -- NDT S2C start or end time that falls within the SNMP polling interval.
+  -- For faster queries we use `partition_date` boundaries. And, to
+  -- guarantee the partition_date data is "complete" (all data collected
+    -- and parsed) we should wait 42 hours after start of a given day.
+  -- The following is equivalent to the pseudo code:
+  --     date(now() - 18h) - 1d
+CREATE TEMPORARY FUNCTION
+  queryDATE() AS ( DATE( TIMESTAMP_SUB( TIMESTAMP_TRUNC( TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 18 HOUR), DAY), INTERVAL 24 HOUR ) ) );
+  -- Takes ParseInfo.TaskFileName and returns an M-Lab hostname.
+CREATE TEMPORARY FUNCTION
+  toNodeName(tfn STRING) AS ( CONCAT( REGEXP_EXTRACT(tfn, r'(mlab[1-4])-[a-z]{3}[0-9]{2}.*'), "-", REGEXP_EXTRACT(tfn, r'mlab[1-4]-([a-z]{3}[0-9]{2}).*') ) );
+WITH
+  disco_intervals_with_discards AS (
   SELECT
     toNodeName(hostname) AS node,
     TIMESTAMP_SUB(sample.timestamp, INTERVAL 10 SECOND) AS tstart,
@@ -40,7 +27,7 @@ WITH disco_intervals_with_discards AS (
     `measurement-lab.utilization.switch`,
     UNNEST(sample) AS sample
   WHERE
-    partition_date = queryDate()
+    partition_date = queryDATE()
     AND metric = 'switch.discards.uplink.tx'
   GROUP BY
     hostname,
@@ -48,8 +35,8 @@ WITH disco_intervals_with_discards AS (
     tend,
     discards
   HAVING
-    discards > 0
-), ndt_s2c_tests AS (
+    discards > 0 ),
+  ndt_s2c_tests AS (
   SELECT
     toNodeName(ParseInfo.TaskFileName) AS node,
     result.S2C.UUID AS s2c_uuid,
@@ -58,7 +45,7 @@ WITH disco_intervals_with_discards AS (
   FROM
     `measurement-lab.ndt.ndt5`
   WHERE
-    partition_date = queryDate()
+    partition_date = queryDATE()
     AND result.S2C.UUID IS NOT NULL
     AND result.S2C.UUID != "ERROR_DISCOVERING_UUID"
   GROUP BY
@@ -66,7 +53,24 @@ WITH disco_intervals_with_discards AS (
     s2c_uuid,
     tstart,
     tend
-), ndt_s2c_tests_with_discards AS (
+  UNION ALL
+  SELECT
+    CONCAT(server.Machine, "-", server.Site) AS node,
+    raw.Download.UUID AS s2c_uuid,
+    raw.Download.StartTime AS tstart,
+    raw.Download.EndTime AS tend
+  FROM
+    `measurement-lab.ndt.ndt7`
+  WHERE
+    date = queryDATE()
+    AND raw.Download.UUID IS NOT NULL
+    AND raw.Download.UUID != "ERROR_DISCOVERING_UUID"
+  GROUP BY
+    node,
+    s2c_uuid,
+    tstart,
+    tend ),
+  ndt_s2c_tests_with_discards AS (
   SELECT
     ndt_s2c_tests.s2c_uuid AS s2c_uuid,
     SUM(disco_intervals_with_discards.discards) AS discards
@@ -77,13 +81,13 @@ WITH disco_intervals_with_discards AS (
   ON
     (ndt_s2c_tests.node = disco_intervals_with_discards.node
       AND (disco_intervals_with_discards.tstart = ndt_s2c_tests.tstart
-        OR ndt_s2c_tests.tstart BETWEEN disco_intervals_with_discards.tstart AND disco_intervals_with_discards.tend
+        OR ndt_s2c_tests.tstart BETWEEN disco_intervals_with_discards.tstart
+        AND disco_intervals_with_discards.tend
         OR disco_intervals_with_discards.tend = ndt_s2c_tests.tend
-        OR ndt_s2c_tests.tend BETWEEN disco_intervals_with_discards.tstart AND disco_intervals_with_discards.tend))
+        OR ndt_s2c_tests.tend BETWEEN disco_intervals_with_discards.tstart
+        AND disco_intervals_with_discards.tend))
   GROUP BY
-    s2c_uuid
-)
-
+    s2c_uuid )
 SELECT
   metro,
   site,
@@ -98,14 +102,34 @@ FROM (
     toNodeName(ParseInfo.TaskFileName) AS node,
     CASE
       WHEN result.S2C.UUID IN ( SELECT s2c_uuid FROM ndt_s2c_tests_with_discards) THEN 'true'
-      ELSE 'false'
-    END AS discards
+    ELSE
+    'false'
+  END
+    AS discards
   FROM
     `measurement-lab.ndt.ndt5`
   WHERE
-    partition_date = queryDate()
+    partition_date = queryDATE()
     AND result.S2C.UUID IS NOT NULL
-    AND result.S2C.UUID != "ERROR_DISCOVERING_UUID")
+    AND result.S2C.UUID != "ERROR_DISCOVERING_UUID"
+  UNION ALL
+  SELECT
+    raw.Download.UUID AS s2c_uuid,
+    REGEXP_EXTRACT(server.Site, r'([a-z]{3})[0-9]{2}') AS metro,
+    server.Site AS site,
+    CONCAT(server.Machine, "-", server.Site) AS node,
+    CASE
+      WHEN raw.Download.UUID IN ( SELECT s2c_uuid FROM ndt_s2c_tests_with_discards) THEN 'true'
+    ELSE
+    'false'
+  END
+    AS discards
+  FROM
+    `measurement-lab.ndt.ndt7`
+  WHERE
+    date = queryDATE()
+    AND raw.Download.UUID IS NOT NULL
+    AND raw.Download.UUID != "ERROR_DISCOVERING_UUID")
 GROUP BY
   metro,
   site,

--- a/config/federation/bigquery/bq_ndt_s2c.sql
+++ b/config/federation/bigquery/bq_ndt_s2c.sql
@@ -8,7 +8,7 @@
   -- NDT S2C start or end time that falls within the SNMP polling interval.
   -- For faster queries we use `partition_date` boundaries. And, to
   -- guarantee the partition_date data is "complete" (all data collected
-    -- and parsed) we should wait 42 hours after start of a given day.
+  -- and parsed) we should wait 42 hours after start of a given day.
   -- The following is equivalent to the pseudo code:
   --     date(now() - 18h) - 1d
 CREATE TEMPORARY FUNCTION


### PR DESCRIPTION
Currently, the bigquery-exporter query used for detecting NDT download test that may have been coincident with switch discards only looks at NDT5 tests. This is a problem, since the vast majority of NDT tests against the platform are NDT7 (from Onebox). This PR adds NDT7 test results to the query.

_NOTE_: some of the changes in this PR are the result of me using the auto-format feature in the BigQuery Web UI. However, the principal changes (`UNION ALL` query additions) should be pretty easy to pick out.

This PR is intended to resolve #749.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/752)
<!-- Reviewable:end -->
