### PR TITLE
Sets correct datasource for panel

### DIFF
--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -14,21 +14,23 @@
   },
   "description": "This dashboard displays metrics that are useful to be reviewed as part of the Ops Tactical meetings and SRE rotation.",
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 76,
-  "iteration": 1623449034534,
+  "id": 266,
+  "iteration": 1644349276212,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -61,7 +63,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -100,9 +102,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Alerts (active + suppressed)",
       "tooltip": {
         "shared": false,
@@ -111,9 +111,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -123,22 +121,17 @@
           "format": "short",
           "label": "# of alerts",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
           "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -146,11 +139,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$cluster",
+      "datasource": {
+        "uid": "$cluster"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -184,7 +178,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -203,9 +197,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Pod container restarts (increase 1d)",
       "tooltip": {
         "shared": true,
@@ -214,33 +206,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -248,11 +232,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -288,7 +273,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -307,9 +292,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Kernel logs priority <=3",
       "tooltip": {
         "shared": true,
@@ -318,33 +301,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -365,10 +340,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${cluster}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -402,7 +379,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -431,6 +408,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${cluster}"
+          },
           "expr": "candidate_site:uplink:90th_quantile_6h{ifAlias=\"uplink\", speed=\"1g\"} / 1e9 > (40 / 100)",
           "format": "time_series",
           "hide": false,
@@ -441,6 +422,10 @@
           "step": 300
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${cluster}"
+          },
           "expr": "candidate_site:uplink:90th_quantile_6h{ifAlias=\"uplink\", speed=\"10g\"} / (9.4 * 1e9) > (50 / 100)",
           "format": "time_series",
           "hide": false,
@@ -452,9 +437,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Excessive 6h/90th Percentile of Switch Capacity",
       "tooltip": {
         "shared": false,
@@ -463,35 +446,30 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
+          "$$hashKey": "object:119",
           "format": "percentunit",
           "label": "% Utilized",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
-          "decimals": null,
+          "$$hashKey": "object:120",
           "format": "bps",
           "label": "Switch Rate",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -501,14 +479,10 @@
           "value": "current"
         }
       ],
-      "datasource": "$datasource",
-      "description": "Nodes which have been rebooted by Rebot.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
+      "description": "Nodes which have been rebooted by Rebot.",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -518,7 +492,6 @@
       },
       "id": 14,
       "links": [],
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -530,7 +503,6 @@
           "alias": "Rebooted",
           "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": null,
           "mappingType": 1,
           "pattern": "Current",
           "preserveFormat": false,
@@ -541,7 +513,6 @@
         {
           "alias": "Node",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -564,21 +535,16 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
       "title": "Rebooted nodes",
       "transform": "timeseries_aggregations",
       "type": "table-old"
     },
     {
       "columns": [],
-      "datasource": "$datasource",
-      "description": "Sites that are in GMX maintenance.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
+      "description": "Sites that are in GMX maintenance.",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -588,7 +554,6 @@
       },
       "id": 4,
       "links": [],
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -606,7 +571,6 @@
         {
           "alias": "Site",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -637,14 +601,10 @@
     },
     {
       "columns": [],
-      "datasource": "$datasource",
-      "description": "Nodes that are in GMX maintenance and not part of a site under maintenance.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
+      "description": "Nodes that are in GMX maintenance and not part of a site under maintenance.",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -654,7 +614,6 @@
       },
       "id": 6,
       "links": [],
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -665,7 +624,6 @@
         {
           "alias": "Node",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -692,21 +650,16 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
       "title": "Nodes GMX maintenance (outside sites in GMX)",
       "transform": "timeseries_aggregations",
       "type": "table-old"
     },
     {
       "columns": [],
-      "datasource": "$cluster",
-      "description": "Nodes that are currently in lame-duck mode.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$cluster"
       },
+      "description": "Nodes that are currently in lame-duck mode.",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -716,7 +669,6 @@
       },
       "id": 9,
       "links": [],
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -727,7 +679,6 @@
         {
           "alias": "Node",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -754,19 +705,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
       "title": "Lame-ducked nodes",
       "transform": "timeseries_aggregations",
       "type": "table-old"
     },
     {
       "columns": [],
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fontSize": "100%",
       "gridPos": {
@@ -777,7 +723,6 @@
       },
       "id": 13,
       "links": [],
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -816,7 +761,6 @@
         {
           "alias": "State",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -833,7 +777,6 @@
         {
           "alias": "Count",
           "align": "auto",
-          "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -859,8 +802,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Alerts",
       "transform": "table",
       "transformations": [
@@ -882,10 +823,11 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$cluster",
+      "datasource": {
+        "uid": "$cluster"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -919,7 +861,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -950,9 +892,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Cluster versions",
       "tooltip": {
         "shared": true,
@@ -961,33 +901,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -995,11 +927,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$cluster",
+      "datasource": {
+        "uid": "$cluster"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1030,7 +963,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1053,9 +986,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Rolling updates triggered by Reloader (increase 1d)",
       "tooltip": {
         "shared": true,
@@ -1064,38 +995,29 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1106,7 +1028,6 @@
           "text": "Prometheus (mlab-oti)",
           "value": "Prometheus (mlab-oti)"
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Data source",
@@ -1126,7 +1047,6 @@
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -1173,5 +1093,6 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 11
+  "version": 42,
+  "weekStart": ""
 }


### PR DESCRIPTION
The "Excessive 6h/90th Percentile of Switch Capcity" panel was using the
prometheus-federation datasource, but quite some time ago the required
metric were moved to the platform cluster. This commit sets the correct
datasource for the panel.

This small change to the dashboard has brought in a lot more changes than are apparently needed to just fix the one issue which it aims to correct. This must have to do with the JSON being generated by a newer version of Grafana than it was originally created with.