### PR TITLE
Fixes NodeNotReady alert to also consider a status of 'unknown'

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1126,7 +1126,7 @@ groups:
   # lame-duck or GMX maintenance mode.
   - alert: PlatformCluster_NodeNotReady
     expr: |
-      kube_node_status_condition{cluster="platform-cluster", condition="Ready", status="false"} == 1
+      kube_node_status_condition{cluster="platform-cluster", condition="Ready", status=~"(false|unknown)"} == 1
         unless on(node) (
           kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} or
           gmx_machine_maintenance == 1


### PR DESCRIPTION
I thought that the recent PR #750 fixed the `NodeNotReady` alert, but it didn't. It fixed one deficiency, but I just discovered another... that in many (probably most) cases the `status` label for down nodes will be `unknown`, not `false`. This PR causes the alert to consider either status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/754)
<!-- Reviewable:end -->
