### PR TITLE
Relax threshold for bq_gardener_historical_throughput alerts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -840,7 +840,7 @@ groups:
 # GardenerHistoricalThroughputIsStalled fires when historical reprocessing for
 # datatypes under processing by the v2 pipeline falls below 1 date / day.
 # The bq_gardener_historical_throughput metric is under the bigquery exporter 3h
-# deployment, so the timeout for this alert is 3 hours and 10 minutes.
+# deployment, so the timeout for this alert is 4 hours.
   - alert: GardenerHistoricalThroughputIsStalled
     expr: |
       increase(gardener_jobs_total{status="success", daily="false"}[1d]) > 0

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -845,7 +845,7 @@ groups:
     expr: |
       increase(gardener_jobs_total{status="success", daily="false"}[1d]) > 0
         UNLESS ON(datatype) bq_gardener_historical_throughput > 0
-    for: 190m
+    for: 4h
     labels:
       repo: dev-tracker
       severity: ticket
@@ -861,7 +861,7 @@ groups:
   - alert: GardenerConfigDatatypeMissingInGardenerHistoricalThroughputQuery
     expr: |
       gardener_config_datatypes UNLESS ON(datatype) bq_gardener_historical_throughput
-    for: 190m
+    for: 4h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
The ` bq_gardener_historical_throughput` query is run every 3h.

The current threshold for the alerts that use this query is 3h and 10mins. T

he GardenerHistoricalThroughputIsStalled alert fired because it took BQ Exporter 3h and 13mins to report the new throughput.

This PR is adjusting the threshold to 4h.

Example:
Alert condition became true at 18:15 and resolved itself at 21:28 (3h and 13mins later).
https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=increase(gardener_jobs_total%7Bdaily%3D%22false%22%2Cstatus%3D%22success%22%7D%5B1d%5D)%20%3E%200%20unless%20on(datatype)%20bq_gardener_historical_throughput%20%3E%200&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=3h28m21s591ms&g0.end_input=2022-02-03%2021%3A40%3A04&g0.moment_input=2022-02-03%2021%3A40%3A04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/873)
<!-- Reviewable:end -->
