### PR TITLE
Fixes the 'cluster' label value for platform scrape job

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -324,7 +324,7 @@ scrape_configs:
     static_configs:
       - targets: ['prometheus-platform-cluster-basicauth.{{PROJECT}}.measurementlab.net:443']
         labels:
-          cluster: "platform-cluster"
+          cluster: "platform"
 
     metric_relabel_configs:
       # Adds an experiment label to lame_duck_experiment metrics for


### PR DESCRIPTION
With the move of platform alerts to the platform cluster, I also did some relabeling working. Previously, all metrics scraped from the platform clusters were given a label of `cluster="platform-cluster"`. Now that we have alerts coming from multiple clusters, alerts have a new label named `cluster` so you know where the alert originated. Presently the possible values are `prometheus-federation` and `platform`. This PR removes the redundant `-cluster` from the value of the `cluster` label so that it is more clean looking. It also fixes at least one firing alert that expects to find a label of only `cluster="platform"`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/829)
<!-- Reviewable:end -->
