### PR TITLE
Add gardener_jobs_total error rate to error panel

### DIFF
--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1659642678392,
+  "iteration": 1659993956987,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1608,6 +1608,18 @@
               "interval": "",
               "legendFormat": "{{status}}",
               "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Gardener2_DS}"
+              },
+              "exemplar": true,
+              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[1d])) / sum by(datatype) (rate(gardener_jobs_total[1d]))) > 0.01",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{datatype}}",
+              "refId": "C"
             }
           ],
           "title": "Gardener Errors",
@@ -2441,7 +2453,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "mlab-oti",
           "value": "mlab-oti"
         },
@@ -2510,7 +2522,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "complete"
           ],
@@ -2544,7 +2556,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "tcpinfo"
           ],
@@ -2575,7 +2587,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
@@ -2606,6 +2618,6 @@
   "timezone": "utc",
   "title": "Pipeline: Overview",
   "uid": "UTgnK-jMz",
-  "version": 15,
+  "version": 17,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -1615,7 +1615,7 @@
                 "uid": "${Gardener2_DS}"
               },
               "exemplar": true,
-              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[1d])) / sum by(datatype) (rate(gardener_jobs_total[1d]))) > 0.01",
+              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[1d])) / sum by(datatype) (rate(gardener_jobs_total[1d])))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{datatype}}",

--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -1592,7 +1592,7 @@
                 "uid": "${Gardener2_DS}"
               },
               "exemplar": true,
-              "expr": "sum by(status)(increase(gardener_warning_total[5m]))",
+              "expr": "sum by(status)(increase(gardener_warning_total[10m]))",
               "interval": "5m",
               "legendFormat": "{{status}}",
               "refId": "A"
@@ -1603,7 +1603,7 @@
                 "uid": "${Gardener2_DS}"
               },
               "exemplar": true,
-              "expr": "sum by(status) (increase(gardener_fail_total[5m]))",
+              "expr": "sum by(status) (increase(gardener_fail_total[10m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{status}}",
@@ -1615,7 +1615,7 @@
                 "uid": "${Gardener2_DS}"
               },
               "exemplar": true,
-              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[1d])) / sum by(datatype) (rate(gardener_jobs_total[1d])))",
+              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[10m])) / sum by(datatype) (rate(gardener_jobs_total[10m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{datatype}}",


### PR DESCRIPTION
This change adds a new time series to the gardener error panel added in https://github.com/m-lab/prometheus-support/pull/933. The new time series matches the gardener jobs total error rate used in the `GardenerFailureRateTooHighOrMissing` alert.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/934)
<!-- Reviewable:end -->
