### PR TITLE
Adds alert for when mlab-ns resp code metric is missing

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -548,6 +548,25 @@ groups:
         the underlying service. Please check the GAE dashboard and logs to
         determine the cause.
 
+# The alert MlabNS_TooManyServiceErrors will generate a page to operators if it
+# fires. We consider it a fairly serious alert, enough to wake people up at
+# night. If the metric that comprises the alert is missing, then fire an alert.
+  - alert: MlabNS_ServerResponseMetricMissing
+    expr: |
+      absent_over_time(
+        stackdriver_gae_app_appengine_googleapis_com_http_server_response_count{
+          deployment="mlabns-stackdriver", loading="false", module_id="default"
+        }
+      [1h])
+    for: 5m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: A critical metric about mlab-ns is missing.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#mlabns_serverresponsemetricmissing
+
 # If container logs for a node are missing in Stackdriver for too long, then
 # fire an alert, unless the node is in maintenance mode. This somewhat awkward
 # query discovers cases where the stackdriver metric has been absent for too


### PR DESCRIPTION
The alert `MlabNS_TooManyServiceErrors` will generate a page to platform operators. However, there is currently no alert for the case when the metric that that alert relies on is missing. This PR adds a new alert to warn us when that metric is missing. This could happen, for example, when the `mlabns-stackdriver` deployment isn't working for some reason, like [a bug in the service](https://github.com/m-lab/prometheus-support/issues/896).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/946)
<!-- Reviewable:end -->
