### PR TITLE
Update to latest version of bqx

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -11,23 +11,21 @@ spec:
     metadata:
       labels:
         run: bigquery-exporter
-        # Update this string to trigger redeployment, or delete the pod.
-        update: '2021-03-05-a'
       annotations:
         prometheus.io/scrape: 'true'
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:production-0.3
-        args: [ "--project={{GCLOUD_PROJECT}}",
-                "--refresh=3h",
-                "--type=gauge", "--query=/queries/bq_annotation.sql",
-                "--type=gauge", "--query=/queries/bq_gardener_parse_time.sql",
-                "--type=gauge", "--query=/queries/bq_gardener.sql",
-                "--type=gauge", "--query=/queries/bq_daily_archive.sql",
+        image: measurementlab/prometheus-bigquery-exporter:v1.1.0
+        args: [ "-project={{GCLOUD_PROJECT}}",
+                "-refresh=3h",
+                "-gauge-query=/queries/bq_annotation.sql",
+                "-gauge-query=/queries/bq_gardener_parse_time.sql",
+                "-gauge-query=/queries/bq_gardener.sql",
+                "-gauge-query=/queries/bq_daily_archive.sql",
               ]
         ports:
-        - containerPort: 9050
+        - containerPort: 9348
         volumeMounts:
         - mountPath: /queries
           name: bigquery-config

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
@@ -11,22 +11,20 @@ spec:
     metadata:
       labels:
         run: bigquery-exporter
-        # Update this string to trigger redeployment, or delete the pod.
-        update: '2020-10-26-a'
       annotations:
         prometheus.io/scrape: 'true'
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:production-0.3
-        args: [ "--project={{GCLOUD_PROJECT}}",
-                "--refresh=5m",
-                "--type=gauge", "--query=/queries/bq_mlabns_ratelimit.sql",
-                "--type=gauge", "--query=/queries/bq_ndt_s2c.sql",
-                "--type=gauge", "--query=/queries/bq_billing_hourly.sql",
+        image: measurementlab/prometheus-bigquery-exporter:v1.1.0
+        args: [ "-project={{GCLOUD_PROJECT}}",
+                "-refresh=5m",
+                "-gauge-query=/queries/bq_mlabns_ratelimit.sql",
+                "-gauge-query=/queries/bq_ndt_s2c.sql",
+                "-gauge-query=/queries/bq_billing_hourly.sql",
               ]
         ports:
-        - containerPort: 9050
+        - containerPort: 9348
         volumeMounts:
         - mountPath: /queries
           name: bigquery-config


### PR DESCRIPTION
This change updates to the latest version of the prometheus-bigquery-exporter v1.1.0 that includes bug fixes that prevented our update until now.

With this change, the bqx should automatically discover and reload query changes in the configmap. Previously this was a manual step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/799)
<!-- Reviewable:end -->
