### PR TITLE
Add wehe dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Wehe_access_envelope.json
+++ b/config/federation/grafana/dashboards/Wehe_access_envelope.json
@@ -1,0 +1,1754 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": 248,
+  "iteration": 1611602682275,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "content": "# Wehe\n\nWehe is deployed with the Access Envelope.\nClients connect to the access envelope before the Wehe server.\nOn success, new files are written to disk and collected by pusher.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.3.5",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 3
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(envelope_requests_total{container=\"access\", status=\"success\"}[2m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "envelope requests open",
+          "refId": "B"
+        },
+        {
+          "expr": " sum(increase(replay_count_total[2m]))\n",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "replay server counts",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(replay_erros_total[2m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "replay server errors",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Global Envelope Opens and Replay Counts by Wehe Server",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 3
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(envelope_requests_total{container=\"access\", status=\"success\"}[2m])) / sum(rate(envelope_requests_total{container=\"access\"}[2m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "envelope requests open",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Global Envelope Success Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(pusher_files_added_total{datatype=~\"replay\", deployment=~\"wehe\"}[2m]))",
+          "hide": false,
+          "interval": "10m",
+          "legendFormat": "{{metro}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Test Files",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by(site) (label_replace(increase(envelope_requests_total{container=\"access\", status=\"success\"}[2m]), \"site\", \"$1\", \"machine\", \"mlab[1-4]-([a-z]{3}).*\"))",
+          "interval": "",
+          "legendFormat": "{{site}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Successful Envelope Opens By Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10, sum by(status, site) (label_replace(increase(envelope_requests_total{container=\"access\", status!=\"success\"}[2m]), \"site\", \"$1\", \"machine\", \"mlab[1-4]-([a-z]{3}).*\")))",
+          "interval": "",
+          "legendFormat": "{{site}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Envelope Errors By Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by(metro) (label_replace(increase(pusher_files_added_total{datatype=~\"replay\", deployment=~\"wehe\"}[2m]), \"metro\", \"$1\", \"machine\", \"mlab[1-4]-([a-z]{3}).*\"))",
+          "hide": false,
+          "interval": "10m",
+          "legendFormat": "{{metro}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Test Files by Location",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": " sum by(name) (increase(replay_count_total[2m]))\n",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(increase(replay_erros_total[2m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "replay server errors",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Global Wehe Server Replays by Name",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by(status) (increase(envelope_requests_total{container=\"access\", status!=\"success\"}[2m]))",
+          "interval": "",
+          "legendFormat": "{{status}} -- {{request}} -- {{site}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Envelope Errors By Kind",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "ops / min",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
+        },
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/Platform Cluster/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "akl01",
+          "value": "akl01"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(machine)",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "TODO(Site)",
+        "multi": false,
+        "name": "site",
+        "options": [
+          {
+            "selected": true,
+            "text": "akl01",
+            "value": "akl01"
+          },
+          {
+            "selected": false,
+            "text": "ams03",
+            "value": "ams03"
+          },
+          {
+            "selected": false,
+            "text": "ams04",
+            "value": "ams04"
+          },
+          {
+            "selected": false,
+            "text": "ams05",
+            "value": "ams05"
+          },
+          {
+            "selected": false,
+            "text": "ams08",
+            "value": "ams08"
+          },
+          {
+            "selected": false,
+            "text": "ams09",
+            "value": "ams09"
+          },
+          {
+            "selected": false,
+            "text": "arn02",
+            "value": "arn02"
+          },
+          {
+            "selected": false,
+            "text": "arn03",
+            "value": "arn03"
+          },
+          {
+            "selected": false,
+            "text": "arn04",
+            "value": "arn04"
+          },
+          {
+            "selected": false,
+            "text": "arn05",
+            "value": "arn05"
+          },
+          {
+            "selected": false,
+            "text": "arn06",
+            "value": "arn06"
+          },
+          {
+            "selected": false,
+            "text": "ath03",
+            "value": "ath03"
+          },
+          {
+            "selected": false,
+            "text": "atl02",
+            "value": "atl02"
+          },
+          {
+            "selected": false,
+            "text": "atl03",
+            "value": "atl03"
+          },
+          {
+            "selected": false,
+            "text": "atl04",
+            "value": "atl04"
+          },
+          {
+            "selected": false,
+            "text": "atl07",
+            "value": "atl07"
+          },
+          {
+            "selected": false,
+            "text": "atl08",
+            "value": "atl08"
+          },
+          {
+            "selected": false,
+            "text": "bcn01",
+            "value": "bcn01"
+          },
+          {
+            "selected": false,
+            "text": "beg01",
+            "value": "beg01"
+          },
+          {
+            "selected": false,
+            "text": "bog02",
+            "value": "bog02"
+          },
+          {
+            "selected": false,
+            "text": "bog03",
+            "value": "bog03"
+          },
+          {
+            "selected": false,
+            "text": "bog04",
+            "value": "bog04"
+          },
+          {
+            "selected": false,
+            "text": "bog05",
+            "value": "bog05"
+          },
+          {
+            "selected": false,
+            "text": "bom01",
+            "value": "bom01"
+          },
+          {
+            "selected": false,
+            "text": "bom02",
+            "value": "bom02"
+          },
+          {
+            "selected": false,
+            "text": "bru01",
+            "value": "bru01"
+          },
+          {
+            "selected": false,
+            "text": "bru02",
+            "value": "bru02"
+          },
+          {
+            "selected": false,
+            "text": "bru03",
+            "value": "bru03"
+          },
+          {
+            "selected": false,
+            "text": "bru04",
+            "value": "bru04"
+          },
+          {
+            "selected": false,
+            "text": "bru05",
+            "value": "bru05"
+          },
+          {
+            "selected": false,
+            "text": "cpt01",
+            "value": "cpt01"
+          },
+          {
+            "selected": false,
+            "text": "del01",
+            "value": "del01"
+          },
+          {
+            "selected": false,
+            "text": "del02",
+            "value": "del02"
+          },
+          {
+            "selected": false,
+            "text": "den02",
+            "value": "den02"
+          },
+          {
+            "selected": false,
+            "text": "den04",
+            "value": "den04"
+          },
+          {
+            "selected": false,
+            "text": "den05",
+            "value": "den05"
+          },
+          {
+            "selected": false,
+            "text": "den06",
+            "value": "den06"
+          },
+          {
+            "selected": false,
+            "text": "dfw02",
+            "value": "dfw02"
+          },
+          {
+            "selected": false,
+            "text": "dfw03",
+            "value": "dfw03"
+          },
+          {
+            "selected": false,
+            "text": "dfw05",
+            "value": "dfw05"
+          },
+          {
+            "selected": false,
+            "text": "dfw07",
+            "value": "dfw07"
+          },
+          {
+            "selected": false,
+            "text": "dfw08",
+            "value": "dfw08"
+          },
+          {
+            "selected": false,
+            "text": "dub01",
+            "value": "dub01"
+          },
+          {
+            "selected": false,
+            "text": "fln01",
+            "value": "fln01"
+          },
+          {
+            "selected": false,
+            "text": "fra01",
+            "value": "fra01"
+          },
+          {
+            "selected": false,
+            "text": "fra02",
+            "value": "fra02"
+          },
+          {
+            "selected": false,
+            "text": "fra03",
+            "value": "fra03"
+          },
+          {
+            "selected": false,
+            "text": "fra04",
+            "value": "fra04"
+          },
+          {
+            "selected": false,
+            "text": "fra05",
+            "value": "fra05"
+          },
+          {
+            "selected": false,
+            "text": "fra06",
+            "value": "fra06"
+          },
+          {
+            "selected": false,
+            "text": "gig01",
+            "value": "gig01"
+          },
+          {
+            "selected": false,
+            "text": "gig02",
+            "value": "gig02"
+          },
+          {
+            "selected": false,
+            "text": "gig03",
+            "value": "gig03"
+          },
+          {
+            "selected": false,
+            "text": "gig04",
+            "value": "gig04"
+          },
+          {
+            "selected": false,
+            "text": "gru01",
+            "value": "gru01"
+          },
+          {
+            "selected": false,
+            "text": "gru02",
+            "value": "gru02"
+          },
+          {
+            "selected": false,
+            "text": "gru03",
+            "value": "gru03"
+          },
+          {
+            "selected": false,
+            "text": "gru04",
+            "value": "gru04"
+          },
+          {
+            "selected": false,
+            "text": "ham02",
+            "value": "ham02"
+          },
+          {
+            "selected": false,
+            "text": "hkg01",
+            "value": "hkg01"
+          },
+          {
+            "selected": false,
+            "text": "hkg02",
+            "value": "hkg02"
+          },
+          {
+            "selected": false,
+            "text": "hnd01",
+            "value": "hnd01"
+          },
+          {
+            "selected": false,
+            "text": "hnd02",
+            "value": "hnd02"
+          },
+          {
+            "selected": false,
+            "text": "hnd03",
+            "value": "hnd03"
+          },
+          {
+            "selected": false,
+            "text": "hnd04",
+            "value": "hnd04"
+          },
+          {
+            "selected": false,
+            "text": "hnd05",
+            "value": "hnd05"
+          },
+          {
+            "selected": false,
+            "text": "iad02",
+            "value": "iad02"
+          },
+          {
+            "selected": false,
+            "text": "iad03",
+            "value": "iad03"
+          },
+          {
+            "selected": false,
+            "text": "iad04",
+            "value": "iad04"
+          },
+          {
+            "selected": false,
+            "text": "iad05",
+            "value": "iad05"
+          },
+          {
+            "selected": false,
+            "text": "iad06",
+            "value": "iad06"
+          },
+          {
+            "selected": false,
+            "text": "jnb01",
+            "value": "jnb01"
+          },
+          {
+            "selected": false,
+            "text": "lax02",
+            "value": "lax02"
+          },
+          {
+            "selected": false,
+            "text": "lax03",
+            "value": "lax03"
+          },
+          {
+            "selected": false,
+            "text": "lax04",
+            "value": "lax04"
+          },
+          {
+            "selected": false,
+            "text": "lax05",
+            "value": "lax05"
+          },
+          {
+            "selected": false,
+            "text": "lax06",
+            "value": "lax06"
+          },
+          {
+            "selected": false,
+            "text": "lga03",
+            "value": "lga03"
+          },
+          {
+            "selected": false,
+            "text": "lga04",
+            "value": "lga04"
+          },
+          {
+            "selected": false,
+            "text": "lga05",
+            "value": "lga05"
+          },
+          {
+            "selected": false,
+            "text": "lga06",
+            "value": "lga06"
+          },
+          {
+            "selected": false,
+            "text": "lga08",
+            "value": "lga08"
+          },
+          {
+            "selected": false,
+            "text": "lhr02",
+            "value": "lhr02"
+          },
+          {
+            "selected": false,
+            "text": "lhr03",
+            "value": "lhr03"
+          },
+          {
+            "selected": false,
+            "text": "lhr04",
+            "value": "lhr04"
+          },
+          {
+            "selected": false,
+            "text": "lhr05",
+            "value": "lhr05"
+          },
+          {
+            "selected": false,
+            "text": "lhr06",
+            "value": "lhr06"
+          },
+          {
+            "selected": false,
+            "text": "lhr07",
+            "value": "lhr07"
+          },
+          {
+            "selected": false,
+            "text": "lhr08",
+            "value": "lhr08"
+          },
+          {
+            "selected": false,
+            "text": "lis01",
+            "value": "lis01"
+          },
+          {
+            "selected": false,
+            "text": "lis02",
+            "value": "lis02"
+          },
+          {
+            "selected": false,
+            "text": "lis03",
+            "value": "lis03"
+          },
+          {
+            "selected": false,
+            "text": "lju01",
+            "value": "lju01"
+          },
+          {
+            "selected": false,
+            "text": "los02",
+            "value": "los02"
+          },
+          {
+            "selected": false,
+            "text": "maa01",
+            "value": "maa01"
+          },
+          {
+            "selected": false,
+            "text": "maa02",
+            "value": "maa02"
+          },
+          {
+            "selected": false,
+            "text": "mad02",
+            "value": "mad02"
+          },
+          {
+            "selected": false,
+            "text": "mad03",
+            "value": "mad03"
+          },
+          {
+            "selected": false,
+            "text": "mad04",
+            "value": "mad04"
+          },
+          {
+            "selected": false,
+            "text": "mad05",
+            "value": "mad05"
+          },
+          {
+            "selected": false,
+            "text": "mad06",
+            "value": "mad06"
+          },
+          {
+            "selected": false,
+            "text": "mex01",
+            "value": "mex01"
+          },
+          {
+            "selected": false,
+            "text": "mex02",
+            "value": "mex02"
+          },
+          {
+            "selected": false,
+            "text": "mia02",
+            "value": "mia02"
+          },
+          {
+            "selected": false,
+            "text": "mia03",
+            "value": "mia03"
+          },
+          {
+            "selected": false,
+            "text": "mia04",
+            "value": "mia04"
+          },
+          {
+            "selected": false,
+            "text": "mia05",
+            "value": "mia05"
+          },
+          {
+            "selected": false,
+            "text": "mia06",
+            "value": "mia06"
+          },
+          {
+            "selected": false,
+            "text": "mil02",
+            "value": "mil02"
+          },
+          {
+            "selected": false,
+            "text": "mil03",
+            "value": "mil03"
+          },
+          {
+            "selected": false,
+            "text": "mil04",
+            "value": "mil04"
+          },
+          {
+            "selected": false,
+            "text": "mil05",
+            "value": "mil05"
+          },
+          {
+            "selected": false,
+            "text": "mil06",
+            "value": "mil06"
+          },
+          {
+            "selected": false,
+            "text": "mil07",
+            "value": "mil07"
+          },
+          {
+            "selected": false,
+            "text": "mnl01",
+            "value": "mnl01"
+          },
+          {
+            "selected": false,
+            "text": "mnl02",
+            "value": "mnl02"
+          },
+          {
+            "selected": false,
+            "text": "mrs01",
+            "value": "mrs01"
+          },
+          {
+            "selected": false,
+            "text": "mrs02",
+            "value": "mrs02"
+          },
+          {
+            "selected": false,
+            "text": "mrs03",
+            "value": "mrs03"
+          },
+          {
+            "selected": false,
+            "text": "mrs04",
+            "value": "mrs04"
+          },
+          {
+            "selected": false,
+            "text": "nbo01",
+            "value": "nbo01"
+          },
+          {
+            "selected": false,
+            "text": "nuq02",
+            "value": "nuq02"
+          },
+          {
+            "selected": false,
+            "text": "nuq03",
+            "value": "nuq03"
+          },
+          {
+            "selected": false,
+            "text": "nuq04",
+            "value": "nuq04"
+          },
+          {
+            "selected": false,
+            "text": "nuq06",
+            "value": "nuq06"
+          },
+          {
+            "selected": false,
+            "text": "nuq07",
+            "value": "nuq07"
+          },
+          {
+            "selected": false,
+            "text": "ord02",
+            "value": "ord02"
+          },
+          {
+            "selected": false,
+            "text": "ord03",
+            "value": "ord03"
+          },
+          {
+            "selected": false,
+            "text": "ord04",
+            "value": "ord04"
+          },
+          {
+            "selected": false,
+            "text": "ord05",
+            "value": "ord05"
+          },
+          {
+            "selected": false,
+            "text": "ord06",
+            "value": "ord06"
+          },
+          {
+            "selected": false,
+            "text": "par02",
+            "value": "par02"
+          },
+          {
+            "selected": false,
+            "text": "par03",
+            "value": "par03"
+          },
+          {
+            "selected": false,
+            "text": "par04",
+            "value": "par04"
+          },
+          {
+            "selected": false,
+            "text": "par05",
+            "value": "par05"
+          },
+          {
+            "selected": false,
+            "text": "par06",
+            "value": "par06"
+          },
+          {
+            "selected": false,
+            "text": "par07",
+            "value": "par07"
+          },
+          {
+            "selected": false,
+            "text": "prg02",
+            "value": "prg02"
+          },
+          {
+            "selected": false,
+            "text": "prg03",
+            "value": "prg03"
+          },
+          {
+            "selected": false,
+            "text": "prg04",
+            "value": "prg04"
+          },
+          {
+            "selected": false,
+            "text": "prg05",
+            "value": "prg05"
+          },
+          {
+            "selected": false,
+            "text": "prg06",
+            "value": "prg06"
+          },
+          {
+            "selected": false,
+            "text": "sea02",
+            "value": "sea02"
+          },
+          {
+            "selected": false,
+            "text": "sea03",
+            "value": "sea03"
+          },
+          {
+            "selected": false,
+            "text": "sea04",
+            "value": "sea04"
+          },
+          {
+            "selected": false,
+            "text": "sea07",
+            "value": "sea07"
+          },
+          {
+            "selected": false,
+            "text": "sea08",
+            "value": "sea08"
+          },
+          {
+            "selected": false,
+            "text": "sin01",
+            "value": "sin01"
+          },
+          {
+            "selected": false,
+            "text": "svg01",
+            "value": "svg01"
+          },
+          {
+            "selected": false,
+            "text": "syd02",
+            "value": "syd02"
+          },
+          {
+            "selected": false,
+            "text": "syd03",
+            "value": "syd03"
+          },
+          {
+            "selected": false,
+            "text": "tgd01",
+            "value": "tgd01"
+          },
+          {
+            "selected": false,
+            "text": "tnr01",
+            "value": "tnr01"
+          },
+          {
+            "selected": false,
+            "text": "tpe01",
+            "value": "tpe01"
+          },
+          {
+            "selected": false,
+            "text": "trn02",
+            "value": "trn02"
+          },
+          {
+            "selected": false,
+            "text": "tun01",
+            "value": "tun01"
+          },
+          {
+            "selected": false,
+            "text": "wlg02",
+            "value": "wlg02"
+          },
+          {
+            "selected": false,
+            "text": "yqm01",
+            "value": "yqm01"
+          },
+          {
+            "selected": false,
+            "text": "yul02",
+            "value": "yul02"
+          },
+          {
+            "selected": false,
+            "text": "yvr01",
+            "value": "yvr01"
+          },
+          {
+            "selected": false,
+            "text": "ywg01",
+            "value": "ywg01"
+          },
+          {
+            "selected": false,
+            "text": "yyc02",
+            "value": "yyc02"
+          },
+          {
+            "selected": false,
+            "text": "yyz02",
+            "value": "yyz02"
+          }
+        ],
+        "query": "label_values(machine)",
+        "refresh": 0,
+        "regex": "/mlab[1-4].([a-z]{3}..).*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Wehe: access envelope",
+  "uid": "A2SM_Iumx",
+  "version": 84
+}


### PR DESCRIPTION
This change adds a new dashboard for the Wehe service on M-Lab. It includes panels for the access envelope, the wehe service itself, as well as total files saved according to pusher.

Review should include in person talk-through.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/776)
<!-- Reviewable:end -->
