### PR TITLE
Update v1beta1 k8s resources to v1

### DIFF
--- a/k8s/data-processing/persistentvolumes/storage-class.yml
+++ b/k8s/data-processing/persistentvolumes/storage-class.yml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: slow
@@ -6,7 +6,7 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fast

--- a/k8s/data-processing/roles/rbac-prometheus.yml
+++ b/k8s/data-processing/roles/rbac-prometheus.yml
@@ -1,5 +1,5 @@
 # Add a cluster role for access to the v1.6 node/metrics resource.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -24,7 +24,7 @@ metadata:
 ---
 # Bind the cluster role above to the service account, granting this account
 # permission to the resources defined by the role.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/k8s/prometheus-federation/persistentvolumes/storage-class.yml
+++ b/k8s/prometheus-federation/persistentvolumes/storage-class.yml
@@ -7,7 +7,7 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fast


### PR DESCRIPTION
This change upgrades the resources to use the "v1" api rather than the now deprecated "v1beta1" apis. This upgrade is required to enable automatic upgrades of GKE clusters from v1.21 to v1.22.

Part of:
* https://github.com/m-lab/etl-gardener/issues/379