### PR TITLE
Sets sessionAffinity=ClientIP for script-exporter service

### DIFF
--- a/k8s/prometheus-federation/services/script-exporter.yml
+++ b/k8s/prometheus-federation/services/script-exporter.yml
@@ -12,5 +12,5 @@ spec:
     targetPort: 9172
   selector:
     run: script-exporter
-  sessionAffinity: None
+  sessionAffinity: ClientIP
   type: ClusterIP


### PR DESCRIPTION
The impetus for this change is how our e2e test caching works. The caching is machine-local, but the script-exporter Deployment has two replicas. You never know which replica is going to get the request from Prometheus. This means that an e2e test for a given machine is going to happen at least twice as often as we expect, and not just roughly once every 5 minutes or so. This change should cause all tests, or at least a majority, to go to one machine, allowing the caching to work more as intended. The default session affinity timeout is 10800 (3h), which means that the bulk of tests should occasionally flip flop back and forth between the replicas in the Deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/817)
<!-- Reviewable:end -->
