### PR TITLE
Adds flag --enable-feature=memory-snapshot-on-shutdown

### DIFF
--- a/k8s/data-processing/deployments/prometheus.yml
+++ b/k8s/data-processing/deployments/prometheus.yml
@@ -64,7 +64,8 @@ spec:
         args: ["--config.file=/etc/prometheus/prometheus.yml",
                "--storage.tsdb.retention.time=120d",
                "--storage.tsdb.path=/data",
-               "--web.enable-lifecycle"]
+               "--web.enable-lifecycle",
+               "--enable-feature=memory-snapshot-on-shutdown"]
         ports:
           - containerPort: 9090
         resources:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -56,7 +56,8 @@ spec:
                "--storage.tsdb.path=/prometheus",
                "--storage.tsdb.retention.time=120d",
                "--web.enable-lifecycle",
-               "--web.external-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net"]
+               "--web.external-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net",
+               "--enable-feature=memory-snapshot-on-shutdown"]
         ports:
           - containerPort: 9090
         resources:


### PR DESCRIPTION
This is an experimental feature which is supposed to make startups
faster. This is running in the platform cluster and seems to work as
advertised.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/864)
<!-- Reviewable:end -->
