### PR TITLE
Use GitHub provider with oauth2-proxy for prometheus & grafana

### DIFF
--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -29,7 +29,6 @@ spec:
         #- --pass-authorization-header=true
         #- --pass-user-headers=true
         - --email-domain=*
-        - --redirect-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/callback
         - --set-xauthrequest=true
         - --whitelist-domain=.measurementlab.net
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -26,6 +26,7 @@ spec:
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
         - --github-org=m-lab
         - --email-domain=*
+        - --redirect-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/callback
         - --set-xauthrequest=true
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
         name: oauth2-proxy

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -19,8 +19,8 @@ spec:
         - --provider=github
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180
-        - --client-id=3d84e669439b5e000a2c # Temporary. Do not use.
-        - --client-secret=8e9f1105f338fb7414b1acf6aa33a644b5a2ad69 # Temporary. Do not use.
+        - --client-id={{OAUTH_PROXY_CLIENT_ID}}
+        - --client-secret={{OAUTH_PROXY_CLIENT_SECRET}}
         - --cookie-domain={{GCLOUD_PROJECT}}.measurementlab.net
         - --cookie-refresh=1h
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -25,9 +25,13 @@ spec:
         - --cookie-refresh=1h
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
         - --github-org=m-lab
+        #- --pass-access-token=true
+        #- --pass-authorization-header=true
+        #- --pass-user-headers=true
         - --email-domain=*
         - --redirect-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/callback
         - --set-xauthrequest=true
+        - --whitelist-domain=.measurementlab.net
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
         name: oauth2-proxy
         ports:

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -25,10 +25,8 @@ spec:
         - --cookie-refresh=1h
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
         - --github-org=m-lab
-        #- --pass-access-token=true
-        #- --pass-authorization-header=true
-        #- --pass-user-headers=true
         - --email-domain=*
+        - --redirect-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/callback
         - --set-xauthrequest=true
         - --whitelist-domain=.measurementlab.net
         image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -28,7 +28,7 @@ spec:
         - --email-domain=*
         - --redirect-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/callback
         - --set-xauthrequest=true
-        image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
         name: oauth2-proxy
         ports:
         - containerPort: 4180

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -19,8 +19,8 @@ spec:
         - --provider=github
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180
-        - --client-id=9244e1e1a5e64cfba055 # Temporary. Do not use.
-        - --client-secret=a82001514bf66cbd5834c331df8d08ebf62d6e4a # Temporary. Do not use.
+        - --client-id=3d84e669439b5e000a2c # Temporary. Do not use.
+        - --client-secret=8e9f1105f338fb7414b1acf6aa33a644b5a2ad69 # Temporary. Do not use.
         - --cookie-domain={{GCLOUD_PROJECT}}.measurementlab.net
         - --cookie-refresh=1h
         - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -21,6 +21,9 @@ spec:
         - --http-address=0.0.0.0:4180
         - --client-id=9244e1e1a5e64cfba055 # Temporary. Do not use.
         - --client-secret=a82001514bf66cbd5834c331df8d08ebf62d6e4a # Temporary. Do not use.
+        - --cookie-domain={{GCLOUD_PROJECT}}.measurementlab.net
+        - --cookie-refresh=1h
+        - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
         - --github-org=m-lab
         - --email-domain=*
         - --set-xauthrequest=true

--- a/k8s/prometheus-federation/deployments/oauth2-proxy.yml
+++ b/k8s/prometheus-federation/deployments/oauth2-proxy.yml
@@ -16,21 +16,15 @@ spec:
     spec:
       containers:
       - args:
-        - --provider=google
+        - --provider=github
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180
-        - --client-id={{OAUTH_PROXY_CLIENT_ID}}
-        - --client-secret={{OAUTH_PROXY_CLIENT_SECRET}}
-        - --cookie-domain={{GCLOUD_PROJECT}}.measurementlab.net
-        - --cookie-refresh=1h
-        - --cookie-secret={{OAUTH_PROXY_COOKIE_SECRET}}
-        - --email-domain=measurementlab.net
-        - --email-domain={{GCLOUD_PROJECT}}.iam.gserviceaccount.com
-        - --email-domain=husky.neu.edu
-        - --email-domain=northeastern.edu
+        - --client-id=9244e1e1a5e64cfba055 # Temporary. Do not use.
+        - --client-secret=a82001514bf66cbd5834c331df8d08ebf62d6e4a # Temporary. Do not use.
+        - --github-org=m-lab
+        - --email-domain=*
         - --set-xauthrequest=true
-        - --whitelist-domain=.measurementlab.net
-        image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
         name: oauth2-proxy
         ports:
         - containerPort: 4180

--- a/k8s/prometheus-federation/services/grafana-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/grafana-tls-oauth.yml
@@ -34,8 +34,10 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     # Set authentication URL and sign-in URL for OAuth.
-    nginx.ingress.kubernetes.io/auth-url: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    #nginx.ingress.kubernetes.io/auth-url: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/auth"
+    #nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
     # Make sure the user and email are available to the proxied application
     # in the X-User and X-Email headers.
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/k8s/prometheus-federation/services/grafana-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/grafana-tls-oauth.yml
@@ -35,7 +35,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     # Set authentication URL and sign-in URL for OAuth.
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
     #nginx.ingress.kubernetes.io/auth-url: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/auth"
     #nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
     # Make sure the user and email are available to the proxied application

--- a/k8s/prometheus-federation/services/grafana-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/grafana-tls-oauth.yml
@@ -34,8 +34,8 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     # Set authentication URL and sign-in URL for OAuth.
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-url: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
     # Make sure the user and email are available to the proxied application
     # in the X-User and X-Email headers.
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/k8s/prometheus-federation/services/grafana-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/grafana-tls-oauth.yml
@@ -35,7 +35,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     # Set authentication URL and sign-in URL for OAuth.
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=https://$host$escaped_request_uri"
     # Make sure the user and email are available to the proxied application
     # in the X-User and X-Email headers.
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/k8s/prometheus-federation/services/grafana-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/grafana-tls-oauth.yml
@@ -36,8 +36,6 @@ metadata:
     # Set authentication URL and sign-in URL for OAuth.
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
-    #nginx.ingress.kubernetes.io/auth-url: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/auth"
-    #nginx.ingress.kubernetes.io/auth-signin: "https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net/oauth2/start?rd=https://grafana.{{GCLOUD_PROJECT}}.measurementlab.net$escaped_request_uri"
     # Make sure the user and email are available to the proxied application
     # in the X-User and X-Email headers.
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/k8s/prometheus-federation/services/prometheus-tls-oauth.yml
+++ b/k8s/prometheus-federation/services/prometheus-tls-oauth.yml
@@ -35,7 +35,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     # Set authentication URL and sign-in URL for OAuth.
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=https://$host$escaped_request_uri"
     # Make sure the user and email are available to the proxied application
     # in the X-User and X-Email headers.
     nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
This change migrates the oauth2-proxy from using the google provider (with domain access control, e.g. *@measurementlab.net) to using github organization membership (e.g. users within github.com/m-lab ).

This means that members of M-Lab staff will be able to access Grafana with the same email address registered with their github account. And, this address will be the one used to assign privileges in Grafana. Because individual's github and prior Grafana emails may differ, the default permission may be `Viewer` in Grafana and will need to be updated by someone with elevated privileges.

This change requires registering a new "Oauth App" within the M-Lab github organization https://github.com/organizations/m-lab/settings/applications - We will need to create two more for the staging and production deployments.

It should additionally be possible to add new services like the alertmanager behind oauth also.

This change continues to work as the single oauth2-proxy configuration serving the prometheus-platform-cluster instance as well.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/940)
<!-- Reviewable:end -->
