### PR TITLE
Scrapes ifInErrors from platform-cluster

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1096,7 +1096,7 @@ groups:
 
 # Some SNMP metrics are missing from Prometheus. These should always be present.
   - alert: PlatformCluster_SnmpMetricsMissing
-    expr: absent(ifHCOutOctets)
+    expr: absent(ifHCOutOctets) or absent(ifInErrors)
     for: 30m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -326,6 +326,7 @@ scrape_configs:
         - 'up{job=~".+"}'
         - 'disco_collect_errors_total'
         - 'ifHCOutOctets{deployment="disco"}'
+        - 'ifInErrors{deployment="disco", ifAlias="uplink"}'
         - 'lame_duck_experiment{job!="node-exporter"}'
         - 'node_boot_time_seconds'
         - 'node_filesystem_size_bytes{deployment="node-exporter"}'


### PR DESCRIPTION
We have [an alert for when switch errors exceed a certain threshold](https://github.com/m-lab/prometheus-support/blob/master/config/federation/prometheus/alerts.yml#L763). However, the alert cannot currently ever fire because we do not scrape the `ifInErrors` metric from the platform-cluster. This PR should resolve that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/821)
<!-- Reviewable:end -->
