### PR TITLE
Fixes broken inhibit rule

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -76,12 +76,12 @@ inhibit_rules:
     alertname: 'PlatformCluster_.+Missing|MachineRunningWithoutK8sNode'
   equal: ['cluster']
 
-# Don't alert on BMC connection failures if the switch is down.
+# Don't alert on various things when the switch is down.
 - source_match:
-    alertname: 'SwitchDownAtSite'
-  target_match_re:
-    alertname: 'BMC_ConnectionFailed'
-  equal: []
+    alertname: 'SwitchUnpingableAtSite'
+  target_match:
+    alertname: 'BMC_E2eTestFailed'
+  equal: [site]
 
 receivers:
 # For M-Lab Slack, visit:


### PR DESCRIPTION
Alert names changed over time, but this inhibit rule did not. This PR updates the inhibit rule to match the current alert names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/796)
<!-- Reviewable:end -->
