### PR TITLE
Bumps script-exporter-support image version to v0.2.3

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -32,7 +32,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: measurementlab/script-exporter-support:v0.2.2
+        image: measurementlab/script-exporter-support:v0.2.3
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:


### PR DESCRIPTION
This should resolve the long-standing bug we have had in the script_exporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/809)
<!-- Reviewable:end -->
