### PR TITLE
Replaces datasource UID with $datasource

### DIFF
--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -966,8 +966,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "WW1Jk2sGk"
+            "uid": "$datasource"
           },
           "exemplar": false,
           "expr": "avg(node_hwmon_temp_celsius{node=~\"$node.$site.*\", chip=\"platform_coretemp_0\"})",
@@ -1244,8 +1243,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "WW1Jk2sGk"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "8 * rate(node_network_transmit_bytes_total{device=~\"(eth0|ens4)\", node=~\"$node-$site.*\"}[4m])",
@@ -1257,8 +1255,7 @@
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "WW1Jk2sGk"
+            "uid": "$datasource"
           },
           "exemplar": true,
           "expr": "- 8 * rate(node_network_receive_bytes_total{device=~\"(eth0|ens4)\", node=~\"$node-$site.*\"}[4m])",


### PR DESCRIPTION
Somehow various panels got a statically defined datasource UID, which is
only valid in sandbox. The correct UID should be "$datasource", allowing
users to effectively switch datasources from a select box. I'm not sure
when error was introduced, but this commit should correct it.