### PR TITLE
Remove offset from throughput alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -843,7 +843,7 @@ groups:
 # deployment, so the timeout for this alert is 3 hours and 10 minutes.
   - alert: GardenerHistoricalThroughputIsStalled
     expr: |
-      increase(gardener_jobs_total{status="success", daily="false"}[1d] offset 24h) > 0
+      increase(gardener_jobs_total{status="success", daily="false"}[1d]) > 0
         UNLESS ON(datatype) bq_gardener_historical_throughput > 0
     for: 190m
     labels:


### PR DESCRIPTION
The alert started misfiring in staging. 

On further inspection, this is because the Gardener self-reported throughput the alert is looking at is from 48h to 24h ago, while the throughput detected in BQ is from the last 24h until now.

With this change, they are both looking at the last 24h period.

We can observe that they line up for that time period in the Throughput section of the dashboard (where there is no offset in the query).
https://grafana.mlab-sandbox.measurementlab.net/d/q4MrNzh7k/pipeline-slis?orgId=1&var-project=mlab-staging&var-PrometheusDS=Prometheus%20(mlab-staging)&var-Gardener2_DS=Data%20Processing%20(mlab-staging)

We can also see that the alert gets resolved with the modified query.
https://prometheus.mlab-staging.measurementlab.net/graph?g0.expr=increase(gardener_jobs_total%7Bdaily%3D%22false%22%2Cstatus%3D%22success%22%7D%5B1d%5D)%20%3E%200%20unless%20on(datatype)%20bq_gardener_historical_throughput%20%3E%200&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/867)
<!-- Reviewable:end -->
