### PR TITLE
Fixes blackbox-exporter scrapes for targets without port specifications

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -494,7 +494,6 @@ scrape_configs:
       # The default __address__ value is a target host from the config file.
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
       # host value. NOTE: we also insert a trailing "." to optimize DNS lookup.
-      # NOTE: all address ports must be specified explicitly.
       - source_labels: [__address__]
         regex: (.*)(:.*)?
         target_label: __param_target

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -496,7 +496,7 @@ scrape_configs:
       # host value. NOTE: we also insert a trailing "." to optimize DNS lookup.
       # NOTE: all address ports must be specified explicitly.
       - source_labels: [__address__]
-        regex: (.*)(:.*)
+        regex: (.*)(:.*)?
         target_label: __param_target
         replacement: ${1}.${2}
 

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -27,6 +27,7 @@ spec:
         - --email-domain=measurementlab.net
         - --email-domain={{GCLOUD_PROJECT}}.iam.gserviceaccount.com
         - --email-domain=neu.edu
+        - --email-domain=northeastern.edu
         - --set-xauthrequest=true
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.0.0
         name: oauth2-proxy


### PR DESCRIPTION
Today, the production alert `PlatformCluster_NodeNotReady` fired for mlab{1,2,3}-lis01. However, the switch was down too, and NodeNotReady alerts should not fire when the switch is down. Investigation revealed that ICMP switch probes have been broken for the past couple weeks in all project, apparently the result of this change:

https://github.com/m-lab/prometheus-support/commit/3a2f404b1a5ca4ccce46143792dfc2418403d733

This PR should fix that issue by making an explicit port specification to target machines optional.

Additionally, this PR adds the domain northeastern.edu to the list of permitted email domains for oauth2-proxy, as we try to figure out a way to get the Wehe team access to the Granfa.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/782)
<!-- Reviewable:end -->
