### PR TITLE
Add node-exporter DS to the data-processing cluster

### DIFF
--- a/k8s/data-processing/deployments/node-exporter.yml
+++ b/k8s/data-processing/deployments/node-exporter.yml
@@ -15,7 +15,7 @@ spec:
         prometheus.io/scrape: 'true'
     spec:
       containers:
-      - image: prom/node-exporter
+      - image: prom/node-exporter:v1.1.1
         name: node-exporter
         ports:
         - containerPort: 9100

--- a/k8s/data-processing/deployments/node-exporter.yml
+++ b/k8s/data-processing/deployments/node-exporter.yml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      run: node-exporter
+  template:
+    metadata:
+      name: node-exporter
+      labels:
+        run: node-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      - image: prom/node-exporter
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: scrape
+      hostNetwork: true
+      hostPID: true


### PR DESCRIPTION
This PR copies the node-exporter DaemonSet into the data-processing cluster. I mostly wanted this so I could check network utilization on the stats-pipeline node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/789)
<!-- Reviewable:end -->
