### PR TITLE
Add alert for queries from discuss@ users

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1235,6 +1235,7 @@ groups:
     labels:
       repo: dev-tracker
       severity: ticket
+      cluster: prometheus-federation
     annotations:
       summary: Queries run by discuss@ users may be broken or return zero results.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_dailydiscussaccesszeroormissing

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1224,3 +1224,18 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#prometheuspersistentdisktoofull
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/sVklmeHik/prometheus-self-monitoring?orgId=1&var-datasource=default
 
+
+# Pipeline_DailyDiscussAccessZeroOrMissing fires when queries run with the same
+# permissions as a member of the discuss@ mailing list return zero results
+# or fail entirely.
+  - alert: Pipeline_DailyDiscussAccessZeroOrMissing
+    expr: |
+      bq_daily_discuss_total == 0 OR absent(bq_daily_discuss_total)
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+    annotations:
+      summary: Queries run by discuss@ users may be broken or return zero results.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_dailydiscussaccesszeroormissing
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/UTgnK-jMz/pipeline-overview?orgId=1&refresh=5m


### PR DESCRIPTION
This change adds a new alert based on the metrics produced by https://github.com/m-lab/prometheus-support/pull/895

This alert should fire when queries fail (for one reason or another) when run by a service account with the same permissions as users of the discuss@measurementlab.net mailing list.

This change includes a new playbook entry at https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_dailydiscussaccesszeroormissing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/903)
<!-- Reviewable:end -->
