### PR TITLE
Update Grafana to version 8.1.1

### DIFF
--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -22,21 +22,10 @@ spec:
         # public IP and port so that it is publically accessible.
         run: grafana-server
     spec:
-      # http://docs.grafana.org/installation/docker/#user-id-changes
-      # TODO (kinkade): Remove this initContainers section once it has been
-      # deployed once and permissions have been changed. It won't be needed
-      # again once the perms are changed once.
-      initContainers:
-      - name: reset-perms
-        image: busybox
-        command: ['chown', '-R', '472:472', '/work-dir']
-        volumeMounts:
-        - mountPath: /work-dir
-          name: grafana-storage
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:7.3.5
+      - image: grafana/grafana:8.1.1
         name: grafana-server
         # NOTE: the official Grafana Docker images may set various environment
         # variables which will override configurations in grafana.ini (which is


### PR DESCRIPTION
This PR updates our Grafana version to 8.1.1

 This version now needs plugins to be signed. Our two plugins in sandbox were quite outdated and not signed:
- grafana-worldmap-panel
- camptocamp-prometheus-alertmanager-datasource (_I suspect we're not using this anywhere_)

Since they were manually installed (according to the README), I've also manually updated them from within the grafana-server container:
```
$ grafana-cli plugins update grafana-worldmap-panel
$ grafana-cli plugins update camptocamp-prometheus-alertmanager-datasource
```

This also removed an initContainer that was used to fix some permission issue, resolving a TODO. Grafana's data disk is permanent, so (as the TODO mentioned) there should be no reason to keep running `chown` every time Grafana starts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/839)
<!-- Reviewable:end -->
