### PR TITLE
Scrape platform-cluster prometheus on the -basicauth domain

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -365,7 +365,7 @@ scrape_configs:
         # PusherSLO
         - 'pusher_finder_mtime_lower_bound'
     static_configs:
-      - targets: ['prometheus-platform-cluster.{{PROJECT}}.measurementlab.net:443']
+      - targets: ['prometheus-platform-cluster-basicauth.{{PROJECT}}.measurementlab.net:443']
         labels:
           cluster: "platform-cluster"
 


### PR DESCRIPTION
Step 2/3: Change the prometheus-federation config to scrape the -basicauth domain for platform-cluster prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/791)
<!-- Reviewable:end -->
