### PR TITLE
Split GardenerFailureRateTooHighOrMissing into two alerts

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -819,20 +819,34 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#gardenerconfigdatatypemissingingardenerhistoricalthroughputquery
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/q4MrNzh7k/pipeline-slis?orgId=1&var-project=mlab-oti&var-PrometheusDS=Prometheus%20(mlab-oti)&var-Gardener2_DS=Data%20Processing%20(mlab-oti)
 
-# GardenerFailureRateTooHighOrMissing fires when the number of failed Gardener jobs
-# in the last day rises above 1% or the number of total jobs is not reported.
+# GardenerFailureRateTooHigh fires when the number of failed Gardener jobs
+# in the last day rises above 1%.
   - alert: GardenerFailureRateTooHighOrMissing
     expr: (sum(rate(gardener_jobs_total{status!="success"}[1d])) by (datatype) /
       sum(rate(gardener_jobs_total[1d])) by (datatype)) > 0.01
-      OR absent(gardener_jobs_total)
     for: 10m
     labels:
       repo: dev-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: Gardener job failure rate above 1% or missing for {{ $labels.datatype }}.
+      summary: Gardener job failure rate above 1% for {{ $labels.datatype }}.
       description: Gardener runs in the "data-processing" cluster.
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/q4MrNzh7k/pipeline-slis?orgId=1&var-project=mlab-oti&var-PrometheusDS=Prometheus%20(mlab-oti)&var-Gardener2_DS=Data%20Processing%20(mlab-oti)
+
+# GardenerJobsTotalMissing fires when the number of total jobs is not reported.
+  - alert: GardenerJobsTotalMissing
+    expr: absent(gardener_jobs_total)
+    for: 30m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: gardener_jobs_total metric is missing.
+      description: Gardener runs in the "data-processing" cluster. Is the
+        gardener running? If it is running has processing slowed below 1 job every
+        30min?
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/q4MrNzh7k/pipeline-slis?orgId=1&var-project=mlab-oti&var-PrometheusDS=Prometheus%20(mlab-oti)&var-Gardener2_DS=Data%20Processing%20(mlab-oti)
 
 # ParserFailureRateTooHighOrMissing fires when the number of failed parser tasks


### PR DESCRIPTION
The alert `GardenerFailureRateTooHighOrMissing` fired in staging after a routine change merge and deployment. This coincides with the recent deployment of the pcap parser to 100%, which slows average processing rate.

`gardener_jobs_total` was absent for about 18min (16:20 to 16:38) after deployment. Because this restarts the process all previous metrics are reset to zero. The alert threshold was 10min. Now, with pcap processing, the average time between jobs is about 12.5 min/job (1440 min/day / 116 jobs/day) (though may be higher or lower).

This change splits the two alerts, preserving 10m for failure rates and increasing the absent check to 30m.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/921)
<!-- Reviewable:end -->
