### PR TITLE
Fixes greedy regexp matching

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -495,7 +495,7 @@ scrape_configs:
       # Here, we set (i.e. "replace") a request parameter "target" equal to the
       # host value. NOTE: we also insert a trailing "." to optimize DNS lookup.
       - source_labels: [__address__]
-        regex: (.*)(:.*)?
+        regex: ([a-z0-9-.]+)(:[0-9]+)?
         target_label: __param_target
         replacement: ${1}.${2}
 


### PR DESCRIPTION
We got a ` TooManyNdtTlsIpv4ServersDown` down alert in staging not too long after I merged #782. Closer inspection revealed that the issue had something to do with a greedy regexp pattern which was gobbling up the entire string before it got to the second matching group. This PR should fix that by more appropriately scoping the matching so that grouping works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/783)
<!-- Reviewable:end -->
