### PR TITLE
Update links referencing main branch

### DIFF
--- a/IPV6_MONITORING.md
+++ b/IPV6_MONITORING.md
@@ -35,12 +35,12 @@ Below are first-time setup instructions and requirements for the VM:
   prom/blackbox-exporter:v0.12.0`.
 
 * Manually upload [the blackbox\_exporter config
-  file](https://github.com/m-lab/prometheus-support/blob/master/config/federation/blackbox/config.yml)
+  file](https://github.com/m-lab/prometheus-support/blob/main/config/federation/blackbox/config.yml.template)
   to mlab's home directory, then make three copies of it with the following
   names. If you don't do this, instantiating the Docker instances will fail
   because the blackbox\_exporter will not be able to find its config file.
   Later, these files will be [pushed to the VM automatically on
-  builds](https://github.com/m-lab/prometheus-support/blob/master/deploy_bbe_config.sh)
+  builds](https://github.com/m-lab/prometheus-support/blob/main/deploy_bbe_config.sh)
   of m-lab/prometheus-support repo.
 
 ```text

--- a/config/cluster/prometheus/prometheus.yml.template
+++ b/config/cluster/prometheus/prometheus.yml.template
@@ -43,7 +43,7 @@ rule_files:
 scrape_configs:
 
   # Kubernetes configurations were inspired by:
-  # https://github.com/prometheus/prometheus/blob/master/documentation/examples
+  # https://github.com/prometheus/prometheus/blob/main/documentation/examples
   #
   # The four kubernetes scrape configs correspond to specific cluster
   # components.

--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -104,7 +104,7 @@ receivers:
       {{.CommonAnnotations.summary}}
       > {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}
       {{- else}}*Please add an alert description!*{{end -}}
-      <https://github.com/m-lab/prometheus-support/edit/master/config/federation/prometheus/alerts.yml|(edit...)>
+      <https://github.com/m-lab/prometheus-support/edit/main/config/federation/prometheus/alerts.yml|(edit...)>
       {{- end }}
       {{ range $key, $value := .CommonLabels }} {{ $key }}=*{{ $value }}*, {{ end }}
     actions:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -56,7 +56,7 @@ alerting:
 scrape_configs:
 
   # Kubernetes configurations were inspired by:
-  # https://github.com/prometheus/prometheus/blob/master/documentation/examples
+  # https://github.com/prometheus/prometheus/blob/main/documentation/examples
   #
   # The four kubernetes scrape configs correspond to specific cluster
   # components.
@@ -652,7 +652,7 @@ scrape_configs:
     relabel_configs:
       # The value of the source label named "service" must match the name of a
       # configured script in the script_exporter configuration. See this file:
-      # https://github.com/m-lab/prometheus-support/blob/master/config/federation/script-exporter/script_exporter.yml
+      # https://github.com/m-lab/prometheus-support/blob/main/config/federation/script-exporter/script_exporter.yml
       - source_labels: [service]
         regex: (.*)
         target_label: __param_name

--- a/k8s/data-processing/deployments/prometheus.yml
+++ b/k8s/data-processing/deployments/prometheus.yml
@@ -48,10 +48,6 @@ spec:
       # take longer than the default grace period of 30s.
       terminationGracePeriodSeconds: 240
 
-      # Place the pod into the Guaranteed QoS by setting equal resource
-      # requests and limits for *all* containers in the pod.
-      # For more background, see:
-      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.

--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -22,10 +22,6 @@ spec:
         # public IP and port so that it is publically accessible.
         run: alertmanager-server
     spec:
-      # Place the pod into the Guaranteed QoS by setting equal resource
-      # requests and limits for *all* containers in the pod.
-      # For more background, see:
-      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
       containers:
       # Check https://hub.docker.com/r/prom/alertmanager/tags/ for the current
       # stable version.

--- a/k8s/prometheus-federation/deployments/blackbox.yml
+++ b/k8s/prometheus-federation/deployments/blackbox.yml
@@ -38,10 +38,6 @@ spec:
                   values:
                     - blackbox-server
               topologyKey: kubernetes.io/hostname
-      # Place the pod into the Guaranteed QoS by setting equal resource
-      # requests and limits for *all* containers in the pod.
-      # For more background, see:
-      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
       containers:
       # Check https://hub.docker.com/r/prom/blackbox-exporter/tags/ for the current
       # stable version.

--- a/k8s/prometheus-federation/deployments/gcs-exporter.yml
+++ b/k8s/prometheus-federation/deployments/gcs-exporter.yml
@@ -20,7 +20,7 @@ spec:
         image: measurementlab/gcs-exporter:v0.2
         args:
         # NOTE: -time must not be less than the scheduled transfer times from:
-        # https://github.com/m-lab/gcp-config/blob/master/daily-archive-transfers.yaml
+        # https://github.com/m-lab/gcp-config/blob/main/daily-archive-transfers.yaml
         - -source=pusher-{{GCLOUD_PROJECT}}
         - -time=2h30m
         - -source=archive-{{GCLOUD_PROJECT}}

--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -39,10 +39,6 @@ spec:
       # take longer than the default grace period of 30s.
       terminationGracePeriodSeconds: 240
 
-      # Place the pod into the Guaranteed QoS by setting equal resource
-      # requests and limits for *all* containers in the pod.
-      # For more background, see:
-      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.


### PR DESCRIPTION
This change continues work to update github branches to use `main`. This change updates links in configuration to use the main branch where appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/942)
<!-- Reviewable:end -->
