### PR TITLE
Use equivalent legacy views for all bigquery exporter queries

### DIFF
--- a/config/federation/bigquery/bq_annotation.sql
+++ b/config/federation/bigquery/bq_annotation.sql
@@ -17,11 +17,11 @@
 
 WITH recent_ndt_tcpinfo AS (
   SELECT "ndt/tcpinfo" AS datatype, Client.Geo.latitude, Client.Geo.longitude, systems.ASNs AS asn
-  FROM `measurement-lab.ndt.tcpinfo`, UNNEST(Client.Network.Systems) AS systems
+  FROM `measurement-lab.ndt_raw.tcpinfo_legacy`, UNNEST(Client.Network.Systems) AS systems
   WHERE ParseInfo.ParseTime >= (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR))
 ), recent_traceroute AS (
   SELECT "aggregate/traceroute" AS datatype, Source.Geo.latitude, Destination.Geo.longitude, systems.ASNs AS asn
-  FROM   `measurement-lab.aggregate.traceroute`, UNNEST(Destination.Network.Systems) AS systems
+  FROM   `measurement-lab.ndt_raw.traceroute_legacy`, UNNEST(Destination.Network.Systems) AS systems
   WHERE  ParseInfo.ParseTime >= (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR))
 )
 

--- a/config/federation/bigquery/bq_daily_tests.sql
+++ b/config/federation/bigquery/bq_daily_tests.sql
@@ -5,7 +5,7 @@ WITH ndt7_date_counts AS (
   GROUP BY date
 ), ndt5_date_counts AS (
   SELECT partition_date AS date, COUNT(*) AS total_rows
-  FROM `measurement-lab.ndt.ndt5`
+  FROM `measurement-lab.ndt_raw.ndt5_legacy`
   WHERE partition_date > DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
   GROUP BY date
 ), total_date_counts AS (

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -18,22 +18,22 @@ SELECT
   datatype
 FROM (
     SELECT "ndt/web100" AS datatype, MIN(parse_time) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt.web100`
+    FROM   `{{PROJECT}}.ndt_raw.web100_legacy`
   UNION ALL
     SELECT "sidestream/web100" AS datatype, MIN(parse_time) AS min_parse_time
-    FROM   `{{PROJECT}}.sidestream.web100`
+    FROM   `{{PROJECT}}.sidestream.web100_legacy`
   UNION ALL
     SELECT "utilization/switch" AS datatype, MIN(parse_time) AS min_parse_time
-    FROM   `{{PROJECT}}.utilization.switch`
+    FROM   `{{PROJECT}}.utilization.switch_legacy`
   UNION ALL
     SELECT "ndt/traceroute" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt.traceroute`
+    FROM   `{{PROJECT}}.ndt_raw.traceroute_legacy`
   UNION ALL
     SELECT "ndt/tcpinfo" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt.tcpinfo`
+    FROM   `{{PROJECT}}.ndt_raw.tcpinfo_legacy`
   UNION ALL
     SELECT "ndt/ndt5" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt.ndt5`
+    FROM   `{{PROJECT}}.ndt_raw.ndt5_legacy`
   UNION ALL
     SELECT "ndt/ndt7" AS datatype, MIN(Parser.Time) AS min_parse_time
     FROM   `{{PROJECT}}.raw_ndt.ndt7`

--- a/config/federation/bigquery/bq_ipv6_bias.sql
+++ b/config/federation/bigquery/bq_ipv6_bias.sql
@@ -22,7 +22,7 @@ SELECT
    COUNT(*) AS value
 
 FROM
-    `measurement-lab.ndt.web100`
+    `measurement-lab.ndt_raw.web100_legacy`
 
 WHERE
     -- For faster queries we use `partition_date` boundaries. And, to guarantee

--- a/config/federation/bigquery/bq_ndt_geohash_client.sql
+++ b/config/federation/bigquery/bq_ndt_geohash_client.sql
@@ -109,7 +109,7 @@ FROM (
     connection_spec.client_geolocation.country_code AS country_code,
     connection_spec.client_geolocation.continent_code AS continent_code
   FROM
-    `measurement-lab.ndt.web100`
+    `measurement-lab.ndt_raw.web100_legacy`
   WHERE
     -- For faster queries we use `partition_date` boundaries. And, to
     -- guarantee the partition_date data is "complete" (all data collected

--- a/config/federation/bigquery/bq_ndt_geohash_server.sql
+++ b/config/federation/bigquery/bq_ndt_geohash_server.sql
@@ -87,7 +87,7 @@ FROM
     REGEXP_EXTRACT(connection_spec.server_hostname, r"mlab[1-4].([a-z]{3}[0-9]{2}).*") as site,
     COUNT(*) AS value_tests
   FROM
-    `measurement-lab.ndt.web100`
+    `measurement-lab.ndt_raw.web100_legacy`
   WHERE
         -- For faster queries we use `partition_date` boundaries. And, to
         -- guarantee the partition_date data is "complete" (all data collected

--- a/config/federation/bigquery/bq_ndt_s2c.sql
+++ b/config/federation/bigquery/bq_ndt_s2c.sql
@@ -24,7 +24,7 @@ WITH
     sample.timestamp AS tend,
     sample.value AS discards
   FROM
-    `measurement-lab.utilization.switch`,
+    `measurement-lab.utilization.switch_legacy`,
     UNNEST(sample) AS sample
   WHERE
     partition_date = queryDATE()
@@ -43,7 +43,7 @@ WITH
     result.S2C.StartTime AS tstart,
     result.S2C.EndTime AS tend
   FROM
-    `measurement-lab.ndt.ndt5`
+    `measurement-lab.ndt_raw.ndt5_legacy`
   WHERE
     partition_date = queryDATE()
     AND result.S2C.UUID IS NOT NULL
@@ -107,7 +107,7 @@ FROM (
   END
     AS discards
   FROM
-    `measurement-lab.ndt.ndt5`
+    `measurement-lab.ndt_raw.ndt5_legacy`
   WHERE
     partition_date = queryDATE()
     AND result.S2C.UUID IS NOT NULL

--- a/config/federation/bigquery/bq_ndt_server.sql
+++ b/config/federation/bigquery/bq_ndt_server.sql
@@ -53,7 +53,7 @@ FROM (
         web100_log_entry.snap.SumRTT/web100_log_entry.snap.CountRTT/1000 AS rtt
 
     FROM
-       `measurement-lab.ndt.web100`
+       `measurement-lab.ndt_raw.web100_legacy`
 
     WHERE
         -- For faster queries we use `partition_date` boundaries. And, to

--- a/config/federation/bigquery/bq_ndt_tests.sql
+++ b/config/federation/bigquery/bq_ndt_tests.sql
@@ -43,7 +43,7 @@ FROM (
       connection_spec.server_hostname AS machine,
       ROW_NUMBER() OVER (PARTITION BY test_id) row_number
     FROM
-      `measurement-lab.ndt.web100`
+      `measurement-lab.ndt_raw.web100_legacy`
     WHERE
       -- Restrict queries to tests in the range 2d <= log_time < today()
           partition_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)

--- a/config/federation/bigquery/bq_ndt_worldmap_server.sql
+++ b/config/federation/bigquery/bq_ndt_worldmap_server.sql
@@ -18,7 +18,7 @@ FROM (
           END AS direction
 
     FROM
-       `measurement-lab.ndt.web100`
+       `measurement-lab.ndt_raw.web100_legacy`
 
     WHERE
         -- For faster queries we use `partition_date` boundaries. And, to


### PR DESCRIPTION
This change updates all current and past (not actively used by the bq exporter) queries to use legacy views explicitly. This change is in preparation for non-disruptive deployments of v2 parsers for switch, ndt5, and tcpinfo. With these changes, the existing queries and users of the v1 parser schemas will continue to WAI. After this change it should be safe to deploy updated parsers without affecting current bqx queries. After that it will be necessary to update the BQX queries again to use the new v2 tables.

Part of:
* https://github.com/m-lab/etl/issues/1050

FYI: @robertodauria 