### PR TITLE
Configures node-exporter to tolerate outbound-ip nodes

### DIFF
--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -23,3 +23,9 @@ spec:
           name: scrape
       hostNetwork: true
       hostPID: true
+      tolerations:
+      - key: "outbound-ip"
+        operator: "Equal"
+        value: "static"
+        effect: "NoSchedule"
+


### PR DESCRIPTION
Currently, our node-exporter DaemonSet in prometheus-federation does not deploy pods to the `static-outbound-ip` node pool nodes in GKE due to the taint `outbound-ip=static:NoSchedule` on those nodes. This small PR simply adds a toleration to the node-exporter DaemonSet so that it will deploy to those nodes too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/811)
<!-- Reviewable:end -->
