### PR TITLE
Adds new stackdriver-exporter deployment for projects.

### DIFF
--- a/k8s/prometheus-federation/deployments/stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/stackdriver.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stackdriver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: stackdriver
+  template:
+    metadata:
+      labels:
+        run: stackdriver
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        prometheus-node: 'true'
+      containers:
+      - name: stackdriver
+        image: prometheuscommunity/stackdriver-exporter:v0.11.0
+        args: [
+          # Metrics are available with some delay, so look 5 minutes in the past.
+          "--monitoring.metrics-offset=5m",
+          # Prometheus scrapes every minute, so look at a 1 minute window.
+          "--monitoring.metrics-interval=1m",
+          "--google.project-id={{GCLOUD_PROJECT}}",
+          # Metrics are gauges, representing counts over the sampled interval.
+          "--monitoring.metrics-type-prefixes=logging.googleapis.com/user",
+          "--web.listen-address=:9256"
+        ]
+        ports:
+        - containerPort: 9256


### PR DESCRIPTION
The Vector DaemonSet in the platform cluster is now pushing kernel log messages to Google Logging. I have created new log-based metrics named `platform_cluster_kernel_logs` in each project. This PR deploys a new stackdriver-exporter Deployment to prometheus-federation that will scrape all user-defined metrics. In the future it could scrape other things, but for now it is only scraping this one thing.

_NOTE_: There is already another stackdriver-exporter Deployment in prometheus-federation named `mlabns-stackdriver`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/763)
<!-- Reviewable:end -->
