### PR TITLE
Allow redirection to all .measurementlab.net domains

### DIFF
--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -29,6 +29,7 @@ spec:
         - --email-domain=husky.neu.edu
         - --email-domain=northeastern.edu
         - --set-xauthrequest=true
+        - --whitelist-domain=.measurementlab.net
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.0.0
         name: oauth2-proxy
         ports:


### PR DESCRIPTION
Following up to https://github.com/m-lab/k8s-support/pull/559, this PR allows the "redirect URL" to be different from the domain where the authentication request originated. Specifically, it can be anything ending in `.measurementlab.net`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/793)
<!-- Reviewable:end -->
