### PR TITLE
Update Boot_MachineFailedToBoot to ops-tracker repo

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1000,7 +1000,7 @@ groups:
       )
     for: 24h
     labels:
-      repo: dev-tracker
+      repo: ops-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:


### PR DESCRIPTION
The `Boot_MachineFailedToBoot` alert is labeled as a `dev-tracker` alert. This PR updates it to the `ops-tracker` repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/953)
<!-- Reviewable:end -->
