### PR TITLE
Add Gardener errors panel

### DIFF
--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -1603,7 +1603,7 @@
                 "uid": "${Gardener2_DS}"
               },
               "exemplar": true,
-              "expr": "sum by(status) (rate(gardener_fail_total[5m]))",
+              "expr": "sum by(status) (increase(gardener_fail_total[5m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{status}}",

--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1655319796675,
+  "iteration": 1659642678392,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1513,6 +1513,107 @@
           }
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Gardener2_DS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 117,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(status)(increase(gardener_warning_total[5m]))",
+              "interval": "5m",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "sum by(status) (rate(gardener_fail_total[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{status}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Gardener Errors",
+          "type": "timeseries"
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -1531,9 +1632,9 @@
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
+            "h": 8,
+            "w": 12,
+            "x": 12,
             "y": 29
           },
           "hiddenSeries": false,
@@ -2340,7 +2441,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "mlab-oti",
           "value": "mlab-oti"
         },
@@ -2409,7 +2510,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "complete"
           ],
@@ -2443,7 +2544,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "tcpinfo"
           ],
@@ -2505,6 +2606,6 @@
   "timezone": "utc",
   "title": "Pipeline: Overview",
   "uid": "UTgnK-jMz",
-  "version": 13,
+  "version": 15,
   "weekStart": ""
 }


### PR DESCRIPTION
This change adds a new panel for "Gardener Errors" to the third row of the "Gardener" row.

While working on code coverage improvements, I discovered gardener has two metrics for warning and error events. This change adds a panel to report these metrics.

* gardener_warning_total
* gardener_fail_total

This may be helpful in diagnosing transient or chronic error conditions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/933)
<!-- Reviewable:end -->
