### PR TITLE
Updates kube-state-metrics to v2.2.4

### DIFF
--- a/k8s/data-processing/deployments/kube-state-metrics.yml
+++ b/k8s/data-processing/deployments/kube-state-metrics.yml
@@ -11,7 +11,6 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: "v1.2.0"
       annotations:
         prometheus.io/scrape: 'true'
     spec:
@@ -19,6 +18,6 @@ spec:
         prometheus-node: 'true'
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.2.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4
         ports:
         - containerPort: 8080

--- a/k8s/prometheus-federation/deployments/kube-state-metrics.yml
+++ b/k8s/prometheus-federation/deployments/kube-state-metrics.yml
@@ -21,7 +21,7 @@ spec:
       - name: kube-state-metrics
         image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4
         args: [
-          "--collectors=deployments,nodes,pods,services",
+          "--resources=deployments,nodes,pods,services",
           "--port=8080",
         ]
         ports:

--- a/k8s/prometheus-federation/deployments/kube-state-metrics.yml
+++ b/k8s/prometheus-federation/deployments/kube-state-metrics.yml
@@ -19,8 +19,7 @@ spec:
         prometheus-node: 'true'
       containers:
       - name: kube-state-metrics
-        # image: gcr.io/google_containers/kube-state-metrics:v0.5.0
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4
         args: [
           "--collectors=deployments,nodes,pods,services",
           "--port=8080",


### PR DESCRIPTION
This PR updates kube-state-metrics in both the prometheus-federation and data-processing clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/865)
<!-- Reviewable:end -->
