### PR TITLE
Reinstalls package ca-certificates before building in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-language: go
+dist: focal
 
+language: go
 go:
  - 1.13
 
+addons:
+  apt:
+    update: true
+    packages: ca-certificates
 
 # Unconditionally place the repo at GOPATH/src/${go_import_path} to support
 # forks.
@@ -160,5 +165,4 @@ before_install:
 - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
 - sudo apt-get -qq update
 - sudo apt-get install -y apache2-utils jq
-- sudo apt-get install --reinstall ca-certificates
 


### PR DESCRIPTION
Builds in Travis were failing due to server certificate errors. This fix, or one like it, seems to be necessary on pretty much every Travis build lately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/845)
<!-- Reviewable:end -->
