### PR TITLE
Explicitly set -reboot.bmcport for reboot-service

### DIFF
--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -20,6 +20,7 @@ spec:
         args:
           - "-datastore.project={{GCLOUD_PROJECT}}"
           - "-reboot.key=/var/secrets/reboot-api-ssh.key"
+          - "-reboot.bmcport=22"
           - "-auth.username={{REBOOTAPI_USER}}"
           - "-auth.password={{REBOOTAPI_PASS}}"
         volumeMounts:


### PR DESCRIPTION
This PR explicitly sets the `-reboot.bmcport` command-line flag for the reboot-service container.
This change is related to fully automating the DRAC configuration during stage1/2 (https://github.com/m-lab/epoxy/issues/94)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/764)
<!-- Reviewable:end -->
