### PR TITLE
Adds new alert to monitor Vector functionality

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -548,6 +548,24 @@ groups:
         the underlying service. Please check the GAE dashboard and logs to
         determine the cause.
 
+# If container logs for a node are missing in Stackdriver for too long, then
+# fire an alert, unless the node is in maintenance mode.
+  - alert: PlatformCluster_ContainerLogsMissingInStackdriver
+    expr: |
+      label_replace(
+        sum_over_time(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs[1h]) == 0,
+        "node", "$1", "node_id", "(.*)"
+      ) unless on(node) gmx_machine_maintenance == 1
+    for: 24h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: Container logs for a node are missing in Stackdriver for more than 24h.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_containerlogsmissinginstackdriver
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
 # One or more generic (non-experiment specific) mlab-ns metrics is missing.
 # These are metrics that mlab-ns relies on to determine whether an experiment
 # should receive production traffic, so we need to make sure that the metrics

--- a/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/mlabns-stackdriver.yml
@@ -18,7 +18,7 @@ spec:
         prometheus-node: 'true'
       containers:
       - name: stackdriver
-        image: frodenas/stackdriver-exporter:v0.6.0
+        image: prometheuscommunity/stackdriver-exporter:v0.11.0
         args: [
           # Metrics are available with some delay, so look 5 minutes in the past.
           "--monitoring.metrics-offset=5m",


### PR DESCRIPTION
This PR adds a new alert which aims to give us some confidence that Vector in the platform clusters is working as intended. A new logs-based metric named platform-cluster-container-logs was created, and we query this new metric to determine if Vector is pushing container logs to Stackdriver. The new metric is a count of log entries on a per-node basis. When the sum of that count over an hour is equal to 0 for 24h, then this alert should fire.

This PR also updates the mlab-ns instance of stackdriver_exporter to v0.11.0, and moves to using the proper Docker repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/881)
<!-- Reviewable:end -->
