### PR TITLE
Update bigquery-exporter version

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.0
+        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=3h",
                 "-gauge-query=/queries/bq_annotation.sql",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.0
+        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=5m",
                 "-gauge-query=/queries/bq_mlabns_ratelimit.sql",


### PR DESCRIPTION
This change updates the version of the bigquery exporter to prevent persistent failures in response to a collector registration error. This kind of error can occur during a k8s maintenance event that restarts a pod container but during a transient credential failure for the BQX on startup.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/803)
<!-- Reviewable:end -->
