### PR TITLE
Bump reboot-api to v0.6.0

### DIFF
--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: reboot-api
-        image: measurementlab/reboot-api:v0.5.2
+        image: measurementlab/reboot-api:v0.6.0
         args:
           - "-datastore.project={{GCLOUD_PROJECT}}"
           - "-reboot.key=/var/secrets/reboot-api-ssh.key"


### PR DESCRIPTION
This PR updates reboot-api to v0.6.0, which supports the `keyboard-interactive` SSH authentication method. This version hasn't been tagged yet, but will be in a while. I'll make sure to merge it only after reboot-api:v0.6.0 becomes available on Docker Hub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/768)
<!-- Reviewable:end -->
