### PR TITLE
Add other datatypes and set longer annotation threshold

### DIFF
--- a/config/federation/bigquery/bq_annotation.sql
+++ b/config/federation/bigquery/bq_annotation.sql
@@ -37,6 +37,10 @@ FROM (
    SELECT * FROM recent_ndt_tcpinfo
    UNION ALL
    SELECT * FROM recent_ndt_ndt7
+   UNION ALL
+   SELECT * FROM recent_ndt_ndt5
+   UNION ALL
+   SELECT * FROM recent_ndt_scamper1
 )
 GROUP BY
   datatype

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -875,11 +875,11 @@ groups:
 # NDT_AsnAnnotationRatioTooLowOrMissing fires when the client annotations on NDT
 # tests appear to have too many failures or the bq_ndt_annotation_* metrics
 # disappear.
-  - alert: NDT_AsnAnnotationRatioTooLowOrMissing
+  - alert: DataPipeline_AsnAnnotationRatioTooLowOrMissing
     expr: |
       bq_annotation_asn_success / bq_annotation_total < 0.98
         or absent(bq_annotation_asn_success / bq_annotation_total)
-    for: 30m
+    for: 60m
     labels:
       repo: dev-tracker
       severity: ticket
@@ -892,11 +892,11 @@ groups:
 # NDT_GeoAnnotationRatioTooLowOrMissing fires when the client annotations on NDT
 # tests (or sidecars) appear to have too many failures or the bq_annotation_* metrics
 # disappear.
-  - alert: NDT_GeoAnnotationRatioTooLowOrMissing
+  - alert: DataPipeline_GeoAnnotationRatioTooLowOrMissing
     expr: |
       bq_annotation_geo_success / bq_annotation_total < 0.98
         or absent(bq_annotation_geo_success / bq_annotation_total)
-    for: 30m
+    for: 60m
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
After migration to the v2 data pipeline and the retirement of the annotation-service, the `DataPipeline_(Asn|Geo)AnnotationRatioTooLowOrMissing` alerts needed to be updated for v2 data type annotations. This change adds two additional annotated data types. Since uuid-annotations are collected at measurement times, and bq processing is delayed 2days, this alert should represent a failure of the pipeline rather than a data loss. Other alerts should cover incomplete uuid-annotation data volume from the node.

This change also extends the alert threshold time from 30min to 60min to allow GKE to restart pods and for the bq-exporter to rerun queries to report metrics. Previously, the 30min threshold has caused false positives due to firing prematurely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/916)
<!-- Reviewable:end -->
