### PR TITLE
Create k8s Secret for GMX Github webhook

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -292,6 +292,13 @@ kubectl create secret generic switch-monitoring-credentials\
   "--from-file=/tmp/switch-monitoring.key" \
   --dry-run="client" -o json | kubectl apply -f -
 
+## Github Maintenance Exporter
+
+# Create GMX Github webhook secret as a Kubernetes secret.
+kubectl create secret generic gmx-webhook-secret \
+  "--from-literal=gmx-webhook-secret=${GMX_GITHUB_WEBHOOK_SECRET}" \
+  --dry-run="client" -o json | kubectl apply -f -
+
 ## OAuth2 Proxy
 
 # Replace template variables in oauth2-proxy.yml.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,8 @@ availableSecrets:
     env: GF_AUTH_GOOGLE_CLIENT_ID
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-github-receiver-auth-token/versions/latest
     env: GITHUB_RECEIVER_AUTH_TOKEN
+  - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-gmx-github-webhook-secret/versions/latest
+    env: GMX_GITHUB_WEBHOOK_SECRET
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-linode-private-key-ipv6-monitoring/versions/latest
     env: LINODE_PRIVATE_KEY_ipv6_monitoring
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-script-exporter-monitoring-signer-key/versions/latest
@@ -58,6 +60,7 @@ steps:
   - GF_AUTH_GOOGLE_CLIENT_SECRET
   - GF_AUTH_GOOGLE_CLIENT_ID
   - GITHUB_RECEIVER_AUTH_TOKEN
+  - GMX_GITHUB_WEBHOOK_SECRET
   - LINODE_PRIVATE_KEY_ipv6_monitoring
   - MONITORING_SIGNER_KEY
   - OAUTH_PROXY_CLIENT_ID


### PR DESCRIPTION
Currently, the secret is deployed as part of the github-maintenance-exporter build. This commit creates the secret as part of the prometheus-support build, after which the GMX build can be nothing but running unit tests, and migrated to Cloud Build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/952)
<!-- Reviewable:end -->
