### PR TITLE
Enabled husky.neu.edu in oauth2-proxy.yml

### DIFF
--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -26,7 +26,7 @@ spec:
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
         - --email-domain=measurementlab.net
         - --email-domain={{GCLOUD_PROJECT}}.iam.gserviceaccount.com
-        - --email-domain=neu.edu
+        - --email-domain=husky.neu.edu
         - --email-domain=northeastern.edu
         - --set-xauthrequest=true
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.0.0


### PR DESCRIPTION
oauth2-proxy does not seem to automatically authorize subdomains, so `neu.edu` does not allow `husky.neu.edu` to log in. This change explicitly allows `husky.neu.edu`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/785)
<!-- Reviewable:end -->
