### PR TITLE
Updates container image versions for external-dns and kubeip deployments

### DIFF
--- a/k8s/prometheus-federation/deployments/external-dns.yml
+++ b/k8s/prometheus-federation/deployments/external-dns.yml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.17
+        image: k8s.gcr.io/external-dns/external-dns:v0.10.1
         # domain-filter is the zone we want to manage. txt-owner-id is an
         # arbitrary identifier used to track who created each entry (scoped
         # here to the cluster, in case we end up using more than one

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubeip
-  namespace: default
+  namespace: kube-system
 spec:
   replicas: 1
   selector:

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -16,7 +16,7 @@ spec:
         priorityClassName: system-cluster-critical
         containers:
         - name: "kubeip"
-          image: doitintl/kubeip:issue-34
+          image: doitintl/kubeip:v1.0.0
           imagePullPolicy: Always
           volumeMounts:
           - name: google-cloud-key

--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       app: kubeip
+  strategy:
+    type: Recreate
   template:
       metadata:
         labels:

--- a/k8s/prometheus-federation/roles/rbac-kubeip.yml
+++ b/k8s/prometheus-federation/roles/rbac-kubeip.yml
@@ -3,12 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubeip
+  namespace: kube-system
 ---
 # Allow kubeIP to keep an eye on nodes and pods
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kubeip
+  namespace: kube-system
 rules:
 - apiGroups: [""]
   resources: ["nodes"]


### PR DESCRIPTION
Additionally, the PR moves the kubeip deployment, and related resources, to the kube-system namespace, resolving this issue: https://github.com/m-lab/prometheus-support/issues/824

**NOTE**: Changing the namespace of the kubeip deployment and related resources requires recreating the GCP service account key Secret in the kube-system namespace:

```
kubectl get secret kubeip-key -o jsonpath='{.data.key\.json}' | base64 --decode > key.json
kubectl create secret generic kubeip-key --namespace kube-system --from-file key.json
```

... and also deleting the resources in the default namespace:

```
kubectl delete deployment kubeip
kubectl delete secrets kubeip-key
kubectl delete serviceaccount kubeip
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/851)
<!-- Reviewable:end -->
