### PR TITLE
Adds a new GKE Datasource variable to SiteOverview

### DIFF
--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -21,8 +21,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 65,
-  "iteration": 1659037480998,
+  "id": 246,
+  "iteration": 1659542413927,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2005,7 +2005,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -2018,7 +2018,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "/Platform Cluster.*/",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -2037,7 +2037,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "/Prometheus \\([a-z-]+\\)/",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -2200,6 +2200,6 @@
   "timezone": "",
   "title": "k8s: Site Overview",
   "uid": "rJ7z2Suik",
-  "version": 20,
+  "version": 57,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/K8s_SiteOverview.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverview.json
@@ -21,8 +21,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 246,
-  "iteration": 1657921475306,
+  "id": 65,
+  "iteration": 1659037480998,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -42,7 +42,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "OSuRJ_YMz"
+        "uid": "${gkedatasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -118,10 +118,17 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${gkedatasource}"
+          },
+          "exemplar": false,
           "expr": "probe_success{module=\"icmp\", instance=\"s1-$site.measurement-lab.org\"}",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -131,7 +138,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "OSuRJ_YMz"
+        "uid": "${gkedatasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -207,10 +214,17 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${gkedatasource}"
+          },
+          "exemplar": false,
           "expr": "gmx_site_maintenance{site=\"$site\"}",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -466,7 +480,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "OSuRJ_YMz"
+        "uid": "${gkedatasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -544,10 +558,17 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${gkedatasource}"
+          },
+          "exemplar": false,
           "expr": "gmx_machine_maintenance{machine=~\"$node-$site.*\"}",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -1984,7 +2005,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -2004,6 +2025,25 @@
       {
         "current": {
           "selected": true,
+          "text": "Prometheus (mlab-oti)",
+          "value": "Prometheus (mlab-oti)"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "GKE Datasource",
+        "multi": false,
+        "name": "gkedatasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
           "text": [
             "physical",
             "virtual"
@@ -2037,7 +2077,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "akl01",
           "value": "akl01"
         },
@@ -2160,6 +2200,6 @@
   "timezone": "",
   "title": "k8s: Site Overview",
   "uid": "rJ7z2Suik",
-  "version": 51,
+  "version": 20,
   "weekStart": ""
 }


### PR DESCRIPTION
The dashboard has a few panels that make use of metrics from the
prometheus-federation cluster. Previously it was using a static
datasource UID, which was only valid for the prometheus-federation
cluster in mlab-sandbox. With this commit, we can properly select the
right datasource at the top and all panels should work as expected in
all projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/932)
<!-- Reviewable:end -->
