### PR TITLE
Updates Grafana and limits Google OAuth login to measurementlab.net and google.com

### DIFF
--- a/config/federation/grafana/grafana.ini
+++ b/config/federation/grafana/grafana.ini
@@ -208,6 +208,7 @@ disable_login_form = true
 [auth.google]
 enabled = true
 allow_sign_up = true
+allowed_domains = measurementlab.net google.com
 ;client_id = <set via environment variable: GF_AUTH_GOOGLE_CLIENT_ID>
 ;client_secret = <set via environment variable: GF_AUTH_GOOGLE_CLIENT_SECRET>
 scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -36,7 +36,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:6.4.5
+      - image: grafana/grafana:7.3.5
         name: grafana-server
         # NOTE: the official Grafana Docker images may set various environment
         # variables which will override configurations in grafana.ini (which is


### PR DESCRIPTION
Currently, anyone with a Google account can login to our Grafana instance. This PR limits the Google account domains to `measurementlab.net` and `google.com`. It also updates Grafana to essentially the latest version.

I verified that the login restriction is minimally working by trying to login with a personal Gmail account and got:

![Screenshot from 2021-01-08 14-57-09](https://user-images.githubusercontent.com/1392825/104069022-9a599700-51c2-11eb-80a8-a78eb97fa40c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/772)
<!-- Reviewable:end -->
