### PR TITLE
Update Pipeline: Overview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1654867866731,
+  "iteration": 1654868086229,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2436,41 +2436,6 @@
         "current": {
           "selected": false,
           "text": [
-            "Finishing",
-            "Processing"
-          ],
-          "value": [
-            "Finishing",
-            "Processing"
-          ]
-        },
-        "datasource": {
-          "uid": "$LegacyDS"
-        },
-        "definition": "label_values(gardener_state_date, state)",
-        "error": {
-          "message": "Datasource  was not found"
-        },
-        "hide": 0,
-        "includeAll": true,
-        "label": "Gardener States",
-        "multi": true,
-        "name": "states",
-        "options": [],
-        "query": "label_values(gardener_state_date, state)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": true,
-          "text": [
             "complete"
           ],
           "value": [
@@ -2503,7 +2468,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "tcpinfo"
           ],

--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1654690382020,
+  "iteration": 1654867866731,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -871,7 +871,7 @@
       }
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -879,1463 +879,1465 @@
         "y": 15
       },
       "id": 67,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$Gardener2_DS"
+          },
+          "description": "We may want to monitor this from the Gardener instance, and suspend operation if the cost exceeds some threshold.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 59,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "expr": "sum  by(version, datatype, query)(rate(query_cost_seconds_sum{}[1h])/rate(query_cost_seconds_count{}[1h]))",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Slot Time per Query {{datatype}} {{query}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "sum by(version, datatype, query)(increase(query_cost_seconds_sum{}[24h]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{datatype}} - {{query}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Gardener BigQuery Slot time (basis of \"cost\")",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:70",
+              "format": "s",
+              "label": "Avg Slot Time per Day",
+              "logBase": 10,
+              "min": "60",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:71",
+              "format": "s",
+              "label": "",
+              "logBase": 1,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "description": "This measures the bytes submitted for processing. \nIt reflects the ETL throughput, which is governed by concurrency settings.\n\nThe rate is governed by how fast the pipeline process daily job tasks.\n\nThis is fundamentally rather lumpy at the 10 minute level, so we average over 24h.  Aside from the fine-grained lumpiness, this should be the most stable of the throughput metrics, because it reflects the quantity of data, rather than the number or size of files.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 103,
+          "interval": "",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(datatype)(rate(gardener_bytes_sum[24h]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{datatype}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Byte Rate (24h avg)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:3840",
+              "format": "decbytes",
+              "label": "Bytes/Hour",
+              "logBase": 10,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:3841",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 101,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "rate(process_cpu_seconds_total{container=\"etl-gardener\"}[5m])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{deployment}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "CPU Utilization",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 107,
+          "interval": "",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:387",
+              "alias": "/Avg Bytes.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "avg by(datatype, year) (\n    rate(gardener_bytes_sum{}[1h]) /\n    rate(gardener_files_sum{}[1h]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{year}} {{datatype}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Bytes / JSONL-Archives",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:3138",
+              "format": "decbytes",
+              "label": "Bytes / File",
+              "logBase": 10,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:3139",
+              "format": "decbytes",
+              "label": "Bytes / File",
+              "logBase": 10,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 111,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:246",
+              "alias": "/ndt7-/",
+              "fill": 1,
+              "stack": "A"
+            },
+            {
+              "$$hashKey": "object:247",
+              "alias": "/annotation-/",
+              "fill": 1,
+              "stack": "B"
+            },
+            {
+              "$$hashKey": "object:248",
+              "alias": "/Stuck|failed/",
+              "color": "rgb(255, 49, 49)",
+              "linewidth": 5,
+              "zindex": -3
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "sum by(datatype) (gardener_tasks_in_flight{state=\"parsing\"}) # sum merges across restarts",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{datatype}} ",
+              "refId": "E"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parsing Tasks in Flight",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:281",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:282",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 105,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": false
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(experiment, datatype, year)(increase(gardener_files_sum[1h]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{experiment}} - {{datatype}} - {{year}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "JSONL-Archive Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:3079",
+              "format": "short",
+              "label": "Files / Hour",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:3080",
+              "format": "decbytes",
+              "label": "Bytes / File",
+              "logBase": 10,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "How long each date spends in each processing state.\nIf Processing exceeds 12 hours, then there will likely be data loss from expiration in the task queue.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 113,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 0.5,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "histogram_quantile(0.90, sum(rate(gardener_state_time_histogram_bucket{datatype=~\"$datatype\"}[6h])) by (state, datatype, le))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{datatype}}: {{state}}",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [
+            {
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 28800,
+              "yaxis": "left"
+            }
+          ],
+          "timeRegions": [],
+          "title": "Time in State (90th Percentile)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:129",
+              "decimals": -3,
+              "format": "s",
+              "logBase": 10,
+              "min": "1",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:130",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Gardener",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$Gardener2_DS"
-      },
-      "description": "We may want to monitor this from the Gardener instance, and suspend operation if the cost exceeds some threshold.",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 59,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "expr": "sum  by(version, datatype, query)(rate(query_cost_seconds_sum{}[1h])/rate(query_cost_seconds_count{}[1h]))",
-          "format": "time_series",
-          "hide": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Slot Time per Query {{datatype}} {{query}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "sum by(version, datatype, query)(increase(query_cost_seconds_sum{}[24h]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{datatype}} - {{query}}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Gardener BigQuery Slot time (basis of \"cost\")",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:70",
-          "format": "s",
-          "label": "Avg Slot Time per Day",
-          "logBase": 10,
-          "min": "60",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:71",
-          "format": "s",
-          "label": "",
-          "logBase": 1,
-          "min": "0",
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "description": "This measures the bytes submitted for processing. \nIt reflects the ETL throughput, which is governed by concurrency settings.\n\nThe rate is governed by how fast the pipeline process daily job tasks.\n\nThis is fundamentally rather lumpy at the 10 minute level, so we average over 24h.  Aside from the fine-grained lumpiness, this should be the most stable of the throughput metrics, because it reflects the quantity of data, rather than the number or size of files.",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 103,
-      "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "sum by(datatype)(rate(gardener_bytes_sum[24h]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{datatype}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Byte Rate (24h avg)",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:3840",
-          "format": "decbytes",
-          "label": "Bytes/Hour",
-          "logBase": 10,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:3841",
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 101,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "rate(process_cpu_seconds_total{container=\"etl-gardener\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{deployment}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "CPU Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percentunit",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 0,
-        "y": 23
-      },
-      "hiddenSeries": false,
-      "id": 107,
-      "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:387",
-          "alias": "/Avg Bytes.*/",
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "avg by(datatype, year) (\n    rate(gardener_bytes_sum{}[1h]) /\n    rate(gardener_files_sum{}[1h]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{year}} {{datatype}}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Bytes / JSONL-Archives",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:3138",
-          "format": "decbytes",
-          "label": "Bytes / File",
-          "logBase": 10,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:3139",
-          "format": "decbytes",
-          "label": "Bytes / File",
-          "logBase": 10,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 23
-      },
-      "hiddenSeries": false,
-      "id": 111,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": false,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:246",
-          "alias": "/ndt7-/",
-          "fill": 1,
-          "stack": "A"
-        },
-        {
-          "$$hashKey": "object:247",
-          "alias": "/annotation-/",
-          "fill": 1,
-          "stack": "B"
-        },
-        {
-          "$$hashKey": "object:248",
-          "alias": "/Stuck|failed/",
-          "color": "rgb(255, 49, 49)",
-          "linewidth": 5,
-          "zindex": -3
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "sum by(datatype) (gardener_tasks_in_flight{state=\"parsing\"}) # sum merges across restarts",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{datatype}} ",
-          "refId": "E"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parsing Tasks in Flight",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:281",
-          "format": "short",
-          "label": "",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:282",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 23
-      },
-      "hiddenSeries": false,
-      "id": 105,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": false
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "sum by(experiment, datatype, year)(increase(gardener_files_sum[1h]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{experiment}} - {{datatype}} - {{year}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "JSONL-Archive Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:3079",
-          "format": "short",
-          "label": "Files / Hour",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:3080",
-          "format": "decbytes",
-          "label": "Bytes / File",
-          "logBase": 10,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "description": "How long each date spends in each processing state.\nIf Processing exceeds 12 hours, then there will likely be data loss from expiration in the task queue.",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 29
-      },
-      "hiddenSeries": false,
-      "id": 113,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 0.5,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "histogram_quantile(0.90, sum(rate(gardener_state_time_histogram_bucket{datatype=~\"$datatype\"}[6h])) by (state, datatype, le))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{datatype}}: {{state}}",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 28800,
-          "yaxis": "left"
-        }
-      ],
-      "timeRegions": [],
-      "title": "Time in State (90th Percentile)",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:129",
-          "decimals": -3,
-          "format": "s",
-          "logBase": 10,
-          "min": "1",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:130",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 16
       },
       "id": 65,
-      "panels": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 99,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "$$hashKey": "object:1910",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status!=\"OK\"}[120m]))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{worker}}",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parser - QPS (Errors)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1095",
+              "decimals": 2,
+              "format": "none",
+              "label": "QPS",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1096",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$Gardener2_DS"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 98,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Parser logs",
+              "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
+            }
+          ],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "60*sum by (table) (rate(etl_gcs_retry_count[10m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{table}} Errors/Min",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parsers - GCS Read Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1996",
+              "format": "short",
+              "label": "Errors/Minute",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1997",
+              "format": "short",
+              "label": "Failures/Thousand Files",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$Gardener2_DS"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 83,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "sum by(table)(rate(etl_test_file_size_bytes_sum{}[30m]))",
+              "interval": "",
+              "legendFormat": "{{table}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parsers - Processing Data Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:115",
+              "format": "Bps",
+              "logBase": 10,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:116",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "editable": false,
+          "error": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 92,
+          "isNew": false,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "histogram_quantile(0.95, sum by(le, table, status) (rate(etl_insertion_time_seconds_bucket{service=\"etl-batch-parser\"}[5m])))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "0.95 {{status}} {{table}}",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "(sum by(le, table, status)(rate(etl_insertion_time_seconds_sum{service=\"etl-batch-parser\"}[5m]))) / (sum by(le, table, status)(rate(etl_insertion_time_seconds_count{service=\"etl-batch-parser\"}[5m])))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "average {{table}}",
+              "refId": "F",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "TODO: Approximate Commit Time Percentiles",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "format": "",
+            "logBase": 0,
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1992",
+              "format": "s",
+              "logBase": 2,
+              "min": 0,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1993",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 94,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "$$hashKey": "object:1910",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status=\"OK\"}[120m]))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{worker}}",
+              "refId": "F"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parser - QPS (OK)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1095",
+              "decimals": 2,
+              "format": "none",
+              "label": "QPS",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1096",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$Gardener2_DS"
+          },
+          "description": "Not clear why there is a small background failure rate.  Probably should investigate.\n\nTODO - separate GCS read and write error metrics",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 73,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Parser logs",
+              "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
+            }
+          ],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "60*sum by (kind, table)(rate(etl_backend_failure_count[10m]))\n",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{table}} Failures/Min {{kind}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "1000*(sum by (table)(rate(etl_backend_failure_count{kind=\"googleapi.Error\"}[30m])))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{table}} Failures Per Thousand Files",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parsers - GCS Write Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1996",
+              "format": "short",
+              "label": "Errors/Minute",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1997",
+              "format": "short",
+              "label": "Failures/Thousand Files",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$Gardener2_DS"
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 87,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000062"
+              },
+              "exemplar": true,
+              "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{}[1h])))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{table}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Parsers - Median Filesize (Bytes)",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:115",
+              "format": "decbytes",
+              "logBase": 10,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:116",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
       "title": "Parsers",
       "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 42
-      },
-      "hiddenSeries": false,
-      "id": 99,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "$$hashKey": "object:1910",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status!=\"OK\"}[120m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{worker}}",
-          "refId": "F"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parser - QPS (Errors)",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1095",
-          "decimals": 2,
-          "format": "none",
-          "label": "QPS",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1096",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$Gardener2_DS"
-      },
-      "description": "",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 42
-      },
-      "hiddenSeries": false,
-      "id": 98,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "Parser logs",
-          "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
-        }
-      ],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "60*sum by (table) (rate(etl_gcs_retry_count[10m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{table}} Errors/Min",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parsers - GCS Read Errors",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1996",
-          "format": "short",
-          "label": "Errors/Minute",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1997",
-          "format": "short",
-          "label": "Failures/Thousand Files",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$Gardener2_DS"
-      },
-      "description": "",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 42
-      },
-      "hiddenSeries": false,
-      "id": 83,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "sum by(table)(rate(etl_test_file_size_bytes_sum{}[30m]))",
-          "interval": "",
-          "legendFormat": "{{table}}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parsers - Processing Data Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:115",
-          "format": "Bps",
-          "logBase": 10,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:116",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "editable": false,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 42
-      },
-      "hiddenSeries": false,
-      "id": 92,
-      "isNew": false,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by(le, table, status) (rate(etl_insertion_time_seconds_bucket{service=\"etl-batch-parser\"}[5m])))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "0.95 {{status}} {{table}}",
-          "refId": "B",
-          "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "(sum by(le, table, status)(rate(etl_insertion_time_seconds_sum{service=\"etl-batch-parser\"}[5m]))) / (sum by(le, table, status)(rate(etl_insertion_time_seconds_count{service=\"etl-batch-parser\"}[5m])))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "average {{table}}",
-          "refId": "F",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "TODO: Approximate Commit Time Percentiles",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "format": "",
-        "logBase": 0,
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1992",
-          "format": "s",
-          "logBase": 2,
-          "min": 0,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1993",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${Gardener2_DS}"
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 49
-      },
-      "hiddenSeries": false,
-      "id": 94,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null as zero",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "$$hashKey": "object:1910",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Gardener2_DS}"
-          },
-          "exemplar": true,
-          "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status=\"OK\"}[120m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{worker}}",
-          "refId": "F"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parser - QPS (OK)",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1095",
-          "decimals": 2,
-          "format": "none",
-          "label": "QPS",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1096",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$Gardener2_DS"
-      },
-      "description": "Not clear why there is a small background failure rate.  Probably should investigate.\n\nTODO - separate GCS read and write error metrics",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 49
-      },
-      "hiddenSeries": false,
-      "id": 73,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "Parser logs",
-          "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
-        }
-      ],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "60*sum by (kind, table)(rate(etl_backend_failure_count[10m]))\n",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{table}} Failures/Min {{kind}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "1000*(sum by (table)(rate(etl_backend_failure_count{kind=\"googleapi.Error\"}[30m])))",
-          "hide": true,
-          "interval": "",
-          "legendFormat": "{{table}} Failures Per Thousand Files",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parsers - GCS Write Errors",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1996",
-          "format": "short",
-          "label": "Errors/Minute",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1997",
-          "format": "short",
-          "label": "Failures/Thousand Files",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$Gardener2_DS"
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 49
-      },
-      "hiddenSeries": false,
-      "id": 87,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "000000062"
-          },
-          "exemplar": true,
-          "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{}[1h])))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{table}}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Parsers - Median Filesize (Bytes)",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:115",
-          "format": "decbytes",
-          "logBase": 10,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:116",
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
     }
   ],
   "refresh": "5m",
@@ -2563,6 +2565,6 @@
   "timezone": "utc",
   "title": "Pipeline: Overview",
   "uid": "UTgnK-jMz",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -13,14 +13,14 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1623702230339,
+  "iteration": 1654690382020,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "collapsed": true,
-      "datasource": null,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -28,1577 +28,8 @@
         "y": 0
       },
       "id": 90,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$PrometheusDS",
-          "decimals": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 8
-          },
-          "hiddenSeries": false,
-          "id": 63,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": false,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "bq_gardener_parse_time_age_days",
-              "format": "time_series",
-              "instant": true,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{datatype}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Oldest Bigquery Parse Time",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-              "total"
-            ]
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:574",
-              "decimals": 1,
-              "format": "none",
-              "label": "Days",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:575",
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "We may want to monitor this from the Gardener instance, and suspend operation if the cost exceeds some threshold.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 8
-          },
-          "hiddenSeries": false,
-          "id": 59,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:63",
-              "alias": "/Cumulative/",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum  by(version, datatype, query)(rate(query_cost_seconds_sum{}[1h])/rate(query_cost_seconds_count{}[1h]))",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Slot Time per Query {{datatype}} {{query}}",
-              "refId": "A"
-            },
-            {
-              "expr": "sum by(version, datatype, query)(increase(query_cost_seconds_sum{}[24h]))",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Cumulative per Day {{datatype}} {{query}}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [
-            {
-              "$$hashKey": "object:98",
-              "colorMode": "warning",
-              "fill": true,
-              "line": true,
-              "op": "gt",
-              "value": 2419200,
-              "yaxis": "right"
-            }
-          ],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Gardener 2.0 Bigquery Costs",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:70",
-              "decimals": null,
-              "format": "s",
-              "label": "Slot Time per Query",
-              "logBase": 1,
-              "max": "28800",
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:71",
-              "decimals": null,
-              "format": "s",
-              "label": "Avg Slot Time per Day",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 8
-          },
-          "hiddenSeries": false,
-          "id": 61,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:482",
-              "alias": "/Recent/",
-              "linewidth": 5
-            },
-            {
-              "$$hashKey": "object:490",
-              "alias": "/Dedup/",
-              "color": "#3274D9"
-            },
-            {
-              "$$hashKey": "object:500",
-              "alias": "/4 weeks/",
-              "dashes": true,
-              "linewidth": 3
-            },
-            {
-              "$$hashKey": "object:511",
-              "alias": "/Join/",
-              "color": "#A352CC"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by(version, query)(increase(query_cost_seconds_sum{}[24h]))",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 10,
-              "legendFormat": "Recent {{version}} {{query}}",
-              "refId": "B"
-            },
-            {
-              "expr": "sum by(version, query)(increase(query_cost_seconds_sum{}[24h]  offset 28d))",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 10,
-              "legendFormat": "4 weeks ago {{version}} {{query}}",
-              "refId": "C"
-            },
-            {
-              "expr": "sum by(query)(increase(query_cost_seconds_sum{}[24h]  offset 56d))",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 10,
-              "legendFormat": "8 weeks ago {{query}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Weekly query slot-time",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:289",
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:290",
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "General",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 67,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$LegacyDS",
-          "description": "Uptime for Legacy Gardener Instances",
-          "editable": false,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 0,
-            "y": 9
-          },
-          "hiddenSeries": false,
-          "id": 49,
-          "interval": "",
-          "isNew": false,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:750",
-              "alias": "/instance count/",
-              "fill": 0,
-              "yaxis": 2
-            },
-            {
-              "$$hashKey": "object:751",
-              "alias": "/Gardener/",
-              "linewidth": 2,
-              "steppedLine": false
-            },
-            {
-              "$$hashKey": "object:752",
-              "alias": "/Git Commit/",
-              "fill": 0,
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "avg by(run, pod_template_hash)(time()-process_start_time_seconds{container=~\"etl-gardener\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{run}} {{pod_template_hash}}",
-              "refId": "A",
-              "step": 20
-            },
-            {
-              "expr": "sum by(container, value)(etl_commit_hash{})",
-              "interval": "",
-              "legendFormat": "Git Hash {{container}} = {{value}}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Legacy Gardeners (one per datatype) ",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "format": "",
-            "logBase": 0,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:777",
-              "format": "dtdurations",
-              "logBase": 10,
-              "min": 60,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:778",
-              "decimals": null,
-              "format": "short",
-              "logBase": 1,
-              "max": "20",
-              "min": 0,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$PrometheusDS",
-          "description": "",
-          "editable": false,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 8,
-            "y": 9
-          },
-          "hiddenSeries": false,
-          "id": 52,
-          "interval": "",
-          "isNew": false,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/Max/",
-              "fill": 0
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "avg by(version, service)(time()-process_start_time_seconds{version!=\"\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Avg {{service}} {{version}}",
-              "refId": "B",
-              "step": 20
-            },
-            {
-              "expr": "max by(version, service)(time()-process_start_time_seconds{version!=\"\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Max {{service}} {{version}}",
-              "refId": "C",
-              "step": 20
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Legacy Parsers / Annotators",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "format": "",
-            "logBase": 0,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:995",
-              "decimals": 0,
-              "format": "dtdurations",
-              "logBase": 10,
-              "max": null,
-              "min": "360",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:996",
-              "decimals": null,
-              "format": "short",
-              "logBase": 1,
-              "max": "20",
-              "min": 0,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "Uptimes for V2 Gardener and Parsers.",
-          "editable": false,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 16,
-            "y": 9
-          },
-          "hiddenSeries": false,
-          "id": 48,
-          "interval": "",
-          "isNew": false,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "alias": "/Gardener Instances/",
-              "color": "#37872D",
-              "fill": 0,
-              "yaxis": 2
-            },
-            {
-              "alias": "/Gardener/",
-              "linewidth": 2
-            },
-            {
-              "alias": "/Parser Instances/",
-              "color": "#8F3BB8",
-              "fill": 0,
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "avg by(run, pod_template_hash)(time()-process_start_time_seconds{container=~\"etl-.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{run}} {{pod_template_hash}}",
-              "refId": "A",
-              "step": 20
-            },
-            {
-              "expr": "avg by(run, container, pod_template_hash)(time()-process_start_time_seconds{container=~\"etl-parser\"})",
-              "format": "time_series",
-              "hide": true,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Avg {{run}} {{pod_template_hash}}",
-              "refId": "C",
-              "step": 20
-            },
-            {
-              "expr": "count by(container, pod_template_hash, value)(etl_commit_hash{container=~\"etl-parser.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Parser Instances {{pod_template_hash}} - Git: {{value}} ",
-              "refId": "D",
-              "step": 20
-            },
-            {
-              "expr": "count by(run, pod_template_hash)(process_start_time_seconds{container=~\"etl-gardener.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Gardener Instances {{pod_template_hash}}",
-              "refId": "B",
-              "step": 20
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Gardener 2.0 and K8S Parsers",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "format": "",
-            "logBase": 0,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1074",
-              "format": "dtdurations",
-              "logBase": 10,
-              "min": 60,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1075",
-              "decimals": 0,
-              "format": "short",
-              "label": "Instances",
-              "logBase": 1,
-              "max": "5",
-              "min": 0,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "Uptime",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 2
-      },
-      "id": 65,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "Task dates of the most recent updates to each task state.\n\n\"Invalid date\" appears when Gardener has been restarted recently.  Haven't figured out how to suppress that.\n\nNOTE: In sandbox, we now process only a small subset of the requests, to get high throughput and test across the full date range quickly.  Cycle time is less than a day for sandbox, compared with one or two weeks for production.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 18
-          },
-          "hiddenSeries": false,
-          "id": 54,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 0.5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "1000*quantile_over_time(0.8, gardener_state_date{state=~\"$states2\"}[5m])",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{datatype}} {{state}}",
-              "refId": "E"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "V2 Task Date of Recent State Updates",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:385",
-              "decimals": null,
-              "format": "dateTimeAsIso",
-              "label": "State update for task date",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:386",
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "",
-          "editable": false,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 18
-          },
-          "hiddenSeries": false,
-          "id": 53,
-          "isNew": false,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1124",
-              "alias": "/Average Ram etl-parser/",
-              "color": "#8F3BB8",
-              "linewidth": 3
-            },
-            {
-              "$$hashKey": "object:1125",
-              "alias": "/Instance Ram etl-parser/",
-              "color": "rgb(85, 57, 89)"
-            },
-            {
-              "$$hashKey": "object:1314",
-              "alias": "/Instance Ram/",
-              "hideTooltip": true
-            },
-            {
-              "$$hashKey": "object:1321",
-              "alias": "/gardener/",
-              "color": "#37872D"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by(container, instance) (process_resident_memory_bytes{container=~\"etl-.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "60s",
-              "intervalFactor": 1,
-              "legendFormat": "Instance Ram {{container}} - {{instance}}",
-              "refId": "A",
-              "step": 60
-            },
-            {
-              "expr": "avg by(container, pod_template_hash) (process_resident_memory_bytes{container=~\"etl-.*|stats.*\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Average Ram {{container}} - {{pod_template_hash}}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Parsers - Process Resident Memory",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "format": "",
-            "logBase": 0,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1140",
-              "format": "decbytes",
-              "logBase": 10,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1141",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "",
-          "editable": false,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {},
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 18
-          },
-          "hiddenSeries": false,
-          "id": 57,
-          "isNew": false,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:219",
-              "alias": "/Average/",
-              "color": "#65c5db",
-              "linewidth": 3
-            },
-            {
-              "$$hashKey": "object:220",
-              "alias": "Num CPU",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by (instance)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[2m])/etl_num_cpu{container=\"etl-parser\"})",
-              "format": "time_series",
-              "interval": "60s",
-              "intervalFactor": 1,
-              "legendFormat": "{{instance}}",
-              "refId": "A",
-              "step": 60
-            },
-            {
-              "expr": "avg by (pod_template_hash)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[10m])/etl_num_cpu)",
-              "format": "time_series",
-              "interval": "60s",
-              "intervalFactor": 1,
-              "legendFormat": "Average {{pod_template_hash}}",
-              "refId": "B",
-              "step": 60
-            },
-            {
-              "expr": "avg by (pod_template_hash)(etl_num_cpu{container=\"etl-parser\"})",
-              "format": "time_series",
-              "interval": "60s",
-              "intervalFactor": 1,
-              "legendFormat": "Num CPU",
-              "refId": "C",
-              "step": 60
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Parser Utilization",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "format": "",
-            "logBase": 0,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:235",
-              "decimals": null,
-              "format": "percentunit",
-              "logBase": 1,
-              "max": 1,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:236",
-              "decimals": null,
-              "format": "short",
-              "logBase": 1,
-              "max": "20",
-              "min": "0",
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "Not clear why there is a small background failure rate.  Probably should investigate.\n\nTODO - separate GCS read and write error metrics",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 25
-          },
-          "hiddenSeries": false,
-          "id": 73,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "Parser logs",
-              "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
-            }
-          ],
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:341",
-              "alias": "/Files/",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "60 * sum by (kind, table)(rate(etl_backend_failure_count[10m]))",
-              "interval": "",
-              "legendFormat": "{{table}} Failures/Min {{kind}}",
-              "refId": "A"
-            },
-            {
-              "expr": "1000*(sum by (table)(rate(etl_backend_failure_count{kind=\"googleapi.Error\"}[30m])) OR vector(0))/(sum by( table)(rate(etl_test_file_size_bytes_count{}[30m])) OR vector(1))",
-              "interval": "",
-              "legendFormat": "{{table}} Failures Per Thousand Files",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [
-            {
-              "$$hashKey": "object:2361",
-              "colorMode": "warning",
-              "fill": true,
-              "line": true,
-              "op": "gt",
-              "value": 1,
-              "yaxis": "left"
-            },
-            {
-              "$$hashKey": "object:2367",
-              "colorMode": "critical",
-              "fill": true,
-              "line": true,
-              "op": "gt",
-              "value": 10,
-              "yaxis": "left"
-            }
-          ],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "GCS JSON Write Failures",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1996",
-              "decimals": 0,
-              "format": "short",
-              "label": "Failures/Minute",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1997",
-              "format": "short",
-              "label": "Failures/Thousand Files",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 25
-          },
-          "hiddenSeries": false,
-          "id": 83,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum by(table)(rate(etl_test_file_size_bytes_sum{}[30m]))",
-              "interval": "",
-              "legendFormat": "Bytes/Sec {{table}}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Processing Rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:115",
-              "format": "Bps",
-              "label": null,
-              "logBase": 10,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:116",
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$Gardener2_DS",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 25
-          },
-          "hiddenSeries": false,
-          "id": 87,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{}[1h])))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Bytes/File {{table}}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Median Filesize",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:115",
-              "format": "decbytes",
-              "label": null,
-              "logBase": 10,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:116",
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "2.0 Pipeline",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 3
-      },
-      "id": 76,
       "panels": [],
-      "title": "Legacy Pipeline",
+      "title": "Overview",
       "type": "row"
     },
     {
@@ -1606,11 +37,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$LegacyDS",
-      "description": "Task dates of the most recent updates to each task state.\n\n\"Invalid date\" appears when Gardener has been restarted recently.  Haven't figured out how to suppress that.\n\nNOTE: In sandbox, we now process only a small subset of the requests, to get high throughput and test across the full date range quickly.  Cycle time is less than a day for sandbox, compared with one or two weeks for production.\nNOTE: In sandbox, we now process only a small subset of the requests, to get high throughput and test across the full date range quickly.  Cycle time is less than a day for sandbox, compared with one or two weeks for production.",
+      "datasource": {
+        "uid": "$Gardener2_DS"
+      },
+      "description": "Dates of the most recent updates to each Job state.\n\n\"Invalid date\" appears when Gardener has been restarted recently.  Haven't figured out how to suppress that.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1621,10 +53,209 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 4
+        "y": 1
       },
       "hiddenSeries": false,
-      "id": 44,
+      "id": 54,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "1000*quantile_over_time(0.8, gardener_state_date{state=~\"$states2\"}[5m])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}} {{state}}",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Gardener - Recent Job Date Updates",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:385",
+          "format": "dateTimeAsIso",
+          "label": "Task date",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:386",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$PrometheusDS"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 63,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "bq_gardener_parse_time_age_days",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Oldest Bigquery Parse Time",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "series",
+        "show": false,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:574",
+          "decimals": 1,
+          "format": "none",
+          "label": "Days",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:575",
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 109,
       "legend": {
         "avg": false,
         "current": false,
@@ -1642,7 +273,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1652,20 +283,23 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1000*quantile_over_time(0.2, gardener_state_date{state=~\"$states\"}[20m])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "4*sum by(deployment, datatype) (increase(gardener_completed_total[6h]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{deployment}} {{state}}",
-          "refId": "D"
+          "legendFormat": "Completed {{datatype}}",
+          "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Task Date of Recent State Updates",
+      "title": "SLO: Completion Rate (Jobs / day)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1673,36 +307,28 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1834",
-          "decimals": null,
-          "format": "dateTimeAsIso",
-          "label": "State update for task date",
+          "$$hashKey": "object:3489",
+          "format": "short",
+          "label": "Jobs / Day",
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
-          "$$hashKey": "object:1835",
+          "$$hashKey": "object:3490",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1710,13 +336,15 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
+      "datasource": {
+        "uid": "$Gardener2_DS"
+      },
       "description": "",
       "editable": false,
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1725,11 +353,276 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 8,
-        "y": 4
+        "x": 0,
+        "y": 8
       },
       "hiddenSeries": false,
-      "id": 2,
+      "id": 57,
+      "isNew": false,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:219",
+          "alias": "/Average/",
+          "color": "#65c5db",
+          "linewidth": 3
+        },
+        {
+          "$$hashKey": "object:220",
+          "alias": "Num CPU",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (instance)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[2m])/etl_num_cpu{container=\"etl-parser\"})",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "avg by (pod_template_hash)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[10m])/etl_num_cpu)",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "Average {{pod_template_hash}}",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "expr": "avg by (pod_template_hash)(etl_num_cpu{container=\"etl-parser\"})",
+          "format": "time_series",
+          "interval": "60s",
+          "intervalFactor": 1,
+          "legendFormat": "Num CPU",
+          "refId": "C",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Parsers - Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "format": "",
+        "logBase": 0,
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:235",
+          "format": "percentunit",
+          "logBase": 1,
+          "max": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:236",
+          "format": "short",
+          "logBase": 1,
+          "max": "20",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
+      },
+      "description": "Uptimes for V2 Gardener and Parsers.",
+      "editable": false,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 48,
+      "interval": "",
+      "isNew": false,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:2874",
+          "alias": "/Instances/",
+          "fill": 3,
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "avg by(container, pod_template_hash)(time()-process_start_time_seconds{container=~\"etl-.*\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Uptime {{container}} {{pod_template_hash}}",
+          "refId": "A",
+          "step": 20
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "count by(container, run, pod_template_hash)(process_start_time_seconds{container=~\"etl-.*\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Instances {{container}} {{pod_template_hash}}",
+          "refId": "B",
+          "step": 20
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "v2 Data Pipeline Gardener & Parser Uptime & Instances",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "format": "",
+        "logBase": 0,
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1074",
+          "format": "dtdurations",
+          "label": "Uptime",
+          "logBase": 10,
+          "min": 60,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1075",
+          "decimals": 0,
+          "format": "short",
+          "label": "Instances",
+          "logBase": 1,
+          "max": "40",
+          "min": 0,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$Gardener2_DS"
+      },
+      "description": "",
+      "editable": false,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 53,
       "isNew": false,
       "legend": {
         "alignAsTable": false,
@@ -1752,30 +645,31 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "$$hashKey": "object:106",
-          "alias": "/Instances/",
-          "color": "#6ed0e0",
-          "fill": 0,
-          "linewidth": 4,
-          "yaxis": 2
-        },
-        {
-          "$$hashKey": "object:108",
-          "alias": "/inst .*/",
-          "color": "rgba(163, 163, 163, 0.55)",
-          "fill": 0
-        },
-        {
-          "$$hashKey": "object:921",
-          "alias": "/Average: etl-/",
+          "$$hashKey": "object:1124",
+          "alias": "/Average Ram etl-parser/",
           "color": "#8F3BB8",
-          "linewidth": 2
+          "linewidth": 3
+        },
+        {
+          "$$hashKey": "object:1125",
+          "alias": "/Instance Ram etl-parser/",
+          "color": "rgb(85, 57, 89)"
+        },
+        {
+          "$$hashKey": "object:1314",
+          "alias": "/Instance Ram/",
+          "hideTooltip": true
+        },
+        {
+          "$$hashKey": "object:1321",
+          "alias": "/gardener/",
+          "color": "#37872D"
         }
       ],
       "spaceLength": 10,
@@ -1783,38 +677,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(instance) (process_resident_memory_bytes{service=~\"etl-batch-parser\"})",
+          "expr": "sum by(container, instance) (process_resident_memory_bytes{container=~\"etl-.*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "60s",
           "intervalFactor": 1,
-          "legendFormat": "inst {{instance}}",
+          "legendFormat": "Instance Ram {{container}} - {{instance}}",
           "refId": "A",
           "step": 60
         },
         {
-          "expr": "avg by(service,version) (process_resident_memory_bytes{service=~\"etl-batch-parser\"})",
+          "expr": "avg by(container, pod_template_hash) (process_resident_memory_bytes{container=~\"etl-.*|stats.*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Average: {{service}}:{{version}}",
+          "legendFormat": "Average Ram {{container}} - {{pod_template_hash}}",
           "refId": "C"
-        },
-        {
-          "expr": "count by(service,version) (process_start_time_seconds{service=~\"etl-batch-parser\"})",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Instances: {{service}}:{{version}}",
-          "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Parsers - Process Resident Memory",
       "tooltip": {
         "shared": true,
@@ -1823,36 +706,30 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "format": "",
         "logBase": 0,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "$$hashKey": "object:139",
+          "$$hashKey": "object:1140",
           "format": "decbytes",
-          "logBase": 1,
-          "max": "10000000000",
-          "min": null,
+          "logBase": 10,
           "show": true
         },
         {
-          "$$hashKey": "object:140",
+          "$$hashKey": "object:1141",
           "decimals": 0,
           "format": "short",
           "logBase": 1,
-          "max": "15",
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1860,12 +737,165 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "editable": false,
-      "error": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
+      },
+      "description": "",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 61,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:482",
+          "alias": "/0 weeks ago/",
+          "linewidth": 5
+        },
+        {
+          "$$hashKey": "object:500",
+          "alias": "/1 weeks ago/",
+          "color": "#37872D",
+          "linewidth": 3
+        },
+        {
+          "$$hashKey": "object:511",
+          "alias": "/2 weeks ago/",
+          "color": "#37872D",
+          "linewidth": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "sum by(version)(increase(query_cost_seconds_sum{}[24h]))",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 5,
+          "legendFormat": "0 weeks ago {{version}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "sum by(version)(increase(query_cost_seconds_sum{}[24h]  offset 1w  ))",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 5,
+          "legendFormat": "1 weeks ago {{version}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "sum by(version) (increase(query_cost_seconds_sum{}[24h]  offset 2w))",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 10,
+          "legendFormat": "2 weeks ago {{version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Weekly query slot-time",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:289",
+          "format": "s",
+          "label": "Daily Slot Time",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:290",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 67,
+      "panels": [],
+      "title": "Gardener",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
+      },
+      "description": "We may want to monitor this from the Gardener instance, and suspend operation if the cost exceeds some threshold.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1874,18 +904,15 @@
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 16,
-        "y": 4
+        "x": 0,
+        "y": 16
       },
       "hiddenSeries": false,
-      "id": 4,
-      "isNew": false,
+      "id": 59,
       "legend": {
         "alignAsTable": false,
         "avg": false,
         "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": false,
@@ -1895,97 +922,52 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "Parser Status Page",
-          "url": "https://etl-batch-parser-dot-${project}.appspot.com/"
-        },
-        {
-          "targetBlank": true,
-          "title": "Parser Logs",
-          "url": "https://console.cloud.google.com/logs/viewer?project=${project}&interval=PT6H&resource=gae_app%2Fmodule_id%2Fetl-batch-parser&logName=projects%2F${project}%2Flogs%2Fappengine.googleapis.com%252Fstdout&logName=projects%2F${project}%2Flogs%2Fappengine.googleapis.com%252Fstderr&logName=projects%2F${project}%2Flogs%2Fappengine.googleapis.com%252Fnginx.request&advancedFilter=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22etl-batch-parser%22"
-        }
-      ],
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:358",
-          "alias": "/Instance Count/",
-          "color": "#6ed0e0",
-          "linewidth": 4,
-          "yaxis": 2
-        },
-        {
-          "$$hashKey": "object:359",
-          "alias": "/Average/",
-          "color": "#7eb26d",
-          "linewidth": 2
-        },
-        {
-          "$$hashKey": "object:360",
-          "alias": "/Instance CPU/",
-          "color": "rgba(115, 115, 115, 0.55)",
-          "fill": 0
-        },
-        {
-          "$$hashKey": "object:361",
-          "alias": "/Num CPU/",
-          "yaxis": 2
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{service=~\"etl-.*\"}[2m])/etl_num_cpu ",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "expr": "sum  by(version, datatype, query)(rate(query_cost_seconds_sum{}[1h])/rate(query_cost_seconds_count{}[1h]))",
           "format": "time_series",
-          "interval": "60s",
-          "intervalFactor": 5,
-          "legendFormat": "Instance CPU {{instance}}",
-          "refId": "A",
-          "step": 60
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Slot Time per Query {{datatype}} {{query}}",
+          "refId": "A"
         },
         {
-          "expr": "avg(rate(process_cpu_seconds_total{service=~\"etl-.*\"}[5m])/etl_num_cpu)",
-          "format": "time_series",
-          "interval": "60s",
-          "intervalFactor": 4,
-          "legendFormat": "Average Parser CPU",
-          "refId": "C",
-          "step": 60
-        },
-        {
-          "expr": "count by(service) (process_start_time_seconds{service=~\"etl-.*\"})",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "sum by(version, datatype, query)(increase(query_cost_seconds_sum{}[24h]))",
           "format": "time_series",
           "hide": false,
-          "interval": "60s",
-          "intervalFactor": 1,
-          "legendFormat": "Instance Count",
-          "refId": "B"
-        },
-        {
-          "expr": "avg by (version)(etl_num_cpu)",
           "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Num CPU",
-          "refId": "D"
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}} - {{query}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Parser CPU - Per-instance & Avg",
+      "title": "Gardener BigQuery Slot time (basis of \"cost\")",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1993,39 +975,30 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
-        "format": "",
-        "logBase": 0,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "$$hashKey": "object:394",
-          "decimals": null,
-          "format": "percentunit",
-          "label": "CPU %",
-          "logBase": 1,
-          "max": "1",
-          "min": "0",
+          "$$hashKey": "object:70",
+          "format": "s",
+          "label": "Avg Slot Time per Day",
+          "logBase": 10,
+          "min": "60",
           "show": true
         },
         {
-          "$$hashKey": "object:395",
-          "decimals": 0,
-          "format": "short",
-          "label": "Instance Count / Num CPU",
+          "$$hashKey": "object:71",
+          "format": "s",
+          "label": "",
           "logBase": 1,
-          "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2033,24 +1006,28 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "description": "This measures the bytes submitted for processing. \nIt reflects the ETL throughput, which is governed by concurrency settings.\n\nThe rate is governed by how fast the pipeline process daily job tasks.\n\nThis is fundamentally rather lumpy at the 10 minute level, so we average over 24h.  Aside from the fine-grained lumpiness, this should be the most stable of the throughput metrics, because it reflects the quantity of data, rather than the number or size of files.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 8,
-        "x": 0,
-        "y": 11
+        "x": 8,
+        "y": 16
       },
       "hiddenSeries": false,
-      "id": 74,
+      "id": 103,
+      "interval": "",
       "legend": {
         "avg": false,
         "current": false,
@@ -2062,13 +1039,14 @@
       },
       "lines": true,
       "linewidth": 1,
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 2,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
@@ -2077,27 +1055,122 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (kind, table)(60*rate(etl_backend_failure_count[10m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "sum by(datatype)(rate(gardener_bytes_sum[24h]))",
+          "format": "time_series",
+          "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}}",
           "refId": "A"
         }
       ],
-      "thresholds": [
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Byte Rate (24h avg)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
         {
-          "$$hashKey": "object:2272",
-          "colorMode": "warning",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 50,
-          "yaxis": "left"
+          "$$hashKey": "object:3840",
+          "format": "decbytes",
+          "label": "Bytes/Hour",
+          "logBase": 10,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3841",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
         }
       ],
-      "timeFrom": null,
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 101,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "rate(process_cpu_seconds_total{container=\"etl-gardener\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{deployment}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Backend Failure Rate",
+      "title": "CPU Utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2105,9 +1178,644 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 107,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:387",
+          "alias": "/Avg Bytes.*/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "avg by(datatype, year) (\n    rate(gardener_bytes_sum{}[1h]) /\n    rate(gardener_files_sum{}[1h]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{year}} {{datatype}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Bytes / JSONL-Archives",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3138",
+          "format": "decbytes",
+          "label": "Bytes / File",
+          "logBase": 10,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3139",
+          "format": "decbytes",
+          "label": "Bytes / File",
+          "logBase": 10,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 111,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:246",
+          "alias": "/ndt7-/",
+          "fill": 1,
+          "stack": "A"
+        },
+        {
+          "$$hashKey": "object:247",
+          "alias": "/annotation-/",
+          "fill": 1,
+          "stack": "B"
+        },
+        {
+          "$$hashKey": "object:248",
+          "alias": "/Stuck|failed/",
+          "color": "rgb(255, 49, 49)",
+          "linewidth": 5,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "sum by(datatype) (gardener_tasks_in_flight{state=\"parsing\"}) # sum merges across restarts",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}} ",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Parsing Tasks in Flight",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:281",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:282",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 105,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "sum by(experiment, datatype, year)(increase(gardener_files_sum[1h]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{experiment}} - {{datatype}} - {{year}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "JSONL-Archive Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3079",
+          "format": "short",
+          "label": "Files / Hour",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3080",
+          "format": "decbytes",
+          "label": "Bytes / File",
+          "logBase": 10,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "How long each date spends in each processing state.\nIf Processing exceeds 12 hours, then there will likely be data loss from expiration in the task queue.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "hiddenSeries": false,
+      "id": 113,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 0.5,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.90, sum(rate(gardener_state_time_histogram_bucket{datatype=~\"$datatype\"}[6h])) by (state, datatype, le))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{datatype}}: {{state}}",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 28800,
+          "yaxis": "left"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Time in State (90th Percentile)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:129",
+          "decimals": -3,
+          "format": "s",
+          "logBase": 10,
+          "min": "1",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:130",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 65,
+      "panels": [],
+      "title": "Parsers",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 99,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "$$hashKey": "object:1910",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status!=\"OK\"}[120m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{worker}}",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Parser - QPS (Errors)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1095",
+          "decimals": 2,
+          "format": "none",
+          "label": "QPS",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1096",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 98,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "Parser logs",
+          "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
+        }
+      ],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "60*sum by (table) (rate(etl_gcs_retry_count[10m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{table}} Errors/Min",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Parsers - GCS Read Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
         "show": true,
         "values": []
       },
@@ -2115,25 +1823,20 @@
         {
           "$$hashKey": "object:1996",
           "format": "short",
-          "label": "Failures/Minute",
+          "label": "Errors/Minute",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:1997",
           "format": "short",
-          "label": null,
+          "label": "Failures/Thousand Files",
           "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2141,30 +1844,27 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
       },
+      "description": "",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 11
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 42
       },
       "hiddenSeries": false,
-      "id": 86,
+      "id": 83,
       "legend": {
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -2175,7 +1875,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2185,17 +1885,20 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
           "expr": "sum by(table)(rate(etl_test_file_size_bytes_sum{}[30m]))",
           "interval": "",
-          "legendFormat": "Bytes/Sec {{table}}",
+          "legendFormat": "{{table}}",
           "refId": "C"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Processing Rate",
+      "title": "Parsers - Processing Data Rate",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -2203,9 +1906,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2213,25 +1914,18 @@
         {
           "$$hashKey": "object:115",
           "format": "Bps",
-          "label": null,
           "logBase": 10,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:116",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2239,122 +1933,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
       },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 11
-      },
-      "hiddenSeries": false,
-      "id": 85,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{}[10m])))",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Bytes/File {{table}}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Median Filesize",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:115",
-          "format": "decbytes",
-          "label": null,
-          "logBase": 10,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:116",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$PrometheusDS",
       "editable": false,
       "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 19
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 92,
@@ -2379,7 +1970,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2389,6 +1980,11 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
           "expr": "histogram_quantile(0.95, sum by(le, table, status) (rate(etl_insertion_time_seconds_bucket{service=\"etl-batch-parser\"}[5m])))",
           "format": "time_series",
           "interval": "",
@@ -2398,6 +1994,11 @@
           "step": 10
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
           "expr": "(sum by(le, table, status)(rate(etl_insertion_time_seconds_sum{service=\"etl-batch-parser\"}[5m]))) / (sum by(le, table, status)(rate(etl_insertion_time_seconds_count{service=\"etl-batch-parser\"}[5m])))",
           "format": "time_series",
           "interval": "",
@@ -2408,10 +2009,8 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Approximate Insertion Time Percentiles",
+      "title": "TODO: Approximate Commit Time Percentiles",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2419,30 +2018,29 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "format": "",
         "logBase": 0,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1992",
           "format": "s",
           "logBase": 2,
           "min": 0,
           "show": true
         },
         {
+          "$$hashKey": "object:1993",
           "format": "short",
           "logBase": 1,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2450,20 +2048,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${Gardener2_DS}"
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 19
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 49
       },
       "hiddenSeries": false,
       "id": 94,
@@ -2479,35 +2074,38 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
           "$$hashKey": "object:1910",
-          "expr": "sum by(version, status, service) (irate(etl_worker_duration_seconds_count{}[4m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "exemplar": true,
+          "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status=\"OK\"}[120m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{service}} {{version}} {{status}}",
+          "legendFormat": "{{worker}}",
           "refId": "F"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Worker QPS",
+      "title": "Parser - QPS (OK)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -2515,34 +2113,28 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1095",
           "decimals": 2,
           "format": "none",
           "label": "QPS",
           "logBase": 1,
-          "max": null,
-          "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:1096",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2550,160 +2142,21 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "",
-      "editable": false,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
       },
+      "description": "Not clear why there is a small background failure rate.  Probably should investigate.\n\nTODO - separate GCS read and write error metrics",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 19
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 49
       },
       "hiddenSeries": false,
-      "id": 96,
-      "isNew": false,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "/increase.*/",
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "$$hashKey": "object:2532",
-          "expr": "sum by(version, service, table)(increase(etl_insertion_time_seconds_count{}[10m]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "increase - {{version}} {{service}} {{table}}",
-          "refId": "A",
-          "step": 120
-        },
-        {
-          "$$hashKey": "object:2533",
-          "expr": "sum by(version, service)(etl_insertion_time_seconds_count{service=~\"$service\"})",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "total - {{version}} {{service}}",
-          "refId": "B",
-          "step": 120
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "BQ Insert Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "format": "",
-        "logBase": 0,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "Total",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": "Increases",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 69,
-      "panels": [],
-      "title": "Annotator Stats",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "These are the per second request rates to the Annotation Service.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 28
-      },
-      "hiddenSeries": false,
-      "id": 36,
+      "id": 73,
       "legend": {
         "avg": false,
         "current": false,
@@ -2715,325 +2168,55 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "Parser logs",
+          "url": "https://console.cloud.google.com/kubernetes/deployment/us-central1/data-processing/default/etl-parser/logs?project=$project"
+        }
+      ],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:408",
-          "alias": "/Uptime:/",
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by(service, test_type) (rate(etl_annotator_Annotation_Time_Summary_count{service=~\"etl-.*\"}[1h]))",
-          "format": "time_series",
-          "hide": true,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Requests:  {{test_type}}",
-          "refId": "A"
-        },
-        {
-          "expr": "sum by(source, service)(rate(etl_annotator_Error_Count{service=~\"etl-.*\"}[1h]))",
-          "format": "time_series",
-          "hide": true,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Errors: {{source}}",
-          "refId": "B"
-        },
-        {
-          "expr": "avg by(service, version)(time()-process_start_time_seconds{service=~\"annotator\"})",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Uptime: {{service}} {{version}}",
-          "refId": "C"
-        },
-        {
-          "expr": "sum by (type, detail)(rate(annotator_latency_hist_usec_count{service=\"annotator\"}[1h]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Requests: {{type}} {{detail}}",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Uptime and Incoming Request Rates",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:415",
-          "format": "reqps",
-          "label": null,
-          "logBase": 10,
-          "max": null,
-          "min": "1",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:416",
-          "format": "s",
-          "label": null,
-          "logBase": 10,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "Ripples in the various metrics likely reflect oscillations in the different queues feeding the ETL pipelines.  The queues slow down as they empty, and push faster when refilled.  This changes the mix of requests for different data types.  Since the different parsers handle annotation differently, this changes the load on the annotator.\n\nWe expect to see bursts of \"reject (loading)\" when a new dataset is requested.  However, we DON'T want to see reject (cache full).  These might mean that gardener is misbehaving, or that the dataset cache is broken in some way.\n\nEarly (<2013) NDTTests trigger a burst of \"missing annotations for client IP\". Not clear why.\n \nWe are sometimes seeing long bursts of \"Invalid IP\".  This requires more investigation - likely a problem with the raw data.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 28
-      },
-      "hiddenSeries": false,
-      "id": 71,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by(test_type) (rate(etl_annotator_Annotation_Time_Summary_count{}[1h]))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Requests {{test_type}}",
-          "metric": "annotator_Request_Response_Time_Summary_sum",
-          "refId": "B",
-          "step": 20
-        },
-        {
-          "expr": "sum by(source)(rate(etl_annotator_Error_Count{service=~\"etl-.*\"}[1h]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Errors: {{source}}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Request Rate Per Datatype / Result",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:851",
-          "decimals": null,
-          "format": "short",
-          "label": "Requests / Second",
-          "logBase": 10,
-          "max": null,
-          "min": "1",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:852",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$Gardener2_DS",
-      "description": "v2 API requests and error rate from K8S parsers.\n\nNOTE:  These should be zero, since the 2.0 pipeline should get annotations from uuid-annotator.  However, we haven't removed the annotator calls yet.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 28
-      },
-      "hiddenSeries": false,
-      "id": 51,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1408",
-          "alias": "/Error Rate/",
-          "yaxis": 2
-        },
-        {
-          "$$hashKey": "object:1409",
-          "alias": "/High/",
-          "color": "#F2495C",
-          "fill": 1,
-          "fillGradient": 3,
-          "zindex": 3
-        },
-        {
-          "$$hashKey": "object:1410",
-          "alias": "/Request Rate/",
-          "fill": 1
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(test_type) (rate(etl_annotator_Annotation_Time_Summary_count{container=\"etl-parser\"}[1h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "60*sum by (kind, table)(rate(etl_backend_failure_count[10m]))\n",
           "hide": false,
           "interval": "",
-          "legendFormat": "V2 Requests/sec {{test_type}}",
-          "refId": "D"
-        },
-        {
-          "expr": "(sum(rate(annotator_external_latency_hist_msec_count{container=\"etl-parser\", detail!=\"success\"}[10m])) or vector(0)) / (sum(rate(annotator_external_latency_hist_msec_count{container=\"etl-parser\"}[10m])) or vector(1)) > .01",
-          "interval": "",
-          "legendFormat": "High Error Rate",
+          "legendFormat": "{{table}} Failures/Min {{kind}}",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(annotator_external_latency_hist_msec_count{container=\"etl-parser\", detail!=\"success\"}[10m])) or vector(0)) / (sum(rate(annotator_external_latency_hist_msec_count{container=\"etl-parser\"}[10m])) or vector(1))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "1000*(sum by (table)(rate(etl_backend_failure_count{kind=\"googleapi.Error\"}[30m])))",
+          "hide": true,
           "interval": "",
-          "legendFormat": "Error Rate",
-          "refId": "C"
+          "legendFormat": "{{table}} Failures Per Thousand Files",
+          "refId": "B"
         }
       ],
-      "thresholds": [
-        {
-          "$$hashKey": "object:1463",
-          "colorMode": "critical",
-          "fill": false,
-          "line": true,
-          "op": "gt",
-          "value": 0.01,
-          "yaxis": "right"
-        }
-      ],
-      "timeFrom": null,
+      "thresholds": [],
       "timeRegions": [],
-      "timeShift": null,
-      "title": "K8S Parser V2 Requests and Error Rate",
+      "title": "Parsers - GCS Write Errors",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -3041,35 +2224,28 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1435",
+          "$$hashKey": "object:1996",
           "format": "short",
-          "label": "V2 Requests/Sec",
-          "logBase": 10,
-          "max": null,
-          "min": "5",
+          "label": "Errors/Minute",
+          "logBase": 1,
           "show": true
         },
         {
-          "$$hashKey": "object:1436",
-          "format": "percentunit",
-          "label": "V2 Error Rate",
+          "$$hashKey": "object:1997",
+          "format": "short",
+          "label": "Failures/Thousand Files",
           "logBase": 1,
-          "max": "1",
-          "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -3077,43 +2253,38 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "The annotation service runs in AppEngine Flex.  The term \"legacy\" refers to the legacy geolite1 maxmind datasets, NOT the legacy pipeline.\n\nRequest service time varies primarily on the number of IP addresses requested.  Requests of up to 5 are typically completed in about 100 usec.  Large requests of 400+ IPs typically take 2.5 msec.\n\nWhen there are large numbers of small requests, the worst case large request times spike, likely due to lock contention.  We might want to optimize this a bit better.\n\nRoughly 50% of the time is spent marshallling and unmarshallling.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$Gardener2_DS"
       },
-      "fill": 0,
+      "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 36
+        "w": 6,
+        "x": 12,
+        "y": 49
       },
       "hiddenSeries": false,
-      "id": 78,
+      "id": 87,
       "legend": {
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": false
+        "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 5,
+      "pluginVersion": "8.3.4",
+      "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
@@ -3122,199 +2293,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(annotator_latency_hist_usec_bucket[30m])) by (version, le, type, detail))",
-          "format": "time_series",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000062"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{}[1h])))",
           "hide": false,
           "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Median {{type}} {{detail}}",
-          "refId": "D"
-        },
-        {
-          "expr": "topk(1, histogram_quantile(0.99, sum(rate(annotator_latency_hist_usec_bucket[30m])) by (version, le, type, detail)))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Worst 0.99 {{type}} {{detail}}",
-          "refId": "E"
-        },
-        {
-          "expr": "histogram_quantile(0.5, sum(rate(annotator_latency_hist_usec_bucket[30m])) by (version, le))",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Median request {{version}}",
-          "refId": "F"
-        }
-      ],
-      "thresholds": [
-        {
-          "$$hashKey": "object:2865",
-          "colorMode": "warning",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 100000,
-          "yaxis": "left"
-        }
-      ],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Internal Serving Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:2837",
-          "decimals": null,
-          "format": "µs",
-          "label": "Time",
-          "logBase": 10,
-          "max": null,
-          "min": "20",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:2838",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$PrometheusDS",
-      "description": "These currently run on machines with 257GB available memory.\nGradually rising value likely indicates a memory leak.",
-      "editable": false,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 36
-      },
-      "hiddenSeries": false,
-      "id": 88,
-      "isNew": false,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:914",
-          "alias": "/Average: annotator/",
-          "color": "#37872D",
-          "linewidth": 2
-        },
-        {
-          "$$hashKey": "object:1069",
-          "alias": "/Instances:/",
-          "color": "rgb(114, 115, 115)"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg by(service,version) (process_resident_memory_bytes{service=~\"annotator.*\"})",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Average: {{service}}:{{version}}",
+          "legendFormat": "{{table}}",
           "refId": "C"
-        },
-        {
-          "expr": "avg by(service,version, instance) (process_resident_memory_bytes{service=~\"annotator.*\"})",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Instances: {{service}}:{{version}}",
-          "refId": "A"
         }
       ],
-      "thresholds": [
-        {
-          "$$hashKey": "object:1024",
-          "colorMode": "warning",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 240000000000,
-          "yaxis": "left"
-        },
-        {
-          "$$hashKey": "object:1030",
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 257000000000,
-          "yaxis": "left"
-        }
-      ],
-      "timeFrom": null,
+      "thresholds": [],
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Process Resident Memory",
+      "title": "Parsers - Median Filesize (Bytes)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -3322,54 +2315,41 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
-        "format": "",
-        "logBase": 0,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "$$hashKey": "object:139",
-          "decimals": null,
+          "$$hashKey": "object:115",
           "format": "decbytes",
-          "logBase": 1,
-          "max": "300000000000",
-          "min": "200000000000",
+          "logBase": 10,
           "show": true
         },
         {
-          "$$hashKey": "object:140",
-          "decimals": 0,
+          "$$hashKey": "object:116",
           "format": "short",
           "logBase": 1,
-          "max": "15",
-          "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 26,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "mlab-oti",
           "value": "mlab-oti"
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Project",
@@ -3403,7 +2383,6 @@
           "text": "Prometheus (mlab-oti)",
           "value": "Prometheus (mlab-oti)"
         },
-        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "",
@@ -3419,13 +2398,11 @@
       {
         "current": {
           "selected": false,
-          "text": "Data Proc (mlab-oti)",
-          "value": "Data Proc (mlab-oti)"
+          "text": "No data sources found",
+          "value": ""
         },
-        "error": null,
         "hide": 2,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "LegacyDS",
         "options": [],
@@ -3441,7 +2418,6 @@
           "text": "Data Processing (mlab-oti)",
           "value": "Data Processing (mlab-oti)"
         },
-        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "Gardener 2.0 Datasource",
@@ -3455,10 +2431,8 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {
-          "selected": true,
-          "tags": [],
+          "selected": false,
           "text": [
             "Finishing",
             "Processing"
@@ -3468,155 +2442,97 @@
             "Processing"
           ]
         },
-        "datasource": "$LegacyDS",
+        "datasource": {
+          "uid": "$LegacyDS"
+        },
         "definition": "label_values(gardener_state_date, state)",
-        "error": null,
+        "error": {
+          "message": "Datasource  was not found"
+        },
         "hide": 0,
         "includeAll": true,
         "label": "Gardener States",
         "multi": true,
         "name": "states",
-        "options": [
-          {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": false,
-            "text": "Deduplicating",
-            "value": "Deduplicating"
-          },
-          {
-            "selected": false,
-            "text": "Done",
-            "value": "Done"
-          },
-          {
-            "selected": true,
-            "text": "Finishing",
-            "value": "Finishing"
-          },
-          {
-            "selected": true,
-            "text": "Processing",
-            "value": "Processing"
-          },
-          {
-            "selected": false,
-            "text": "Queuing",
-            "value": "Queuing"
-          },
-          {
-            "selected": false,
-            "text": "Stabilizing",
-            "value": "Stabilizing"
-          }
-        ],
+        "options": [],
         "query": "label_values(gardener_state_date, state)",
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
           "text": [
-            "complete",
-            "failed"
+            "complete"
           ],
           "value": [
-            "complete",
-            "failed"
+            "complete"
           ]
         },
-        "datasource": "$Gardener2_DS",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$Gardener2_DS"
+        },
         "definition": "label_values(gardener_state_date, state)",
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Gardener 2.0 States",
         "multi": true,
         "name": "states2",
-        "options": [
-          {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": true,
-            "text": "complete",
-            "value": "complete"
-          },
-          {
-            "selected": false,
-            "text": "copying",
-            "value": "copying"
-          },
-          {
-            "selected": false,
-            "text": "deduplicating",
-            "value": "deduplicating"
-          },
-          {
-            "selected": false,
-            "text": "deleting",
-            "value": "deleting"
-          },
-          {
-            "selected": false,
-            "text": "init",
-            "value": "init"
-          },
-          {
-            "selected": false,
-            "text": "joining",
-            "value": "joining"
-          },
-          {
-            "selected": false,
-            "text": "loading",
-            "value": "loading"
-          },
-          {
-            "selected": false,
-            "text": "parsing",
-            "value": "parsing"
-          },
-          {
-            "selected": false,
-            "text": "postProcessing",
-            "value": "postProcessing"
-          },
-          {
-            "selected": true,
-            "text": "failed",
-            "value": "failed"
-          }
-        ],
-        "query": "label_values(gardener_state_date, state)",
-        "refresh": 0,
+        "options": [],
+        "query": {
+          "query": "label_values(gardener_state_date, state)",
+          "refId": "Data Processing (mlab-oti)-states2-Variable-Query"
+        },
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "tcpinfo"
+          ],
+          "value": [
+            "tcpinfo"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${Gardener2_DS}"
+        },
+        "definition": "label_values(gardener_bytes_sum, datatype)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "datatype",
+        "options": [],
+        "query": {
+          "query": "label_values(gardener_bytes_sum, datatype)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
@@ -3647,5 +2563,6 @@
   "timezone": "utc",
   "title": "Pipeline: Overview",
   "uid": "UTgnK-jMz",
-  "version": 1
+  "version": 10,
+  "weekStart": ""
 }


### PR DESCRIPTION
This change updates the `Pipeline: Overview` dashboard to remove the v1 and annotation service panels. In their place the dashboard now features a top level "overview" panels, expected to be the most common view, and two rows for detailed metrics from the parser and gardener.

Part of:
* https://github.com/m-lab/etl/issues/1084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/918)
<!-- Reviewable:end -->
