### PR TITLE
Adds new alert for machine uptime + only scrape annotation port

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1489,6 +1489,18 @@ groups:
         and/or system messages.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
+  - alert: PlatformHardware_MachineUpTooLong
+    expr: |
+      (time() - node_boot_time_seconds{node=~"(master|mlab[1-4])-.+"}) / (60 * 60 * 24) > 90
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: A machine has not been rebooted for too long
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformhardware_machineuptimetoolong
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
+
 # BMC alerts
 # The Reboot API performs an E2E connection test on a BMC every time its
 # /v1/e2e endpoint is scraped, and reports failure via this metric.

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1498,7 +1498,7 @@ groups:
       severity: ticket
     annotations:
       summary: A machine has not been rebooted for too long
-      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformhardware_machineuptimetoolong
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformhardware_machineuptoolong
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 
 # BMC alerts

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -185,6 +185,15 @@ scrape_configs:
         action: keep
         regex: (\d+)
 
+      # Check for the prometheus.io/port=<port> annotation. If it exists, then
+      # only scrape that one port, no matter how many containerPorts are
+      # declared.
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+
       # Copy all pod labels from kubernetes to the Prometheus metrics.
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
@@ -318,6 +327,7 @@ scrape_configs:
         - 'disco_collect_errors_total'
         - 'ifHCOutOctets{deployment="disco"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
+        - 'node_boot_time_seconds'
         - 'node_filesystem_size_bytes{deployment="node-exporter"}'
         - 'node_filesystem_avail_bytes{deployment="node-exporter"}'
         - 'node_memory_MemTotal_bytes'


### PR DESCRIPTION
This PR adds a new alert which fires when a machine hasn't been rebooted in more than 90d. It builds on the [recent work to cause all platform nodes to get rebooted when up for more than 60d](https://github.com/m-lab/epoxy-images/pull/200).

It also adds a new `relabel_config` config for the kubernetes-pods job which will cause the job to look for the `prometheus.io/port` annotation on a pod, and if it exists, to only scrape the pod on that port.

This PR is expected to resolve #786.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/787)
<!-- Reviewable:end -->
