### PR TITLE
Bumps script-exporter-support image to v0.2.8

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -32,7 +32,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: measurementlab/script-exporter-support:v0.2.7
+        image: measurementlab/script-exporter-support:v0.2.8
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:


### PR DESCRIPTION
The only change is the image should be that it has pulled in the latest changes from the [wehe-cmdline repo](https://github.com/NEU-SNS/wehe-cmdline), and the only change there is the addition of a `@` prefix to the username for the cli client so that they can identify it in the data and filter it out. Currently, the e2e monitoring is polluting their data, with no clear way to filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/822)
<!-- Reviewable:end -->
