### PR TITLE
Target the original 'locate' service in script-exporter

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -41,7 +41,7 @@ spec:
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL
-          value: https://locate-platform-dot-{{LOCATE_PROJECT}}.appspot.com/v2/platform/monitoring/
+          value: https://locate-dot-{{LOCATE_PROJECT}}.appspot.com/v2/platform/monitoring/
         ports:
         - containerPort: 9172
         volumeMounts:


### PR DESCRIPTION
Script exporter generating `script_success` metric https://prometheus.mlab-sandbox.measurementlab.net/graph?g0.expr=script_success&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=6h.

This is part of https://github.com/m-lab/prometheus-support/issues/912.

Original PR where the "locate-platform" target was added: https://github.com/m-lab/prometheus-support/pull/714.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/913)
<!-- Reviewable:end -->
