### PR TITLE
Updates README for "Static outbound IP pinning"

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,12 +644,17 @@ nodes.
 
 Create a two-node pool with a specific label (to make sure that any necessary
 pods can be selected onto it) and taint (to make sure other services are not
-run on it):
+run on it). The machine type will differ depending on project as follows:
+
+mlab-sandbox: n2-standard-8
+mlab-staging: n2-highcpu-16
+mlab-oti: n2-highcpu-48
 
 ```
 gcloud container node-pools create static-outbound-ip \
---cluster=prometheus-federation --machine-type=n1-standard-8 --num-nodes=2 \
---node-labels=outbound-ip=static --node-taints=outbound-ip=static:NoSchedule
+--cluster=prometheus-federation --machine-type=<type> --num-nodes=2 \
+--node-labels=outbound-ip=static --node-taints=outbound-ip=static:NoSchedule \
+--scopes datastore --zone <prometheus-federation-zone> --project <project>
 ```
 
 ### Create kubeIP credentials

--- a/README.md
+++ b/README.md
@@ -646,9 +646,9 @@ Create a two-node pool with a specific label (to make sure that any necessary
 pods can be selected onto it) and taint (to make sure other services are not
 run on it). The machine type will differ depending on project as follows:
 
-mlab-sandbox: n2-standard-8
-mlab-staging: n2-highcpu-16
-mlab-oti: n2-highcpu-48
+* mlab-sandbox: n2-standard-8
+* mlab-staging: n2-highcpu-16
+* mlab-oti: n2-highcpu-48
 
 ```
 gcloud container node-pools create static-outbound-ip \


### PR DESCRIPTION
It was discovered today that perhaps the default VM auth scopes have changed since the `static-outbound-ip` node pools were first set up some time ago. I recreated all of them in the past couple days to modify the underlying node machine types (more CPU), and the reboot-api started throwing errors that it couldn't read credentials from Datastore. I recreated the node pools in all project with an explicit scope of `datastore`, which resolved the issue. This PR just updates the documentation to reflect the new requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/816)
<!-- Reviewable:end -->
