### PR TITLE
Update GCS transfer alert to ignore archive-mlab-oti

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -225,7 +225,7 @@ groups:
 #
 # The following alerts are based on the exact queries that mlab-ns runs to
 # determine the state of NDT services.
-# https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/util/prometheus_status.py
+# https://github.com/m-lab/mlab-ns/blob/main/server/mlabns/util/prometheus_status.py
 #
 # The expression in the denominator of the queries can be read as:
 # count `probe_success`es _unless_ the node is in GMX _and_ the node does not
@@ -658,15 +658,14 @@ groups:
 # GCS Transfer SLO
 #
 # We run daily GCS transfers between project buckets and to the public archive.
-# See: https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml
+# See: https://github.com/m-lab/gcp-config/blob/main/daily-archive-transfers.yaml
 #
 # This alert enforces that daily transfers are working for all datatypes.
 # Periodic delays are expected either to data volume or GCS Transfer service
 # variance, so the expression must be firing for over 36h.
-  - alert: GCSTransfers_ArchiveFilesDoNotMatchOrMissing
+  - alert: GCSTransfers_ArchiveFilesMissing
     expr: |
-      sum(increase(gcs_archive_files_total{bucket="archive-mlab-oti"}[1d]) - ignoring(bucket)
-         increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d]) != 0)
+      increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d]) == 0
       OR
       absent(gcs_archive_files_total)
     for: 36h
@@ -676,7 +675,7 @@ groups:
       cluster: prometheus-federation
     annotations:
       summary: GCS Transfers may not include all files.
-      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#GCSTransfers_ArchiveFilesDoNotMatchOrMissing
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#GCSTransfers_ArchiveFilesMissing
 
 # Pipeline: GCS Archives Not Found in BigQuery
 #

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -665,7 +665,8 @@ groups:
 # variance, so the expression must be firing for over 36h.
   - alert: GCSTransfers_ArchiveFilesMissing
     expr: |
-      increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d]) == 0
+      sum by (experiment, datatype) (increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d])) == 0
+        and (sum by (experiment, datatype) (increase(gcs_archive_files_total{bucket="archive-measurement-lab"}[1d] offset 1d)) > 0)
       OR
       absent(gcs_archive_files_total)
     for: 36h


### PR DESCRIPTION
Due to https://github.com/m-lab/dev-tracker/issues/729 archive files are not preserved in archive-mlab-oti bucket after transfer to the archive-measurement-lab bucket any more. And, the current alert `GCSTransfers_ArchiveFilesDoNotMatchOrMissing` asserts that the same number of files are in both archive-mlab-oti and archive-measurement-lab buckets. Because the new transfer policy violates the alert constraint, it fired: https://github.com/m-lab/dev-tracker/issues/740

This change updates the alert to a simpler `GCSTransfers_ArchiveFilesMissing` daily check for the presence of archive files in the archive-measurement-lab bucket. The `increase()` function will apply to all unique combinations of datatype labels. The `and` clause additionally filters datatypes that have no data transferred (e.g. older datatypes). With this alert, a false positive is possible if there are no new archives for a datatype for over a day. But, using our current metric history, this has not occurred in that last 16w.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/939)
<!-- Reviewable:end -->
