### PR TITLE
Update go version in .travis.yml to 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ go_import_path: github.com/m-lab/prometheus-support
 
 install:
   # Install promtool and pin it at the latest stable version.
+  # TODO: use a prebuilt binary from the prometheus Docker container to speed
+  # up the build.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=v2.16.0;
   GO111MODULE=off go get -d $PROMTOOL_URI;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   PROMTOOL_VERSION=v2.16.0;
   go install $PROMTOOL_URI:$PROMTOOL_VERSION;
   # Install kexpand templating tool. Only works from HEAD.
-- go get github.com/kopeio/kexpand
+- go install github.com/kopeio/kexpand@latest
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl
   # Install jsonlint (use npm which is lightweight and actually works)
 - npm install jsonlint -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=v2.35.0;
-  go get -d $PROMTOOL_URI;
+  GO111MODULE=OFF go get -d $PROMTOOL_URI;
   git -C $GOPATH/src/$PROMTOOL_URI checkout -b $PROMTOOL_VERSION tags/$PROMTOOL_VERSION;
-  go install $PROMTOOL_URI
+  GO111MODULE=OFF go install $PROMTOOL_URI
   # Install kexpand templating tool. Only works from HEAD.
 - go install github.com/kopeio/kexpand@latest
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ go_import_path: github.com/m-lab/prometheus-support
 install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
-  PROMTOOL_VERSION=v2.35.0;
+  PROMTOOL_VERSION=v2.16.0;
   GO111MODULE=off go get -d $PROMTOOL_URI;
   git -C $GOPATH/src/$PROMTOOL_URI checkout -b $PROMTOOL_VERSION tags/$PROMTOOL_VERSION;
   GO111MODULE=off go install $PROMTOOL_URI

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ go_import_path: github.com/m-lab/prometheus-support
 install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
-  PROMTOOL_VERSION=v2.16.0;
-  go install $PROMTOOL_URI@$PROMTOOL_VERSION;
+  PROMTOOL_VERSION=v2.35.0;
+  go get -d $PROMTOOL_URI;
+  git -C $GOPATH/src/$PROMTOOL_URI checkout -b $PROMTOOL_VERSION tags/$PROMTOOL_VERSION;
+  go install $PROMTOOL_URI
   # Install kexpand templating tool. Only works from HEAD.
 - go install github.com/kopeio/kexpand@latest
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 
 language: go
 go:
- - 1.13
+ - 1.18
 
 addons:
   apt:
@@ -18,9 +18,7 @@ install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=v2.16.0;
-  go get -d $PROMTOOL_URI;
-  git -C $GOPATH/src/$PROMTOOL_URI checkout -b $PROMTOOL_VERSION tags/$PROMTOOL_VERSION;
-  go install $PROMTOOL_URI
+  go install $PROMTOOL_URI:$PROMTOOL_VERSION;
   # Install kexpand templating tool. Only works from HEAD.
 - go get github.com/kopeio/kexpand
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=v2.35.0;
-  GO111MODULE=OFF go get -d $PROMTOOL_URI;
+  GO111MODULE=off go get -d $PROMTOOL_URI;
   git -C $GOPATH/src/$PROMTOOL_URI checkout -b $PROMTOOL_VERSION tags/$PROMTOOL_VERSION;
-  GO111MODULE=OFF go install $PROMTOOL_URI
+  GO111MODULE=off go install $PROMTOOL_URI
   # Install kexpand templating tool. Only works from HEAD.
 - go install github.com/kopeio/kexpand@latest
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # Install promtool and pin it at the latest stable version.
 - PROMTOOL_URI=github.com/prometheus/prometheus/cmd/promtool;
   PROMTOOL_VERSION=v2.16.0;
-  go install $PROMTOOL_URI:$PROMTOOL_VERSION;
+  go install $PROMTOOL_URI@$PROMTOOL_VERSION;
   # Install kexpand templating tool. Only works from HEAD.
 - go install github.com/kopeio/kexpand@latest
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl


### PR DESCRIPTION
This PR removes a warning about `io/fs` not existing in Go < 1.16 that appeared in build outputs while installing promtool.

Unfortunately it seems the prometheus repository does not have a /v2 folder, so `go install ...@v2.x.x` does not work. I kept the installation as it was (repository download + manual git checkout of the desired tag), disabling modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/908)
<!-- Reviewable:end -->
