### PR TITLE
Updates configmap-reload container image to v0.7.1

### DIFF
--- a/k8s/data-processing/deployments/prometheus.yml
+++ b/k8s/data-processing/deployments/prometheus.yml
@@ -90,7 +90,7 @@ spec:
 
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
-      - image: jimmidyson/configmap-reload:v0.2.2
+      - image: jimmidyson/configmap-reload:v0.7.1
         name: configmap-reload
         args: ["-webhook-url", "http://prometheus-public-service.default.svc.cluster.local:9090/-/reload",
                "-volume-dir", "/prometheus-config"]

--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -62,7 +62,7 @@ spec:
 
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
-      - image: jimmidyson/configmap-reload:v0.2.2
+      - image: jimmidyson/configmap-reload:v0.7.1
         name: configmap-reload
         args: ["-webhook-url", "$(ALERTMGR_RELOAD_URL)", "-volume-dir", "/alertmanager-config"]
         env:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -158,7 +158,7 @@ spec:
 
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
-      - image: jimmidyson/configmap-reload:v0.3.0
+      - image: jimmidyson/configmap-reload:v0.7.1
         name: configmap-reload
         args: ["-webhook-url", "http://prometheus-service.default.svc.cluster.local:9090/-/reload",
                "-volume-dir", "/prometheus-config"]


### PR DESCRIPTION
The owner of the configmap-reload repo does not do full releases, only tags, but the [set of changes](https://github.com/jimmidyson/configmap-reload/compare/v0.4.0...v0.7.1) from, say, v0.4.0 to the current version (v0.7.1) is pretty minimal.