### PR TITLE
Change BMC_CredentialsNotFound to only fire after 1h

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1508,7 +1508,7 @@ groups:
     expr: |
         reboot_e2e_result{status="credentials_not_found"}
         unless on(machine) gmx_machine_maintenance == 1
-    for: 5m
+    for: 1h
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
The E2E test results are cached for an hour. If credentials are created and then the site is immediately taken out of GMX, this alert would fire because credentials weren't there when the last check happened, then clear itself at the next check.

By requiring that the condition is true for `1h` before the alert fires we prevent this.

Not sure if this also closes https://github.com/m-lab/reboot-service/issues/40 as it's a workaround. @nkinkade what do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/767)
<!-- Reviewable:end -->
