### PR TITLE
Add downloader metrics to data-processing cluster

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -399,6 +399,8 @@ scrape_configs:
         - 'gardener_config_datatypes'
         - 'etl_task_total'
         - 'etl_test_total'
+        - 'up{container="downloader"}'
+        - 'downloader_last_success_time_seconds'
     static_configs:
       - targets: ['prometheus-data-processing.{{PROJECT}}.measurementlab.net:9090']
 


### PR DESCRIPTION
This change updates set of federated metrics scraped from the `data-processing` cluster to include the downloader metrics.

This is part of:
* https://github.com/m-lab/etl/issues/1074
* https://github.com/m-lab/downloader/pull/44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/907)
<!-- Reviewable:end -->
