### PR TITLE
Add prometheus-basicauth URL to the list of monitored ingresses

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -609,6 +609,7 @@ scrape_configs:
         - https://gmx.{{PROJECT}}.measurementlab.net
         - https://grafana.{{PROJECT}}.measurementlab.net/login
         - https://prometheus.{{PROJECT}}.measurementlab.net/graph
+        - https://prometheus-basicauth.{{PROJECT}}.measurementlab.net/graph
         labels:
           module: nginx_proxy_svcs_online
     relabel_configs:


### PR DESCRIPTION
This list is statically defined and didn't include the new -basicauth URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/790)
<!-- Reviewable:end -->
