### PR TITLE
Change datatype name in bq_gardener_historical query to "switch".

### DIFF
--- a/config/federation/bigquery/bq_gardener_historical.sql.template
+++ b/config/federation/bigquery/bq_gardener_historical.sql.template
@@ -64,7 +64,7 @@ WITH all_types AS (
     date > date('2019-03-28')
   UNION ALL
   SELECT
-    "raw_utilization.switch" AS datatype,
+    "switch" AS datatype,
     id,
     date,
     parser.Time as parseTime,


### PR DESCRIPTION
This name should match the name in Gardener, to prevent an inventory alert from firing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/884)
<!-- Reviewable:end -->
