### PR TITLE
Update per-metro query to only use specified sites

### DIFF
--- a/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
+++ b/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
@@ -21,8 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 379,
-  "iteration": 1641441478981,
+  "id": 97,
+  "iteration": 1641584072018,
   "links": [],
   "panels": [
     {
@@ -99,7 +99,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(60 * sum by(metro) (\n    label_replace(rate(ndt_test_rate_mbps_count{protocol=~\"$protocol\", monitoring=\"false\"}[$interval]),\n       \"metro\", \"$1\", \"machine\", \"mlab[1-4].([a-z]{3}).*\"))\n)",
+          "expr": "(60 * sum by(metro) (\n    label_replace(rate(ndt_test_rate_mbps_count{protocol=~\"$protocol\", machine=~\".*$site.*\", monitoring=\"false\"}[$interval]),\n       \"metro\", \"$1\", \"machine\", \"mlab[1-4].([a-z]{3}).*\"))\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -112,7 +112,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$protocol per-metro (global)",
+      "title": "Total test rate of $protocol per-metro ($site)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -748,6 +748,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -881,7 +882,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "lga"
           ],
@@ -915,7 +916,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "ndt7+wss",
           "value": "ndt7+wss"
         },
@@ -966,9 +967,9 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "text": "10m",
-          "value": "10m"
+          "selected": false,
+          "text": "30m",
+          "value": "30m"
         },
         "description": null,
         "error": null,
@@ -989,12 +990,12 @@
             "value": "5m"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "10m",
             "value": "10m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "30m",
             "value": "30m"
           },
@@ -1043,5 +1044,5 @@
   "timezone": "utc",
   "title": "NDT: Client Rates, Quantiles over time, & Heatmaps",
   "uid": "SAvQ0QAnl",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Previously this dashboard reserved the upper-right panel to show all metros. But, I kept editing it to use only the selected metros. Since "all metros" is an option I think this panel should use the `$site` variable as all the other panels do. This change makes this modification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/863)
<!-- Reviewable:end -->
