### PR TITLE
Updates several dashboards to allow switching on site type

### DIFF
--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -273,7 +273,7 @@
             "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "kube_node_labels{node=~\"mlab1-$site.*\"}",
+          "expr": "kube_node_labels{node=~\"$node-$site.*\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -2037,10 +2037,9 @@
       },
       {
         "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
+          "selected": true,
+          "text": "akl01",
+          "value": "akl01"
         },
         "datasource": {
           "type": "prometheus",

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -2075,7 +2075,7 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(node)",
+        "definition": "label_values(kube_node_info{site=\"$site\"}, node)",
         "hide": 0,
         "includeAll": true,
         "label": "Node",
@@ -2083,8 +2083,8 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(node)",
-          "refId": "Platform Cluster (mlab-oti)-node-Variable-Query"
+          "query": "label_values(kube_node_info{site=\"$site\"}, node)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "/(mlab[1-4]).*/",

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -2038,12 +2038,8 @@
       {
         "current": {
           "selected": true,
-          "text": [
-            "akl01"
-          ],
-          "value": [
-            "akl01"
-          ],
+          "text": "akl01",
+          "value": "akl01"
         },
         "datasource": {
           "type": "prometheus",
@@ -2053,7 +2049,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Site",
-        "multi": true,
+        "multi": false,
         "name": "site",
         "options": [],
         "query": {

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -2038,8 +2038,12 @@
       {
         "current": {
           "selected": true,
-          "text": "akl01",
-          "value": "akl01"
+          "text": [
+            "akl01"
+          ],
+          "value": [
+            "akl01"
+          ],
         },
         "datasource": {
           "type": "prometheus",
@@ -2049,7 +2053,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Site",
-        "multi": false,
+        "multi": true,
         "name": "site",
         "options": [],
         "query": {

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 246,
-  "iteration": 1646762660954,
+  "iteration": 1657921475306,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2003,15 +2003,50 @@
       },
       {
         "current": {
+          "selected": true,
+          "text": [
+            "physical",
+            "virtual"
+          ],
+          "value": [
+            "physical",
+            "virtual"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Type",
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "physical",
+            "value": "physical"
+          },
+          {
+            "selected": true,
+            "text": "virtual",
+            "value": "virtual"
+          }
+        ],
+        "query": "physical, virtual",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "isNone": true,
           "selected": false,
-          "text": "akl01",
-          "value": "akl01"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(site)",
+        "definition": "label_values(kube_node_labels{label_mlab_type=~\"$type\"}, site)",
         "hide": 0,
         "includeAll": false,
         "label": "Site",
@@ -2019,8 +2054,8 @@
         "name": "site",
         "options": [],
         "query": {
-          "query": "label_values(site)",
-          "refId": "Platform Cluster (mlab-oti)-site-Variable-Query"
+          "query": "label_values(kube_node_labels{label_mlab_type=~\"$type\"}, site)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -2126,6 +2161,6 @@
   "timezone": "",
   "title": "k8s: Site Overview",
   "uid": "rJ7z2Suik",
-  "version": 47,
+  "version": 51,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -273,7 +273,7 @@
             "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "kube_node_labels{node=~\"$node-$site.*\"}",
+          "expr": "max by (label_mlab_type) (kube_node_labels{node=~\"$node-$site.*\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -281,7 +281,7 @@
           "refId": "A"
         }
       ],
-      "title": "Machine type",
+      "title": "Site type",
       "type": "stat"
     },
     {

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -8,27 +8,36 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 261,
-  "iteration": 1617312292190,
+  "iteration": 1657917203451,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "Left Y: Aggregate DaemonSet CPU usage expressed as a percentage of the entire cluster CPU capacity in cores.\nRight Y: Aggregate DaemonSet CPU usage as an absolute number of cores.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -64,7 +73,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -79,25 +88,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": " daemonset:container_cpu_usage_seconds:ratio\n",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": " daemonset:container_cpu_usage_seconds:ratio{label_mlab_type=~\"$type\"}\n",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "% Total: {{daemonset}}",
           "refId": "A"
         },
         {
-          "expr": "daemonset:container_cpu_usage_seconds:sum_rate1h",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "daemonset:container_cpu_usage_seconds:sum_rate1h{label_mlab_type=~\"$type\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Cores: {{daemonset}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Aggregate DaemonSet CPU usage",
       "tooltip": {
         "shared": true,
@@ -106,34 +125,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": "% Total Cores",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
           "label": "Cores",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -141,11 +152,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "Left Y: Aggregate DaemonSet memory expressed as a percentage of the entire cluster's memory capacity.\n\nRight Y: Aggregate DaemonSet memory usage expressed as an absolute number of bytes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -179,7 +192,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -194,7 +207,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "daemonset:container_memory_working_set_bytes:ratio",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "daemonset:container_memory_working_set_bytes:ratio{label_mlab_type=~\"$type\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -202,17 +220,21 @@
           "refId": "A"
         },
         {
-          "expr": "daemonset:container_memory_working_set_bytes:sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "daemonset:container_memory_working_set_bytes:sum{label_mlab_type=~\"$type\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Memory: {{daemonset}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Aggregate DaemonSet memory usage",
       "tooltip": {
         "shared": true,
@@ -221,34 +243,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": "% Total Memory",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "decbytes",
           "label": "Memory",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -256,11 +270,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "Left Y: Aggregate DaemonSet CPU usage expressed as a percentage of a node's total CPU cores.\n\nRight Y: Aggregate DaemonSet CPU usage as an absolute number of cores on a node.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -296,7 +312,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -311,26 +327,36 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, machine_daemonset:container_cpu_usage_seconds:ratio)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "topk(10, machine_daemonset:container_cpu_usage_seconds:ratio{label_mlab_type=~\"$type\"})",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "% Total: {{daemonset}} ({{machine}})",
           "refId": "A"
         },
         {
-          "expr": "topk(10, machine_daemonset:container_cpu_usage_seconds:sum_rate1h)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "topk(10, machine_daemonset:container_cpu_usage_seconds:sum_rate1h{label_mlab_type=~\"$type\"})",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Cores: {{daemonset}} ({{machine}})",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Top 10: DaemonSet CPU usage by node",
       "tooltip": {
         "shared": true,
@@ -339,34 +365,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": "% Total Cores",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
           "label": "Cores",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -374,11 +392,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "Left Y: Aggregate DaemonSet memory expressed as a percentage of a node's total memory capacity.\n\nRight Y: Aggregate DaemonSet memory usage on a node expressed as an absolute number of bytes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -412,7 +432,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -427,24 +447,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, machine_daemonset:container_memory_working_set_bytes:ratio)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "topk(10, machine_daemonset:container_memory_working_set_bytes:ratio{label_mlab_type=~\"$type\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "% Total: {{daemonset}} ({{machine}})",
           "refId": "A"
         },
         {
-          "expr": "topk(10, machine_daemonset:container_memory_working_set_bytes:sum)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "topk(10, machine_daemonset:container_memory_working_set_bytes:sum{label_mlab_type=~\"$type\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Memory: {{daemonset}} ({{machine}})",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Top10: DaemonSet memory usage by node",
       "tooltip": {
         "shared": true,
@@ -453,34 +483,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "percentunit",
           "label": "% Total Memory",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "decbytes",
           "label": "Memory",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -488,11 +510,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -524,7 +548,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -534,24 +558,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "workload:container_network_transmit_bytes_total:sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "workload:container_network_transmit_bytes_total:sum{label_mlab_type=~\"$type\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Tx: {{container_label_workload}}",
           "refId": "B"
         },
         {
-          "expr": "- workload:container_network_receive_bytes_total:sum",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "- workload:container_network_receive_bytes_total:sum{label_mlab_type=~\"$type\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Rx: {{container_label_workload}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Aggregate DaemonSet network usage (bits/s)",
       "tooltip": {
         "shared": true,
@@ -560,34 +594,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "bps",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -595,11 +619,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -633,7 +659,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -643,25 +669,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, machine_workload:container_network_transmit_bytes_total:sum)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "topk(10, machine_workload:container_network_transmit_bytes_total:sum{label_mlab_type=~\"$type\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Tx: {{container_label_workload}}  ({{machine}})",
           "refId": "B"
         },
         {
-          "expr": "- topk(10, machine_workload:container_network_receive_bytes_total:sum)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "exemplar": true,
+          "expr": "- topk(10, machine_workload:container_network_receive_bytes_total:sum{label_mlab_type=~\"$type\"})",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Rx: {{container_label_workload}} ({{machine}})",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Top 10: DaemonSet network usage by node (bits/s)",
       "tooltip": {
         "shared": true,
@@ -670,34 +706,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "bps",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -705,10 +731,11 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -742,7 +769,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -758,9 +785,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Rollout Counts by (git, k8s revision, workload, and container)",
       "tooltip": {
         "shared": true,
@@ -769,33 +794,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -803,11 +820,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -841,7 +859,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.3.4",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -860,9 +878,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Pod container restarts (increase 1d)",
       "tooltip": {
         "shared": true,
@@ -871,49 +887,40 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 26,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -921,15 +928,50 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "/^Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "physical",
+            "virtual"
+          ],
+          "value": [
+            "physical",
+            "virtual"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Type",
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "physical",
+            "value": "physical"
+          },
+          {
+            "selected": true,
+            "text": "virtual",
+            "value": "virtual"
+          }
+        ],
+        "query": "physical, virtual",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -960,5 +1002,6 @@
   "timezone": "",
   "title": "K8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 114
+  "version": 115,
+  "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
+++ b/config/federation/grafana/dashboards/K8s_WorkloadOverview.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 261,
-  "iteration": 1657917203451,
+  "iteration": 1658331574355,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1000,8 +1000,8 @@
     ]
   },
   "timezone": "",
-  "title": "K8s: Workload Overview",
+  "title": "k8s: Workload Overview",
   "uid": "tZHLFQRZk",
-  "version": 115,
+  "version": 116,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Client_Rates.json
+++ b/config/federation/grafana/dashboards/NDT_Client_Rates.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 319,
-  "iteration": 1658330588250,
+  "iteration": 1658330588260,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1004,7 +1004,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "NDT: Client Rates, Quantiles over time, & Heatmaps",
+  "title": "NDT: Client Rates",
   "uid": "SAvQ0QAnl",
   "version": 52,
   "weekStart": ""

--- a/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
+++ b/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 97,
-  "iteration": 1647289486297,
+  "iteration": 1657823609966,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -817,23 +817,61 @@
         "type": "datasource"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
-          "text": [],
-          "value": []
+          "text": [
+            "physical",
+            "virtual"
+          ],
+          "value": [
+            "physical",
+            "virtual"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "physical",
+            "value": "physical"
+          },
+          {
+            "selected": true,
+            "text": "virtual",
+            "value": "virtual"
+          }
+        ],
+        "query": "physical, virtual",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "akl01"
+          ],
+          "value": [
+            "akl01"
+          ]
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(machine)",
+        "definition": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
         "hide": 0,
         "includeAll": false,
         "multi": true,
         "name": "site",
         "options": [],
         "query": {
-          "query": "label_values(machine)",
+          "query": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -968,6 +1006,6 @@
   "timezone": "utc",
   "title": "NDT: Client Rates, Quantiles over time, & Heatmaps",
   "uid": "SAvQ0QAnl",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
+++ b/config/federation/grafana/dashboards/NDT_Client_Rates_Quantiles_Heatmaps.json
@@ -21,8 +21,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 97,
-  "iteration": 1657823609966,
+  "id": 319,
+  "iteration": 1658330588250,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -799,7 +799,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -875,7 +875,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "/mlab[1-4].([a-z]{3}[0-9]{2}).*/",
+        "regex": "/mlab[1-4].([a-z]{3}[0-9t]{2}).*/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
@@ -885,7 +885,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "ndt7+wss",
           "value": "ndt7+wss"
         },
@@ -1006,6 +1006,6 @@
   "timezone": "utc",
   "title": "NDT: Client Rates, Quantiles over time, & Heatmaps",
   "uid": "SAvQ0QAnl",
-  "version": 3,
+  "version": 52,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR updates these three dashboards:

* K8s: Workload Overview
* k8s: Site Overview
* NDT: Client Rates, Quantiles over time, & Heatmaps

For the SiteOverview and ClientRates dashboards, the main difference is the addition of a new "Type" selector at the top. When you select "physical" then the "Site" selector will only contain physical sites, and when you select "virtual" it will only container virtual sites. When both are selected you get all sites.

For the WorkloadOverview dashboard there were [updates that needed to happen to the underlying recording rules](https://github.com/m-lab/k8s-support/pull/701/commits/d3f891b0fc6a4a51f2e541b474e7c7b622b3fd3b) that drive the dashboard. The queries had to change according to allowing switching on site type. This dashboard also has a new select box to switch on site type.

**NOTE**: Until the new changes to k8s-support are in production, use caution using the SiteOverview dashboard, as it will crash the tab if you are not careful. The chained variables will not work properly for now, and if you select "mlab-oti" for the datasource, it will try to aggregate the data from all sites/nodes. One options would be to hold off on merging this PR until the k8s-support changes are launched to production. That said, this issue will still affect you in both the sandbox and staging versions of the dashboard, if you select "mlab-oti" as the datasource, and it is selected by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/925)
<!-- Reviewable:end -->
