### PR TITLE
Check parsetime for raw_ndt.tcpinfo

### DIFF
--- a/config/federation/bigquery/bq_gardener.sql.template
+++ b/config/federation/bigquery/bq_gardener.sql.template
@@ -117,6 +117,26 @@ WITH all_types AS (
     `{{PROJECT}}.raw_utilization.switch`
   WHERE
     date > date('2015-11-19')
+  UNION ALL
+  SELECT
+   "raw_ndt.tcpinfo" AS datatype,
+   id,
+   date,
+   parser.Time as parseTime,
+  FROM
+    `{{PROJECT}}.raw_ndt.tcpinfo`
+  WHERE
+    date > DATE('2019-01-01')
+  UNION ALL
+  SELECT
+   "ndt.tcpinfo" AS datatype,
+   id,
+   date,
+   parser.Time as parseTime,
+  FROM
+    `{{PROJECT}}.ndt.tcpinfo`
+  WHERE
+    date > DATE('2019-01-01')
 ),
 
 basic_stats AS (

--- a/config/federation/bigquery/bq_gardener_historical.sql.template
+++ b/config/federation/bigquery/bq_gardener_historical.sql.template
@@ -72,6 +72,7 @@ WITH all_types AS (
     `{{PROJECT}}.raw_utilization.switch`
   WHERE
     date > date('2015-11-19')
+  UNION ALL
   SELECT
    "tcpinfo" AS datatype,
    id,

--- a/config/federation/bigquery/bq_gardener_historical.sql.template
+++ b/config/federation/bigquery/bq_gardener_historical.sql.template
@@ -72,6 +72,15 @@ WITH all_types AS (
     `{{PROJECT}}.raw_utilization.switch`
   WHERE
     date > date('2015-11-19')
+  SELECT
+   "tcpinfo" AS datatype,
+   id,
+   date,
+   parser.Time as parseTime,
+  FROM
+    `{{PROJECT}}.raw_ndt.tcpinfo`
+  WHERE
+    date > DATE('2019-01-01')
 ),
 
 processed_types AS (

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -23,15 +23,16 @@ FROM (
     SELECT "sidestream/web100" AS datatype, MIN(parse_time) AS min_parse_time
     FROM   `{{PROJECT}}.sidestream.web100_legacy`
   UNION ALL
+    SELECT "ndt/traceroute" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
+    FROM   `{{PROJECT}}.ndt_raw.traceroute_legacy`
+  UNION ALL
     SELECT "utilization/switch" AS datatype, MIN(parser.Time) AS min_parse_time
     FROM   `{{PROJECT}}.utilization.switch`
     WHERE date > DATE('2015-11-19')
   UNION ALL
-    SELECT "ndt/traceroute" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt_raw.traceroute_legacy`
-  UNION ALL
-    SELECT "ndt/tcpinfo" AS datatype, MIN(ParseInfo.ParseTime) AS min_parse_time
-    FROM   `{{PROJECT}}.ndt_raw.tcpinfo_legacy`
+    SELECT "ndt/tcpinfo" AS datatype, MIN(parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.tcpinfo`
+    WHERE date > DATE('2019-01-01') -- satisfy required date filter.
   UNION ALL
     SELECT "ndt/ndt5" AS datatype, MIN(parser.Time) AS min_parse_time
     FROM   `{{PROJECT}}.raw_ndt.ndt5`

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -30,10 +30,6 @@ FROM (
     FROM   `{{PROJECT}}.utilization.switch`
     WHERE date > DATE('2015-11-19')
   UNION ALL
-    SELECT "ndt/tcpinfo" AS datatype, MIN(parser.Time) AS min_parse_time
-    FROM   `{{PROJECT}}.raw_ndt.tcpinfo`
-    WHERE date > DATE('2019-01-01') -- satisfy required date filter.
-  UNION ALL
     SELECT "ndt/ndt5" AS datatype, MIN(parser.Time) AS min_parse_time
     FROM   `{{PROJECT}}.raw_ndt.ndt5`
     WHERE date > DATE('2019-01-01') -- satisfy required date filter.
@@ -57,4 +53,8 @@ FROM (
     SELECT "ndt/scamper1" AS datatype, MIN(Parser.Time) AS min_parse_time
     FROM   `{{PROJECT}}.raw_ndt.scamper1`
     WHERE date > date('2019-03-28')
+  UNION ALL
+    SELECT "ndt/tcpinfo" AS datatype, MIN(parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.tcpinfo`
+    WHERE date > DATE('2019-01-01') -- satisfy required date filter.
 )


### PR DESCRIPTION
This change replaces parse time monitoring of `tcpinfo_legacy` with `ndt_raw.tcpinfo` to complement the new v2 tcpinfo parser. This change also adds tcpinfo to the `bq_gardener_historical_*` for the inventory alert.

This change does not yet pdate `bq_annotation.sql` since it references `measurement-lab`, which depends on a production deployment of the new parser.

Part of:
* https://github.com/m-lab/etl/issues/1066

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/888)
<!-- Reviewable:end -->
