### PR TITLE
Make annotation service alert fire only when all instances are down

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -929,7 +929,7 @@ groups:
 # (prometheus scrape attempts fail) or prometheus does not know about the
 # annotator service at all.
   - alert: ETL_AnnotationDownOrMissing
-    expr: up{service="annotator"} == 0 or absent(up{service="annotator"})
+    expr: sum(up{service="annotator"}) == 0 or absent(up{service="annotator"})
     for: 30m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
Fix alert misfire.

Before: https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=up%7Bservice%3D%22annotator%22%7D%20%3D%3D%200%20or%20absent(up%7Bservice%3D%22annotator%22%7D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=4d

After: https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=sum(up%7Bservice%3D%22annotator%22%7D)%20%3D%3D%200%20or%20absent(up%7Bservice%3D%22annotator%22%7D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=4d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/872)
<!-- Reviewable:end -->
