### PR TITLE
Add trailing . for DNS lookups by blackbox exporter targets

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -494,6 +494,7 @@ scrape_configs:
       # The default __address__ value is a target host from the config file.
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
       # host value. NOTE: we also insert a trailing "." to optimize DNS lookup.
+      # NOTE: all address ports must be specified explicitly.
       - source_labels: [__address__]
         regex: (.*)(:.*)
         target_label: __param_target

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -507,14 +507,13 @@ scrape_configs:
         target_label: __param_module
         replacement: ${1}
 
-      # Use the target parameter defined above and use it to define the
-      # "instance" label.
+      # Use the original target __address__ to define the "instance" label.
       - source_labels: [__address__]
         regex: (.*)
         target_label: instance
         replacement: ${1}
 
-      # Since __address__ is the target that prometheus will contact,
+      # Since __address__ is the target that prometheus scrapes,
       # unconditionally reset the __address__ label to the blackbox exporter
       # address.
       - source_labels: []

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -491,31 +491,13 @@ scrape_configs:
     # supported configuration: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
 
-      # Create static default port.
-      - source_labels: []
-        regex: .*
-        target_label: __tmp_port
-        replacement: 80
-      # Extract actual port. If there is no :(.*) pattern, use default value.
-      - source_labels: [__address__]
-        regex: .*:(.*)
-        target_label: __tmp_port
-        replacement: ${1}
-      # Extract the host. Note: the replacement value includes a trailing "." to
-      # optimize DNS lookup.
-      - source_labels: [__address__]
-        regex: (.*)(:.*)?
-        target_label: __tmp_host
-        replacement: ${1}.
-
       # The default __address__ value is a target host from the config file.
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
-      # host value.
-      - source_labels: [__tmp_host, __tmp_port]
-        separator: ":"
-        regex: .*
+      # host value. NOTE: we also insert a trailing "." to optimize DNS lookup.
+      - source_labels: [__address__]
+        regex: (.*)(:.*)
         target_label: __param_target
-        replacement: ${1}
+        replacement: ${1}.${2}
 
       # Use the "module" label defined in the input file as the module name for
       # the blackbox exporter request.
@@ -526,7 +508,7 @@ scrape_configs:
 
       # Use the target parameter defined above and use it to define the
       # "instance" label.
-      - source_labels: [__param_target]
+      - source_labels: [__address__]
         regex: (.*)
         target_label: instance
         replacement: ${1}

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -512,7 +512,7 @@ scrape_configs:
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
       # host value.
       - source_labels: [__tmp_host, __tmp_port]
-        separator: :
+        separator: ":"
         regex: .*
         target_label: __param_target
         replacement: ${1}

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -491,11 +491,29 @@ scrape_configs:
     # supported configuration: https://github.com/prometheus/blackbox_exporter
     relabel_configs:
 
+      # Create static default port.
+      - source_labels: []
+        regex: .*
+        target_label: __tmp_port
+        replacement: 80
+      # Extract actual port. If there is no :(.*) pattern, use default value.
+      - source_labels: [__address__]
+        regex: .*:(.*)
+        target_label: __tmp_port
+        replacement: ${1}
+      # Extract the host. Note: the replacement value includes a trailing "." to
+      # optimize DNS lookup.
+      - source_labels: [__address__]
+        regex: (.*)(:.*)?
+        target_label: __tmp_host
+        replacement: ${1}.
+
       # The default __address__ value is a target host from the config file.
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
       # host value.
-      - source_labels: [__address__]
-        regex: (.*)(:80)?
+      - source_labels: [__tmp_host, __tmp_port]
+        separator: :
+        regex: .*
         target_label: __param_target
         replacement: ${1}
 


### PR DESCRIPTION
This change updates the blackbox exporter relabel_config rules to create "target=" parameters that include hostnames with a trailing "." to optimize DNS lookups within GKE.

This change only modifies the target parameter sent to the blackbox exporter and preserves all other labels used on prometheus metrics. There should be no observable change to metrics.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/774)
<!-- Reviewable:end -->
