### PR TITLE
Adds new "fqdn" label to script-exporter metrics

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -679,7 +679,7 @@ scrape_configs:
       - source_labels: [__address__, experiment]
         regex: (.*);([a-z0-9]+)\.?.*
         target_label: fqdn
-        replacement: ${1}-${2}
+        replacement: ${2}-${1}
 
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the script_exporter

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -673,6 +673,14 @@ scrape_configs:
         target_label: site
         replacement: ${1}
 
+      # Create an "fqdn" label for each target host, which will vary depending
+      # on the service. The awkward regexp for the "experiment" label is to
+      # accommodate legacy experiment names like "ndt.iupui".
+      - source_labels: [__address__, experiment]
+        regex: (.*);([a-z0-9]+)\.?.*
+        target_label: fqdn
+        replacement: ${1}-${2}
+
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the script_exporter
       # address.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -674,8 +674,9 @@ scrape_configs:
         replacement: ${1}
 
       # Create an "fqdn" label for each target host, which will vary depending
-      # on the service. The awkward regexp for the "experiment" label is to
-      # accommodate legacy experiment names like "ndt.iupui".
+      # on the service. TODO(kinkade): once the ".iupui" suffix is entirely
+      # retired from the platform, modify the regexp to simply use the entire
+      # experiment label's value.
       - source_labels: [__address__, experiment]
         regex: (.*);([a-z0-9]+)\.?.*
         target_label: fqdn


### PR DESCRIPTION
The new label will contain the fqdn of the experiment being tested, e.g.,:

```
fqdn="ndt-mlab2-abc01.mlab-oti.measurement-lab.org"
fqdn="wehe-mlab4-lol02.mlab-staging.measurement-lab.org"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/954)
<!-- Reviewable:end -->
