### PR TITLE
Fixes "cluster" label values in MLABNS_PrometheusQueries dashboard

### DIFF
--- a/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
+++ b/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 357,
-  "iteration": 1617995965275,
+  "id": 89,
+  "iteration": 1628628773577,
   "links": [],
   "panels": [
     {
@@ -67,7 +67,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt_ssl$protocol\"} OR\n    script_success{service=\"ndt5_client\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform-cluster\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt_ssl$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt_ssl$protocol\"} OR\n    script_success{service=\"ndt5_client\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt_ssl$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -162,7 +162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt7$protocol\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform-cluster\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt7$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt7$protocol\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt7$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -258,7 +258,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} OR\n    probe_success{service=\"neubot_tls$protocol\", experiment=\"neubot\"} OR\n    label_replace(kube_node_spec_taint{cluster=\"platform-cluster\", key=\"lame-duck\"},\n      \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} OR\n    probe_success{service=\"neubot_tls$protocol\", experiment=\"neubot\"} OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -353,7 +353,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (\n  node_filesystem_size_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"} -\n  node_filesystem_avail_bytes{cluster=\"platform-cluster\", mountpoint=\"/cache/data\"}\n)\n              ",
+          "expr": "sum (\n  node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n  node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}\n)\n              ",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -924,13 +924,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(kube_node_spec_taint{cluster=\"platform-cluster\", key=\"lame-duck\"})\n              ",
+          "expr": "count(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"})\n              ",
           "interval": "",
           "legendFormat": "nodes",
           "refId": "A"
         },
         {
-          "expr": "count(lame_duck_experiment{cluster=\"platform-cluster\"} == 1)",
+          "expr": "count(lame_duck_experiment{cluster=\"platform\"} == 1)",
           "interval": "",
           "legendFormat": "experiments",
           "refId": "B"
@@ -986,7 +986,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus (mlab-oti)",
           "value": "Prometheus (mlab-oti)"
         },
@@ -1044,5 +1044,5 @@
   "timezone": "",
   "title": "MLAB-NS: Prometheus Queries",
   "uid": "T-t8rWwGz",
-  "version": 19
+  "version": 4
 }

--- a/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
+++ b/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 89,
-  "iteration": 1628628773577,
+  "id": 357,
+  "iteration": 1628630520671,
   "links": [],
   "panels": [
     {
@@ -1044,5 +1044,5 @@
   "timezone": "",
   "title": "MLAB-NS: Prometheus Queries",
   "uid": "T-t8rWwGz",
-  "version": 4
+  "version": 20
 }


### PR DESCRIPTION
A couple months ago we modified the value of the `cluster` label from `cluster="platform-cluster"` (redundant use of "cluster"), to just `cluster="platform"`. These dashboards were never updated after that change happened.

TODO: These "mlab-ns" queries are triplicated between the mlab-ns repository, the prometheus-support alerts.yml file, and this dashboard. We need to find a way to have a single source for the queries to avoid synchronization issues like these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/837)
<!-- Reviewable:end -->
