### PR TITLE
Use greater than or equal to include previous day

### DIFF
--- a/config/federation/bigquery/bq_daily_discuss.sql
+++ b/config/federation/bigquery/bq_daily_discuss.sql
@@ -12,13 +12,13 @@
 -- authenticated queries of unified views once they are more efficient.
 
 WITH ndt7 AS (
-    SELECT * FROM `measurement-lab.ndt.ndt7` WHERE date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+    SELECT * FROM `measurement-lab.ndt.ndt7` WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), ndt5 AS (
-    SELECT * FROM `measurement-lab.ndt.ndt5` WHERE date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+    SELECT * FROM `measurement-lab.ndt.ndt5` WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), scamper1 AS (
-    SELECT * FROM `measurement-lab.ndt.scamper1` WHERE date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+    SELECT * FROM `measurement-lab.ndt.scamper1` WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), tcpinfo AS (
-    SELECT * FROM `measurement-lab.ndt.tcpinfo` WHERE date > DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+    SELECT * FROM `measurement-lab.ndt.tcpinfo` WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 )
 
 SELECT "ndt7" as datatype, COUNT(*) AS value_total FROM ndt7


### PR DESCRIPTION
Due to daily processing delays between UTC 00:00:00 and 10:30:00 UTC, `>` will briefly exclude all dates with rows, yielding a false counts of zero. This change adds `>=`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/897)
<!-- Reviewable:end -->
