### PR TITLE
Limits MachineRunningWithoutK8sNode to only ssh IPv4 probes.

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -176,7 +176,8 @@ groups:
   # Blackbox exporter probes to a machine are succeeding to a node that
   # kubernetes does not know about (not joined to the k8s cluster).
   - alert: MachineRunningWithoutK8sNode
-    expr: probe_success{service="ssh"} == 1 unless on(machine) kube_node_status_condition
+    expr: probe_success{service="ssh", module="ssh_v4_online"} == 1
+            unless on(machine) kube_node_status_condition
             unless on(machine) gmx_machine_maintenance == 1
     for: 1h
     labels:


### PR DESCRIPTION
Limits query to only use the `ssh_v4_online` probe to eliminate duplicate results for both IPv4 and IPv6 probes, making the problem seem worse than it is (by double). This should cause the query to only ever return a single result per node where the problem exists, instead of 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/773)
<!-- Reviewable:end -->
