### PR TITLE
Add recording rule for daily gcs archive counts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -614,6 +614,31 @@ groups:
         This could be caused by increases in the number of files, size of files,
         changes in configuration, or underlying system delays.
 
+# Pipeline: GCS Archives Not Found in BigQuery
+#
+# This alert enforces that archives found in GCS are successfully parsed and
+# found in BigQuery. Typically, we see ~11-12k archives per day. This alert
+# fires when more than 1% are missing for 6hrs.
+#
+# Scheduling:
+# * Both metrics depend on the GCS transfers completing successfully.
+# * The bq_daily_archive_count metric is run every 3hrs by the bqx.
+# * The gcs exporter is offset 14hr to align with the etl daily parsing.
+  - alert: Pipeline_GCSArchivesMissingFromBigQuery
+    expr: |
+      abs(
+         sum(bq_daily_archive_count {datatype="ndt7"}) - ignoring(experiment)
+         experiment_datatype:gcs_archive_files:increase24h{experiment="ndt", datatype="ndt7"} offset 14h)
+      ) > 110
+    for: 6h
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      summary: Not all GCS archives found in BQ tables for ndt7.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_gcsarchivesmissingfrombigquery
+
+
 # Too many NDT S2C tests on a node are being impacted by switch discards.
   - alert: DataQuality_TooManyNdtS2cTestsWithDiscards
     expr: (bq_ndt_s2c_with_discards / bq_ndt_s2c_total) > 0.05

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -627,7 +627,7 @@ groups:
   - alert: Pipeline_GCSArchivesMissingFromBigQuery
     expr: |
       abs(
-         sum(bq_daily_archive_count {datatype="ndt7"}) - ignoring(experiment)
+         sum by(datatype) (bq_daily_archive_count {datatype="ndt7"}) - ignoring(experiment)
          (experiment_datatype:gcs_archive_files:increase24h{experiment="ndt", datatype="ndt7"} offset 14h)
       ) > 110
     for: 6h

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -628,7 +628,7 @@ groups:
     expr: |
       abs(
          sum(bq_daily_archive_count {datatype="ndt7"}) - ignoring(experiment)
-         experiment_datatype:gcs_archive_files:increase24h{experiment="ndt", datatype="ndt7"} offset 14h)
+         (experiment_datatype:gcs_archive_files:increase24h{experiment="ndt", datatype="ndt7"} offset 14h)
       ) > 110
     for: 6h
     labels:

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -44,10 +44,8 @@ groups:
   - record: candidate_service:etl_test_count:increase24h
     expr: sum by(service) (increase(etl_test_count{service!~".*batch.*",status="ok"}[1d]))
 
-  # Calculates the daily increase of GCS files for all datatypes. The
-  # expression uses subtraction rather than increase() to improve the accuracy
-  # of the result. Evidently, increase() is off 8-10 archives. The drawback is
-  # that this metric will be incorrect for 24hrs after the GCS exporter restarts.
+  # Calculates the daily increase of GCS files for all datatypes.
+  # NOTE: increase() appears to add an addition 8-10 archives over reality.
+  # Cause is unknown, but using increase() is simpler than a manual subtraction.
   - record: daily_public:gcs_archive_files:increase24h
-    expr: ((gcs_archive_files_total{bucket="archive-measurement-lab"}) -
-           (gcs_archive_files_total{bucket="archive-measurement-lab"} offset 24h)) > 0
+    expr: increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[24h])

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -36,10 +36,18 @@ groups:
 - name: rules.yml
   rules:
 
-## Parser volume checks.
-#
-# This rule optimizes the alert query used for ParserDailyVolumeTooLow. Rather
-# than calculate multi-day values continuously, this rule will maintain a history
-# of the precalculated value needed by the rule.
+  ## Parser volume checks.
+  #
+  # This rule optimizes the alert query used for ParserDailyVolumeTooLow. Rather
+  # than calculate multi-day values continuously, this rule will maintain a history
+  # of the precalculated value needed by the rule.
   - record: candidate_service:etl_test_count:increase24h
     expr: sum by(service) (increase(etl_test_count{service!~".*batch.*",status="ok"}[1d]))
+
+  # Calculates the daily increase of GCS files for all datatypes. The
+  # expression uses subtraction rather than increase() to improve the accuracy
+  # of the result. Evidently, increase() is off 8-10 archives. The drawback is
+  # that this metric will be incorrect for 24hrs after the GCS exporter restarts.
+  - record: daily_public:gcs_archive_files:increase24h
+    expr: ((gcs_archive_files_total{bucket="archive-measurement-lab"}) -
+           (gcs_archive_files_total{bucket="archive-measurement-lab"} offset 24h)) > 0

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -47,5 +47,5 @@ groups:
   # Calculates the daily increase of GCS files for all datatypes.
   # NOTE: increase() appears to add an addition 8-10 archives over reality.
   # Cause is unknown, but using increase() is simpler than a manual subtraction.
-  - record: daily_public:gcs_archive_files:increase24h
-    expr: increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[24h])
+  - record: experiment_datatype:gcs_archive_files:increase24h
+    expr: sum by(experiment, datatype) (increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[24h]))


### PR DESCRIPTION
This change adds a new recording rule and new alert based on the GCS exporter and the BQ exporter metrics. The new alert  verifies that archives found in GCS for ndt7 have been processed by ETL and found in BigQuery.

The pieces of our pipeline: pusher -> gcs transfers -> archives parsed -> table availability

To date, we have alerts for pusher, gcs transfers, and table availability. However, if archives are missed, we would not know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/800)
<!-- Reviewable:end -->
