### PR TITLE
Update etl_test_count references

### DIFF
--- a/config/federation/grafana/dashboards/Alert_ParserDailyVolumeTooLow.json
+++ b/config/federation/grafana/dashboards/Alert_ParserDailyVolumeTooLow.json
@@ -56,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "candidate_service:etl_test_count:increase24h",
+          "expr": "candidate_service:etl_test_total:increase24h",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -64,7 +64,7 @@
           "refId": "A"
         },
         {
-          "expr": "0.7 * quantile by(service)(0.50,\n         label_replace(candidate_service:etl_test_count:increase24h offset 1d,\"delay\",\"1d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 3d,\"delay\",\"3d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 5d,\"delay\",\"5d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_count:increase24h offset 7d,\"delay\",\"7d\",\"\",\".*\" ) OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\")\n         )",
+          "expr": "0.7 * quantile by(service)(0.50,\n         label_replace(candidate_service:etl_test_total:increase24h offset 1d,\"delay\",\"1d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_total:increase24h offset 3d,\"delay\",\"3d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_total:increase24h offset 5d,\"delay\",\"5d\",\"\",\".*\" ) OR\n         label_replace(candidate_service:etl_test_total:increase24h offset 7d,\"delay\",\"7d\",\"\",\".*\" ) OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-ndt-parser\",        \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-sidestream-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c1\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\") OR\n         label_replace(label_replace(vector(0),\"delay\",\"c2\",\"\",\".*\" ), \"service\", \"etl-traceroute-parser\", \"\", \".*\")\n         )",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/config/federation/grafana/dashboards/KeepMLabRunning.json
+++ b/config/federation/grafana/dashboards/KeepMLabRunning.json
@@ -465,27 +465,27 @@
       "targets": [
         {
           "datasource": "Data Processing (mlab-oti)",
-          "expr": "60*sum by(table) (rate(etl_test_count[10m]))",
+          "expr": "60*sum by(table) (rate(etl_test_total[10m]))",
           "hide": true,
           "legendFormat": "standard - {{table}}",
           "refId": "C"
         },
         {
           "datasource": "Prometheus (mlab-oti)",
-          "expr": "60 * sum by (table) (rate(etl_test_count[10m]))",
+          "expr": "60 * sum by (table) (rate(etl_test_total[10m]))",
           "hide": true,
           "legendFormat": "legacy - {{table}}",
           "refId": "D"
         },
         {
           "datasource": "Data Processing (mlab-oti)",
-          "expr": "60*sum (rate(etl_test_count[10m]))",
+          "expr": "60*sum (rate(etl_test_total[10m]))",
           "legendFormat": "standard",
           "refId": "A"
         },
         {
           "datasource": "Prometheus (mlab-oti)",
-          "expr": "60 * sum  (rate(etl_test_count[10m]))",
+          "expr": "60 * sum  (rate(etl_test_total[10m]))",
           "legendFormat": "legacy",
           "refId": "B"
         }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -666,12 +666,12 @@ groups:
 # the delay dimension.
   - alert: ParserDailyVolumeTooLow
     expr: |
-      candidate_service:etl_test_count:increase24h
+      candidate_service:etl_test_total:increase24h
         < (0.7 * quantile by(service)(0.5,
-          label_replace(candidate_service:etl_test_count:increase24h offset 1d, "delay", "1d", "", ".*") or
-          label_replace(candidate_service:etl_test_count:increase24h offset 3d, "delay", "3d", "", ".*") or
-          label_replace(candidate_service:etl_test_count:increase24h offset 5d, "delay", "5d", "", ".*") or
-            label_replace(candidate_service:etl_test_count:increase24h offset 1w, "delay", "7d", "", ".*") or
+          label_replace(candidate_service:etl_test_total:increase24h offset 1d, "delay", "1d", "", ".*") or
+          label_replace(candidate_service:etl_test_total:increase24h offset 3d, "delay", "3d", "", ".*") or
+          label_replace(candidate_service:etl_test_total:increase24h offset 5d, "delay", "5d", "", ".*") or
+            label_replace(candidate_service:etl_test_total:increase24h offset 1w, "delay", "7d", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "etl-disco-parser", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "service", "etl-disco-parser", "", ".*") or
             label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "service", "etl-ndt-parser", "", ".*") or

--- a/config/federation/prometheus/rules.yml
+++ b/config/federation/prometheus/rules.yml
@@ -41,8 +41,8 @@ groups:
   # This rule optimizes the alert query used for ParserDailyVolumeTooLow. Rather
   # than calculate multi-day values continuously, this rule will maintain a history
   # of the precalculated value needed by the rule.
-  - record: candidate_service:etl_test_count:increase24h
-    expr: sum by(service) (increase(etl_test_count{service!~".*batch.*",status="ok"}[1d]))
+  - record: candidate_service:etl_test_total:increase24h
+    expr: sum by(service) (increase(etl_test_total{service!~".*batch.*",status="ok"}[1d]))
 
   # Calculates the daily increase of GCS files for all datatypes.
   # NOTE: increase() appears to add an addition 8-10 archives over reality.


### PR DESCRIPTION
The `etl_test_count` metric has been renamed to `etl_test_total` in https://github.com/m-lab/etl/pull/1053. 

Its references in prometheus-support need to be updated.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/879)
<!-- Reviewable:end -->
