### PR TITLE
Bumps reboot-api version and adjusts reboot e2e test alerts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1517,34 +1517,17 @@ groups:
         deployment on GKE, and that the /v1/e2e endpoint is returning a status
         code = 200.
 
-  - alert: BMC_CredentialsNotFound
+  - alert: BMC_E2eTestFailed
     expr: |
-        reboot_e2e_result{status="credentials_not_found"}
+        reboot_e2e_success == 0
         unless on(machine) gmx_machine_maintenance == 1
-    for: 1h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: Credentials for {{ $labels.target }} not found on GCD.
-      description: >
-        The E2E test cannot run because credentials for this BMC are not
-        present on Google Cloud Datastore. Please add them.
-
-  - alert: BMC_ConnectionFailed
-    expr: |
-      reboot_e2e_result{status="connection_failed"}
-      unless on(machine) gmx_machine_maintenance == 1
     for: 1d
     labels:
       repo: ops-tracker
       severity: ticket
     annotations:
-      summary: Connection to {{ $labels.target }} has failed.
-      description: >
-        The E2E test is failing because the Reboot API could't connect to this
-        BMC. Please check that the BMC is enabled on this machine and the
-        credentials in Datastore are correct.
+      summary: E2E testing is failing to a DRAC
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#bmc_e2etestfailed
 
 # switch-monitoring alerts.
 # The switch-monitoring tool checks that the switch configurations match

--- a/k8s/prometheus-federation/deployments/reboot-api.yml
+++ b/k8s/prometheus-federation/deployments/reboot-api.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: reboot-api
-        image: measurementlab/reboot-api:v0.6.0
+        image: measurementlab/reboot-api:v0.6.1
         args:
           - "-datastore.project={{GCLOUD_PROJECT}}"
           - "-reboot.key=/var/secrets/reboot-api-ssh.key"


### PR DESCRIPTION
This PR bumps the reboot-api version to v0.6.1, which includes the fixes to issue https://github.com/m-lab/reboot-service/issues/39.

This PR also updates the alerts that were based on the old `reboot_e2e_result` metric. The new metric name `reboot_e2e_success`, and with these changes there will only be a single alert for any E2E test failure. It will be up to the operator to look at the alert and inspect the `reason` label of the alert to find out what may have caused the failure.

Additionally, the PR removes the `description` annotation of the new `BMC_E2eTestFailed` alert to only point to the new [documentation for the alert](https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#bmc_e2etestfailed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/792)
<!-- Reviewable:end -->
