### PR TITLE
Use unless on() for all conditions of ipv6 alert query

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -493,10 +493,8 @@ groups:
       count by (site) (
         probe_success{service="ndt7_ipv6", ipv6="present"} == 0
           unless on(machine) probe_success{service="ndt7"} == 0
-          unless on(machine) (
-            gmx_machine_maintenance == 1 or
-            kube_node_spec_taint{cluster="platform", key="lame-duck"}
-          )
+          unless on(machine) gmx_machine_maintenance == 1
+          unless on(machine) kube_node_spec_taint{cluster="platform", key="lame-duck"}
       ) > 0
     for: 24h
     labels:

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -492,9 +492,11 @@ groups:
     expr: |
       count by (site) (
         probe_success{service="ndt7_ipv6", ipv6="present"} == 0
-          unless on(machine) probe_success{service="ndt7"} == 0
-          unless on(machine) gmx_machine_maintenance == 1
-          unless on(machine) kube_node_spec_taint{cluster="platform", key="lame-duck"}
+          unless on(machine) (
+            probe_success{service="ndt7"} == 0
+            or gmx_machine_maintenance == 1
+            or kube_node_spec_taint{cluster="platform", key="lame-duck"}
+          )
       ) > 0
     for: 24h
     labels:


### PR DESCRIPTION
This change updates the `PlatformCluster_IPv6AtSiteDownForTooLong` alert query to use the `unless on(machine)` operator for all conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/838)
<!-- Reviewable:end -->
