### PR TITLE
Add a new service discovery container using -project=LOCATE_PROJECT

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -141,7 +141,7 @@ spec:
                 "--http-target=/targets/switch-monitoring-targets/switch-monitoring.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/switch-monitoring-targets/switch-monitoring.json",
                 "--project={{GCLOUD_PROJECT}}",
-                "--aef-project={{LOCATE_PROJECT}}"]
+                "--aef-project=mlab-ns"]
         ports:
           - containerPort: 9373
         resources:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -161,7 +161,7 @@ spec:
         args: [ "--aef-target=/targets/aeflex-targets/aeflex-locate.json",
                 "--project=mlab-ns"]
         ports:
-          - containerPort: 9373
+          - containerPort: 9374
         resources:
           requests:
             memory: "150Mi"

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -101,7 +101,7 @@ spec:
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
-      - image: measurementlab/gcp-service-discovery:v1.5.1
+      - image: measurementlab/gcp-service-discovery:cristinaleon
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",
@@ -140,7 +140,8 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/bmc-targets/bmc_e2e.json",
                 "--http-target=/targets/switch-monitoring-targets/switch-monitoring.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/switch-monitoring-targets/switch-monitoring.json",
-                "--project={{GCLOUD_PROJECT}}"]
+                "--project={{GCLOUD_PROJECT}}",
+                "--aef-project={{LOCATE_PROJECT}}"]
         ports:
           - containerPort: 9373
         resources:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -101,7 +101,7 @@ spec:
         # /etc/prometheus/prometheus.yml contains the M-Lab Prometheus config.
         - mountPath: /etc/prometheus
           name: prometheus-config
-      - image: measurementlab/gcp-service-discovery:cristinaleon
+      - image: measurementlab/gcp-service-discovery:v1.5.1
         name: service-discovery
         args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--gke-target=/targets/federation-targets/prometheus-clusters.json",
@@ -140,8 +140,26 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/bmc-targets/bmc_e2e.json",
                 "--http-target=/targets/switch-monitoring-targets/switch-monitoring.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/switch-monitoring-targets/switch-monitoring.json",
-                "--project={{GCLOUD_PROJECT}}",
-                "--aef-project=mlab-ns"]
+                "--project={{GCLOUD_PROJECT}}"]
+        ports:
+          - containerPort: 9373
+        resources:
+          requests:
+            memory: "150Mi"
+            cpu: "150m"
+          limits:
+            memory: "150Mi"
+            cpu: "150m"
+        volumeMounts:
+        # Mount the the prometheus-storage for write access to the target
+        # directories.
+        - mountPath: /targets
+          name: prometheus-storage
+
+      - image: measurementlab/gcp-service-discovery:v1.5.1
+        name: service-discovery-locate
+        args: [ "--aef-target=/targets/aeflex-targets/aeflex-locate.json",
+                "--project=mlab-ns"]
         ports:
           - containerPort: 9373
         resources:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -158,7 +158,7 @@ spec:
 
       - image: measurementlab/gcp-service-discovery:v1.5.1
         name: service-discovery-locate
-        args: [ "--aef-target=/targets/aeflex-targets/aeflex-locate.json",
+        args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
                 "--project={{LOCATE_PROJECT}}",
                 "--prometheusx.listen-address=:9374"]
         ports:

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -140,7 +140,8 @@ spec:
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/bmc-targets/bmc_e2e.json",
                 "--http-target=/targets/switch-monitoring-targets/switch-monitoring.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/switch-monitoring-targets/switch-monitoring.json",
-                "--project={{GCLOUD_PROJECT}}"]
+                "--project={{GCLOUD_PROJECT}}",
+                "--prometheusx.listen-address=:9373"]
         ports:
           - containerPort: 9373
         resources:
@@ -159,7 +160,7 @@ spec:
       - image: measurementlab/gcp-service-discovery:v1.5.1
         name: service-discovery-locate
         args: [ "--aef-target=/targets/aeflex-targets/aeflex-locate.json",
-                "--project=mlab-ns",
+                "--project={{LOCATE_PROJECT}}",
                 "--prometheusx.listen-address=:9374"]
         ports:
           - containerPort: 9374

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -103,8 +103,7 @@ spec:
           name: prometheus-config
       - image: measurementlab/gcp-service-discovery:v1.5.1
         name: service-discovery
-        args: [ "--aef-target=/targets/aeflex-targets/aeflex.json",
-                "--gke-target=/targets/federation-targets/prometheus-clusters.json",
+        args: [ "--gke-target=/targets/federation-targets/prometheus-clusters.json",
                 "--http-target=/targets/blackbox-targets/ssh.json",
                 "--http-source=https://storage.googleapis.com/operator-{{GCLOUD_PROJECT}}/prometheus/blackbox-targets/ssh.json",
                 "--http-target=/targets/blackbox-targets-ipv6/ssh_ipv6.json",

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -159,7 +159,8 @@ spec:
       - image: measurementlab/gcp-service-discovery:v1.5.1
         name: service-discovery-locate
         args: [ "--aef-target=/targets/aeflex-targets/aeflex-locate.json",
-                "--project=mlab-ns"]
+                "--project=mlab-ns",
+                "--prometheusx.listen-address=:9374"]
         ports:
           - containerPort: 9374
         resources:


### PR DESCRIPTION
Tested by looking at the contents of the target file for `-project=mlab-ns`.
```
/aeflex-targets $ cat aeflex-locate.json
[
    {
        "targets": [
            "35.222.117.74:9090"
        ],
        "labels": {
            "__aef_instance": "aef-locate-20220728t204839-qv9x",
            "__aef_max_total_instances": "20",
            "__aef_project": "mlab-ns",
            "__aef_public_protocol": "tcp",
            "__aef_service": "locate",
            "__aef_version": "20220728t204839",
            "__aef_vm_debug_enabled": "false"
        }
    },
    {
        "targets": [
            "34.134.93.211:9090"
        ],
        "labels": {
            "__aef_instance": "aef-locate-20220728t204839-878j",
            "__aef_max_total_instances": "20",
            "__aef_project": "mlab-ns",
            "__aef_public_protocol": "tcp",
            "__aef_service": "locate",
            "__aef_version": "20220728t204839",
            "__aef_vm_debug_enabled": "false"
        }
    }
```

Note: The "App Engine Deployer" role will need to be added to the corresponding service account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/931)
<!-- Reviewable:end -->
