### PR TITLE
Adds tolerations to run on prometheus pool nodes

### DIFF
--- a/k8s/prometheus-federation/deployments/cadvisor.yml
+++ b/k8s/prometheus-federation/deployments/cadvisor.yml
@@ -63,6 +63,10 @@ spec:
         operator: "Equal"
         value: "static"
         effect: "NoSchedule"
+      - key: "prometheus-node"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
       volumes:
       - name: rootfs
         hostPath:

--- a/k8s/prometheus-federation/deployments/node-exporter.yml
+++ b/k8s/prometheus-federation/deployments/node-exporter.yml
@@ -34,4 +34,8 @@ spec:
         operator: "Equal"
         value: "static"
         effect: "NoSchedule"
+      - key: "prometheus-node"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
 


### PR DESCRIPTION
There were already tolerations for node-exporter and cadvisor to allow
them to run on the static-outbound-ip nodes. This commits adds another
toleration to each so that they can run on prometheus pool nodes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/949)
<!-- Reviewable:end -->
