### PR TITLE
Updates alert for when Stackdriver is missing container logs for a node

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -559,7 +559,7 @@ groups:
         unless on(node) label_replace(
           sum_over_time(
             stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs
-          [15m]),
+          [1h]),
           "node", "$1", "node_id", "(.*)"
         )
         unless on(node) gmx_machine_maintenance == 1

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -556,13 +556,10 @@ groups:
   - alert: PlatformCluster_ContainerLogsMissingInStackdriver
     expr: |
       kube_node_status_condition{condition="Ready", status="true", node=~"mlab[1-4].*"} == 1
-        unless on(node) label_replace(
-          sum_over_time(
-            stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs
-          [1h]),
-          "node", "$1", "node_id", "(.*)"
-        )
-        unless on(node) gmx_machine_maintenance == 1
+        unless on(machine) sum_over_time(
+          stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs
+        [1h])
+        unless on(machine) gmx_machine_maintenance == 1
     for: 24h
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -549,13 +549,20 @@ groups:
         determine the cause.
 
 # If container logs for a node are missing in Stackdriver for too long, then
-# fire an alert, unless the node is in maintenance mode.
+# fire an alert, unless the node is in maintenance mode. This somewhat awkward
+# query discovers cases where the stackdriver metric has been absent for too
+# long, indicating a likely issue with the Vector pod on the node, causing it
+# to fail to upload container logs to Stackdriver.
   - alert: PlatformCluster_ContainerLogsMissingInStackdriver
     expr: |
-      label_replace(
-        sum_over_time(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs[1h]) == 0,
-        "node", "$1", "node_id", "(.*)"
-      ) unless on(node) gmx_machine_maintenance == 1
+      kube_node_status_condition{condition="Ready", status="true", node=~"mlab[1-4].*"} == 1
+        unless on(node) label_replace(
+          sum_over_time(
+            stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs
+          [15m]),
+          "node", "$1", "node_id", "(.*)"
+        )
+        unless on(node) gmx_machine_maintenance == 1
     for: 24h
     labels:
       repo: ops-tracker

--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: github-receiver
-        image: measurementlab/alertmanager-github-receiver:v0.8
+        image: measurementlab/alertmanager-github-receiver:v0.10
         env:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:


### PR DESCRIPTION
The current alert is based on a misunderstanding I had about how metrics from Stackdriver work. This updated alert should warn us when a node's status is "Ready=True", but there is no stackdriver metric indicating that any log entries were received by Stackdriver for a node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/883)
<!-- Reviewable:end -->
