### PR TITLE
Updates script_exporter + pins node_exporter version

### DIFF
--- a/k8s/prometheus-federation/deployments/cadvisor.yml
+++ b/k8s/prometheus-federation/deployments/cadvisor.yml
@@ -58,6 +58,11 @@ spec:
             protocol: TCP
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: "outbound-ip"
+        operator: "Equal"
+        value: "static"
+        effect: "NoSchedule"
       volumes:
       - name: rootfs
         hostPath:

--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -6,6 +6,10 @@ spec:
   selector:
     matchLabels:
       run: node-exporter
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       name: node-exporter

--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -15,8 +15,10 @@ spec:
         prometheus.io/scrape: 'true'
     spec:
       containers:
-      - image: prom/node-exporter
-        name: node-exporter
+      - name: node-exporter
+        image: prom/node-exporter:v1.1.2
+        args:
+        - --collector.processes
         ports:
         - containerPort: 9100
           hostPort: 9100

--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -21,8 +21,6 @@ spec:
       containers:
       - name: node-exporter
         image: prom/node-exporter:v1.1.2
-        args:
-        - --collector.processes
         ports:
         - containerPort: 9100
           hostPort: 9100

--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -21,6 +21,8 @@ spec:
       containers:
       - name: node-exporter
         image: prom/node-exporter:v1.1.2
+        args:
+        - --collector.processes
         ports:
         - containerPort: 9100
           hostPort: 9100

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -32,7 +32,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: measurementlab/script-exporter-support:v0.2.3
+        image: measurementlab/script-exporter-support:v0.2.4
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:


### PR DESCRIPTION
This PR:

* updates the script_exporter image to v0.2.4, [bringing in some bug fixes](https://github.com/m-lab/script_exporter/pull/7)
* adds a toleration to the CAdvisor pod so that it will deploy to the static-outbound-ip nodes
* Enables the `processes` node_exporter collector so that we can look for runaway PID issues
* Updates the updateStrategy for node-exporter so that it rolls out automatically (was `OnDelete` before for some reason)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/812)
<!-- Reviewable:end -->
