### PR TITLE
Increase alert wait time to 3h for bqx frequency

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -893,7 +893,7 @@ groups:
     expr: |
       bq_annotation_asn_success / bq_annotation_total < 0.98
         or absent(bq_annotation_asn_success / bq_annotation_total)
-    for: 60m
+    for: 3h
     labels:
       repo: dev-tracker
       severity: ticket
@@ -910,7 +910,7 @@ groups:
     expr: |
       bq_annotation_geo_success / bq_annotation_total < 0.98
         or absent(bq_annotation_geo_success / bq_annotation_total)
-    for: 60m
+    for: 3h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
In recent weeks some alerts have fired unnecessarily due to a long bigquery-exporter query frequency and a short alert wait time. This change increases the wait time for this condition to allow the bqx time to run the query again before this alert fires. Ideally, the bqx would be updated to run on restart or config reload, rather than strictly on 3h intervals.

Example alerts misfiring:
* https://github.com/m-lab/dev-tracker/issues/725
* https://github.com/m-lab/dev-tracker/issues/726

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/928)
<!-- Reviewable:end -->
