### PR TITLE
Lets a node be down for 1d before firing an alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1071,7 +1071,7 @@ groups:
         unless on(site) (
           sum_over_time(probe_success{module="icmp"}[1h]) < 15
         )
-    for: 1h
+    for: 1d
     labels:
       repo: ops-tracker
       severity: ticket


### PR DESCRIPTION
Sometimes nodes experience transient issues that resolve themselves
after a while. We currently have nearly 600 production nodes, and there
is no need to fire an alert when one is down for only 1h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/927)
<!-- Reviewable:end -->
