### PR TITLE
Remove "in progress" label

### DIFF
--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -27,7 +27,6 @@ spec:
         args: [ "--authtoken=$(GITHUB_AUTH_TOKEN)",
                 "--org=m-lab",
                 "--repo=dev-tracker",
-                "--label=in progress",
                 "--enable-inmemory={{GITHUB_RECEIVER_INMEMORY}}" ]
         ports:
         # TODO: receiver and metrics should be available on the same port.


### PR DESCRIPTION
Issues created by the alertmanager github receiver from prometheus alerts automatically add the 'in progress' label. However, this is confusing and we use this label as part of no other automation. This change removes this label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/943)
<!-- Reviewable:end -->
