### PR TITLE
Adds new alert for when IPv6 is down for too long

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -493,16 +493,11 @@ groups:
   - alert: PlatformCluster_IPv6AtSiteDownForTooLong
     expr: |
       count by (site) (
-        probe_success{service="ndt7_ipv6"} == 0
+        probe_success{service="ndt7_ipv6", ipv6="present"} == 0
           unless on(machine) probe_success{service="ndt7"} == 0
       )
-      unless on(site)
-        probe_success{module="icmp", instance=~"s1.(del02|los02|tnr01).*"}
       unless on(site) (
-        label_replace(
-          gmx_machine_maintenance == 1,
-          "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
-        ) or
+        gmx_machine_maintenance == 1 or
         kube_node_spec_taint{cluster="platform", key="lame-duck"}
       ) > 0
     for: 24h

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -505,7 +505,7 @@ groups:
       )
       unless on(site)
         probe_success{module="icmp", instance=~"s1.(del02|los02|tnr01).*"}
-      unless on(machine) (
+      unless on(site) (
         label_replace(
           gmx_machine_maintenance == 1,
           "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -503,7 +503,7 @@ groups:
           gmx_machine_maintenance == 1,
           "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
         ) or
-        kube_node_spec_taint{cluster="platform", key="lame-duck"},
+        kube_node_spec_taint{cluster="platform", key="lame-duck"}
       ) > 0
     for: 24h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -487,18 +487,16 @@ groups:
 
 # Alert when the status of IPv6 for any or all machines at a site is down for
 # too long, but *only* when the status of IPv4 is up for the same machine. If
-# IPv4 is up, then IPv6 should be too. However, do not alert on sites that
-# don't even have IPv6 (currently DEL02, LOS02, and TNR01). Also don't alert
-# about a machine when it is in GMX or lame-ducked.
+# IPv4 is up, then IPv6 should be too.
   - alert: PlatformCluster_IPv6AtSiteDownForTooLong
     expr: |
       count by (site) (
         probe_success{service="ndt7_ipv6", ipv6="present"} == 0
           unless on(machine) probe_success{service="ndt7"} == 0
-      )
-      unless on(site) (
-        gmx_machine_maintenance == 1 or
-        kube_node_spec_taint{cluster="platform", key="lame-duck"}
+        unless on(machine) (
+          gmx_machine_maintenance == 1 or
+          kube_node_spec_taint{cluster="platform", key="lame-duck"}
+        )
       ) > 0
     for: 24h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -489,19 +489,12 @@ groups:
 # too long, but *only* when the status of IPv4 is up for the same machine. If
 # IPv4 is up, then IPv6 should be too. However, do not alert on sites that
 # don't even have IPv6 (currently DEL02, LOS02, and TNR01). Also don't alert
-# about a machine when it is in GMX or lame-ducked. The semi abusive use of
-# label_replace() is to extract a site label, because we expect this alert will
-# mostly fire when IPv6 is down for an entire site, and grouping on site will
-# cause only a single alert to fire no matter how many machines at site are
-# affected.
+# about a machine when it is in GMX or lame-ducked.
   - alert: PlatformCluster_IPv6AtSiteDownForTooLong
     expr: |
       count by (site) (
-        label_replace(
-          probe_success{service="ndt7_ipv6"} == 0
-            unless on(machine) probe_success{service="ndt7"} == 0,
-          "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
-        )
+        probe_success{service="ndt7_ipv6"} == 0
+          unless on(machine) probe_success{service="ndt7"} == 0,
       )
       unless on(site)
         probe_success{module="icmp", instance=~"s1.(del02|los02|tnr01).*"}
@@ -510,10 +503,7 @@ groups:
           gmx_machine_maintenance == 1,
           "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
         ) or
-        label_replace(
-          kube_node_spec_taint{cluster="platform", key="lame-duck"},
-          "site", "$1", "node", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
-        )
+        kube_node_spec_taint{cluster="platform", key="lame-duck"},
       ) > 0
     for: 24h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -493,10 +493,10 @@ groups:
       count by (site) (
         probe_success{service="ndt7_ipv6", ipv6="present"} == 0
           unless on(machine) probe_success{service="ndt7"} == 0
-        unless on(machine) (
-          gmx_machine_maintenance == 1 or
-          kube_node_spec_taint{cluster="platform", key="lame-duck"}
-        )
+          unless on(machine) (
+            gmx_machine_maintenance == 1 or
+            kube_node_spec_taint{cluster="platform", key="lame-duck"}
+          )
       ) > 0
     for: 24h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -484,6 +484,46 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#PlatformCluster_TooManyServersDown
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/T-t8rWwGz/mlab-ns-prometheus-queries
 
+
+# Alert when the status of IPv6 for any or all machines at a site is down for
+# too long, but *only* when the status of IPv4 is up for the same machine. If
+# IPv4 is up, then IPv6 should be too. However, do not alert on sites that
+# don't even have IPv6 (currently DEL02, LOS02, and TNR01). Also don't alert
+# about a machine when it is in GMX or lame-ducked. The semi abusive use of
+# label_replace() is to extract a site label, because we expect this alert will
+# mostly fire when IPv6 is down for an entire site, and grouping on site will
+# cause only a single alert to fire no matter how many machines at site are
+# affected.
+  - alert: PlatformCluster_IPv6AtSiteDownForTooLong
+    expr: |
+      count by (site) (
+        label_replace(
+          probe_success{service="ndt7_ipv6"} == 0
+            unless on(machine) probe_success{service="ndt7"} == 0,
+          "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
+        )
+      )
+      unless on(site)
+        probe_success{module="icmp", instance=~"s1.(del02|los02|tnr01).*"}
+      unless on(machine) (
+        label_replace(
+          gmx_machine_maintenance == 1,
+          "site", "$1", "machine", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
+        ) or
+        label_replace(
+          kube_node_spec_taint{cluster="platform", key="lame-duck"},
+          "site", "$1", "node", "mlab[1-4].([a-z]{3}[0-9]{2}).*"
+        )
+      ) > 0
+    for: 24h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: IPv6 at a site has been down for too long.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#PlatformCluster_IPv6AtSiteDownForTooLong
+
 # Check 5xx errors for the rate-limiter deployment, too.
   - alert: RateLimiterTooManyServerSideErrors
     expr: |

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -494,7 +494,7 @@ groups:
     expr: |
       count by (site) (
         probe_success{service="ndt7_ipv6"} == 0
-          unless on(machine) probe_success{service="ndt7"} == 0,
+          unless on(machine) probe_success{service="ndt7"} == 0
       )
       unless on(site)
         probe_success{module="icmp", instance=~"s1.(del02|los02|tnr01).*"}

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -479,6 +479,13 @@ scrape_configs:
         target_label: instance
         replacement: ${1}
 
+      # Extract the site name from the FQDN of the node/service and drop it
+      # into a label named "site'.
+      - source_labels: [__address__]
+        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        target_label: site
+        replacement: ${1}
+
       # Since __address__ is the target that prometheus scrapes,
       # unconditionally reset the __address__ label to the blackbox exporter
       # address.
@@ -530,6 +537,13 @@ scrape_configs:
       - source_labels: [__address__]
         regex: (.*)
         target_label: __param_target
+        replacement: ${1}
+
+      # Extract the site name from the FQDN of the node/service and drop it
+      # into a label named "site'.
+      - source_labels: [__address__]
+        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        target_label: site
         replacement: ${1}
 
       # Use the "module" label defined in the input file as the module name for
@@ -633,6 +647,13 @@ scrape_configs:
         target_label: __param_target
         replacement: ${1}
 
+      # Extract the site name from the FQDN of the node/service and drop it
+      # into a label named "site'.
+      - source_labels: [__address__]
+        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        target_label: site
+        replacement: ${1}
+
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the script_exporter
       # address.
@@ -708,6 +729,13 @@ scrape_configs:
       - source_labels: [__address__]
         regex: (.*)
         target_label: __param_target
+        replacement: ${1}
+
+      # Extract the site name from the FQDN of the node/service and drop it
+      # into a label named "site'.
+      - source_labels: [__address__]
+        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        target_label: site
         replacement: ${1}
 
       # Since __address__ is the target that prometheus will contact,

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -542,7 +542,7 @@ scrape_configs:
       # Extract the site name from the FQDN of the node/service and drop it
       # into a label named "site'.
       - source_labels: [__address__]
-        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        regex: .*mlab[1-4]v6-([a-z]{3}[0-9t]{2}).*
         target_label: site
         replacement: ${1}
 
@@ -734,7 +734,7 @@ scrape_configs:
       # Extract the site name from the FQDN of the node/service and drop it
       # into a label named "site'.
       - source_labels: [__address__]
-        regex: .*mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        regex: .*mlab[1-4]d-([a-z]{3}[0-9t]{2}).*
         target_label: site
         replacement: ${1}
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -354,6 +354,13 @@ scrape_configs:
         action: replace
         target_label: machine
 
+      # Extract the a node's site from the node name, and add a new 'site'
+      # label using the value.
+      - source_labels: [node]
+        regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
+        target_label: site
+        replacement: ${1}
+
   # Scrape config for the node_exporter on eb.measurementlab.net.
   - job_name: 'eb-node-exporter'
     static_configs:

--- a/k8s/prometheus-federation/deployments/gmx.yml
+++ b/k8s/prometheus-federation/deployments/gmx.yml
@@ -23,7 +23,7 @@ spec:
         run: gmx-server
     spec:
       containers:
-      - image: measurementlab/github-maintenance-exporter:v1.3.2
+      - image: measurementlab/github-maintenance-exporter:v1.3.3
         name: gmx-server
         args:
         - --storage.state-file=/var/lib/gmx/gmx-state


### PR DESCRIPTION
This commit should resolve the case where IPv6 is down for one or all machines at a site without anyone knowing about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/836)
<!-- Reviewable:end -->
