### PR TITLE
Remove v1 gardener alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -734,23 +734,6 @@ groups:
       description: Login to EB to see if it is in fact crashed. If so, look
         through the logs.
 
-# DataProcessingCluster_GardenerDownOrMissing fires when the etl-gardener is down or absent.
-# TODO: enable annotations to ignore some container ports, and simplify this query.
-# https://github.com/m-lab/prometheus-support/issues/48
-  - alert: DataProcessingCluster_GardenerDownOrMissing
-    expr: |
-      up{container="etl-gardener", deployment!="etl-gardener-universal", instance=~".*:9090"} == 0
-        or absent(up{container="etl-gardener", deployment!="etl-gardener-universal", instance=~".*:9090"})
-    for: 10m
-    labels:
-      repo: dev-tracker
-      severity: ticket
-      cluster: prometheus-federation
-    annotations:
-      summary: The Gardener instance is down or missing.
-      description: Gardener runs in the data-processing-cluster.
-      dashboard: https://grafana.mlab-oti.measurementlab.net/d/eBbUW6oik/pipeline-gardener?var-project=mlab-oti&var-pipelineDatasource=Data%20Proc%20(mlab-oti)
-
 # DataProcessing_GardenerDownOrMissing fires when the etl-gardener-universal is down or absent.
 # TODO: enable annotations to ignore some container ports, and simplify this query.
 # https://github.com/m-lab/prometheus-support/issues/48


### PR DESCRIPTION
After removing the v1 gardener deployments, I found that an alert checks whether these deployments are running.

This change removes the alert that is now obsolete.

Part of:
* https://github.com/m-lab/etl/issues/1074

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/904)
<!-- Reviewable:end -->
