### PR TITLE
Change {{PROJECT}} back to 'measurement-lab'

### DIFF
--- a/config/federation/bigquery/bq_annotation.sql
+++ b/config/federation/bigquery/bq_annotation.sql
@@ -17,11 +17,11 @@
 
 WITH recent_ndt_tcpinfo AS (
   SELECT "ndt/tcpinfo" AS datatype, Client.Geo.latitude, Client.Geo.longitude, systems.ASNs AS asn
-  FROM `{{PROJECT}}.ndt_raw.tcpinfo_legacy`, UNNEST(Client.Network.Systems) AS systems
+  FROM `measurement-lab.ndt_raw.tcpinfo_legacy`, UNNEST(Client.Network.Systems) AS systems
   WHERE ParseInfo.ParseTime >= (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR))
 ), recent_paris1 AS (
   SELECT "aggregate/paris1" AS datatype, Source.Geo.latitude, Destination.Geo.longitude, systems.ASNs AS asn
-  FROM   `{{PROJECT}}.ndt_raw.paris1_legacy`, UNNEST(Destination.Network.Systems) AS systems
+  FROM   `measurement-lab.ndt_raw.paris1_legacy`, UNNEST(Destination.Network.Systems) AS systems
   WHERE  ParseInfo.ParseTime >= (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR))
 )
 


### PR DESCRIPTION
The BQ Exporter is generating this error `2022/04/04 20:11:43 collector.go:81: googleapi: Error 400: Invalid project ID '{{PROJECT}}'. Project IDs must contain 6-63 lowercase letters, digits, or dashes. Some project IDs also include domain name separated by a colon. IDs must start with a letter and may not end with a dash., invalid` because the sql file is not a template.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/893)
<!-- Reviewable:end -->
