### PR TITLE
Promotes "GCP Billing" dashboard to GA, with some modifications

### DIFF
--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -34,14 +34,14 @@
         "uid": "xIXR1_LMz"
       },
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 24,
         "x": 0,
         "y": 0
       },
       "id": 8,
       "options": {
-        "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but usage for a given hour may not be available until 2 days later",
+        "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but complete usage for a given hour may not be available until 2 days later\n* Because of the above, the default time range excludes the last 24h",
         "mode": "markdown"
       },
       "pluginVersion": "9.1.5",
@@ -62,7 +62,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 3
       },
       "id": 29,
       "panels": [],
@@ -102,7 +102,7 @@
         "h": 3,
         "w": 5,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "id": 26,
       "options": {
@@ -191,7 +191,7 @@
         "h": 3,
         "w": 5,
         "x": 5,
-        "y": 3
+        "y": 4
       },
       "id": 27,
       "options": {
@@ -257,7 +257,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 20,
       "panels": [],
@@ -311,7 +311,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -339,7 +339,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 12,
       "options": {
@@ -393,7 +393,7 @@
           ]
         }
       ],
-      "title": "Cost per project (per day)",
+      "title": "Cost per project per day (stacked)",
       "type": "timeseries"
     },
     {
@@ -430,7 +430,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -458,7 +458,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 8
       },
       "id": 14,
       "options": {
@@ -512,7 +512,7 @@
           ]
         }
       ],
-      "title": "Cost per service (per day)",
+      "title": "Cost per service per day (stacked)",
       "type": "timeseries"
     },
     {
@@ -577,15 +577,14 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 15,
       "maxDataPoints": 20000,
       "options": {
         "legend": {
           "calcs": [
-            "mean",
-            "max"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -699,7 +698,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "id": 31,
       "options": {
@@ -744,7 +743,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 32
       },
       "id": 18,
       "panels": [],
@@ -827,7 +826,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 33
       },
       "id": 16,
       "options": {
@@ -946,7 +945,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 33
       },
       "id": 11,
       "options": {
@@ -1066,15 +1065,14 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 13,
       "maxDataPoints": 8000,
       "options": {
         "legend": {
           "calcs": [
-            "mean",
-            "max"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -1188,8 +1186,8 @@
     ]
   },
   "time": {
-    "from": "now-7d",
-    "to": "now"
+    "from": "now-8d",
+    "to": "now-1d"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -1208,6 +1206,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 47,
+  "version": 48,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -640,7 +640,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "",
+      "description": "octets_out: the sum of the node-exporter metric \"node_network_transmit_bytes_total\" for every GCE virtual platform node, assuming a $0.10/GB cost. This number is likely to be higher than the actual cost, since some amount of octets out on every node will be to destinations within GCP, and billed at a much lower rate.\n\ngce_egress: calcul1ated using the exported GCP billing data in BigQuery where service.description = \"Compute Engine\" and sku.description LIKE \"Network Internet Egress%\". This number will definitely be _much_ higher than the actual cost of virtual platform node Internet egress, because it includes Internet egress costs for _all_ GCE instances, whether they are part of the platform or not. However, it should show us trends and give us a general idea of how much Internet egress is cost M-Lab.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -713,8 +713,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -725,12 +725,46 @@
           },
           "editorMode": "code",
           "expr": "sum(\n  (\n    (\n      increase(node_network_transmit_bytes_total{device=\"ens4\", node=~\"mlab[1-4].*\"}[1d])\n        and on(node) kube_node_labels{label_mlab_type=\"virtual\"}\n    ) / 2^30\n  ) * 0.10\n)",
-          "legendFormat": "mlab-oti",
+          "legendFormat": "octets_out",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
+          "refId": "B",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
         }
       ],
-      "title": "Estimated GCE egress network cost (per day) (mlab-oti)",
+      "title": "GCE egress network cost per day (mlab-oti)",
       "type": "timeseries"
     },
     {
@@ -1048,8 +1082,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1206,6 +1239,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 48,
+  "version": 49,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -640,7 +640,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "octets_out: the sum of the node-exporter metric \"node_network_transmit_bytes_total\" for every GCE virtual platform node, assuming a $0.10/GB cost. This number is likely to be higher than the actual cost, since some amount of octets out on every node will be to destinations within GCP, and billed at a much lower rate.\n\ngce_egress: calcul1ated using the exported GCP billing data in BigQuery where service.description = \"Compute Engine\" and sku.description LIKE \"Network Internet Egress%\". This number will definitely be _much_ higher than the actual cost of virtual platform node Internet egress, because it includes Internet egress costs for _all_ GCE instances, whether they are part of the platform or not. However, it should show us trends and give us a general idea of how much Internet egress is cost M-Lab.",
+      "description": "octets_out: the sum of the node-exporter metric \"node_network_transmit_bytes_total\" for every GCE virtual platform node, assuming a $0.10/GB cost. This number is likely to be higher than the actual cost, since some amount of octets out on every node will be to destinations within GCP, and billed at a much lower rate.\n\ngce_egress: calculated using the exported GCP billing data in BigQuery where service.description = \"Compute Engine\" and sku.description LIKE \"Network Internet Egress%\". This number will definitely be _much_ higher than the actual cost of virtual platform node Internet egress, because it includes Internet egress costs for _all_ GCE instances, whether they are part of the platform or not. However, it should show us trends and give us a general idea of how much Internet egress is costing M-Lab.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -724,7 +724,7 @@
             "uid": "WW1Jk2sGk"
           },
           "editorMode": "code",
-          "expr": "sum(\n  (\n    (\n      increase(node_network_transmit_bytes_total{device=\"ens4\", node=~\"mlab[1-4].*\"}[1d])\n        and on(node) kube_node_labels{label_mlab_type=\"virtual\"}\n    ) / 2^30\n  ) * 0.10\n)",
+          "expr": "sum(\n  (\n    (\n      (\n        increase(node_network_transmit_bytes_total{device=\"ens4\", node=~\"mlab[1-4].*\"}[1d])\n          and on(node) kube_node_labels{label_mlab_type=\"virtual\"}\n      ) / 2^30\n    ) * 0.10\n  )\n)",
           "legendFormat": "octets_out",
           "range": true,
           "refId": "A"
@@ -1082,7 +1082,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -569,7 +569,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
@@ -640,7 +641,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "octets_out: the sum of the node-exporter metric \"node_network_transmit_bytes_total\" for every GCE virtual platform node, assuming a $0.10/GB cost. This number is likely to be higher than the actual cost, since some amount of octets out on every node will be to destinations within GCP, and billed at a much lower rate.\n\ngce_egress: calculated using the exported GCP billing data in BigQuery where service.description = \"Compute Engine\" and sku.description LIKE \"Network Internet Egress%\". This number will definitely be _much_ higher than the actual cost of virtual platform node Internet egress, because it includes Internet egress costs for _all_ GCE instances, whether they are part of the platform or not. However, it should show us trends and give us a general idea of how much Internet egress is costing M-Lab.",
+      "description": "octets_out_sum: the sum of the node-exporter metric \"node_network_transmit_bytes_total\" for every GCE virtual platform node, assuming a $0.10/GB cost. This number is likely to be higher than the actual cost, since some amount of octets out on every node will be to destinations within GCP, and billed at a much lower rate.\n\ngce_egress_sum: calculated using the exported GCP billing data in BigQuery where service.description = \"Compute Engine\" and sku.description LIKE \"Network Internet Egress%\". This number will definitely be _much_ higher than the actual cost of virtual platform node Internet egress, because it includes Internet egress costs for _all_ GCE instances, whether they are part of the platform or not. However, it should show us trends and give us a general idea of how much Internet egress is costing M-Lab.\n\nNetwork Internet Egress.*: specific network internet egress SKUs where the cost per day is greater than $10. These plots will give you an idea of the major contributors to the \"gce_egress_sum\" plot.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -725,7 +726,7 @@
           },
           "editorMode": "code",
           "expr": "sum(\n  (\n    (\n      (\n        increase(node_network_transmit_bytes_total{device=\"ens4\", node=~\"mlab[1-4].*\"}[1d])\n          and on(node) kube_node_labels{label_mlab_type=\"virtual\"}\n      ) / 2^30\n    ) * 0.10\n  )\n)",
-          "legendFormat": "octets_out",
+          "legendFormat": "octets_out_sum",
           "range": true,
           "refId": "A"
         },
@@ -741,8 +742,42 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress_sum\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
           "refId": "B",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  sku.description as metric,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 10\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date, metric\nORDER BY\n  date, gce_egress\n",
+          "refId": "C",
           "select": [
             [
               {
@@ -1082,8 +1117,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1240,6 +1274,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 49,
+  "version": 50,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -1,0 +1,1199 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 2,
+  "id": 339,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but...\n* Usage for a given hour may not be available until 2 days later",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 24,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Projections (estimates based on recent usage)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 12000
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 0,
+        "y": 5
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "2",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  SUM(cost)/7 AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  DATE(usage_start_time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 8 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)\n  AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Avg Daily Credits (last 7 days)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5000000
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 5,
+        "y": 5
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "2",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  365*SUM(cost)/7 AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  DATE(usage_start_time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 8 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)\n  AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Projected Annual Credits (based on last 7 days)",
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 22,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 20,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "All Projects",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "measurement-lab"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  --service.description AS metric,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL\nGROUP BY\n  date,\n  metric\n  --project\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Costs by project (per day)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 0.01\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Costs by Service (per day) (all projects)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "Recent data may be delayed by 48 hours",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Cloud Storage-Networking Traffic Egress GCP Inter Region within Northern America"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 15,
+      "maxDataPoints": 20000,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  CONCAT(service.description,\n     CASE service.description\n     WHEN \"BigQuery\" THEN CONCAT(\"-\", sku.description)\n     WHEN \"Cloud Storage\" THEN CONCAT(\"-\", sku.description)\n     ELSE \"\"\n     END\n  ) AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 1\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Costs by Service (per hour) (all projects)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 18,
+      "panels": [],
+      "repeat": "project",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "$project",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  --service.description AS metric,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "$project :: Costs by project (per day)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 0.01\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "$project :: Costs by Service (per day)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "Recent data may be delayed by 48 hours",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 13,
+      "maxDataPoints": 8000,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  CONCAT(service.description,\n     CASE service.description\n     WHEN \"BigQuery\" THEN CONCAT(\"-\", sku.description)\n     WHEN \"Cloud Storage\" THEN CONCAT(\"-\", sku.description)\n     ELSE \"\"\n     END\n  ) AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 1\nORDER BY\n  date\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "$project :: Costs by Service (per hour)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "mlab-oti",
+          "value": "mlab-oti"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "project",
+        "options": [
+          {
+            "selected": false,
+            "text": "mlab-sandbox",
+            "value": "mlab-sandbox"
+          },
+          {
+            "selected": false,
+            "text": "mlab-staging",
+            "value": "mlab-staging"
+          },
+          {
+            "selected": true,
+            "text": "mlab-oti",
+            "value": "mlab-oti"
+          },
+          {
+            "selected": false,
+            "text": "measurement-lab",
+            "value": "measurement-lab"
+          },
+          {
+            "selected": false,
+            "text": "mlab-ns",
+            "value": "mlab-ns"
+          },
+          {
+            "selected": false,
+            "text": "mlab-collaboration",
+            "value": "mlab-collaboration"
+          },
+          {
+            "selected": false,
+            "text": "mlab-edgenet",
+            "value": "mlab-edgenet"
+          }
+        ],
+        "query": "mlab-sandbox,mlab-staging,mlab-oti,measurement-lab,mlab-ns,mlab-collaboration,mlab-edgenet",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "GCP Billing",
+  "uid": "a5mC51ZMk",
+  "version": 46,
+  "weekStart": ""
+}

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -23,7 +23,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 2,
+  "graphTooltip": 1,
   "id": 339,
   "links": [],
   "liveNow": false,
@@ -34,14 +34,14 @@
         "uid": "xIXR1_LMz"
       },
       "gridPos": {
-        "h": 4,
+        "h": 2,
         "w": 24,
         "x": 0,
         "y": 0
       },
       "id": 8,
       "options": {
-        "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but...\n* Usage for a given hour may not be available until 2 days later",
+        "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but usage for a given hour may not be available until 2 days later",
         "mode": "markdown"
       },
       "pluginVersion": "9.1.5",
@@ -58,28 +58,15 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "xIXR1_LMz"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 2
       },
-      "id": 24,
+      "id": 29,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "xIXR1_LMz"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Projections (estimates based on recent usage)",
+      "title": "Summary",
       "type": "row"
     },
     {
@@ -115,7 +102,7 @@
         "h": 3,
         "w": 5,
         "x": 0,
-        "y": 5
+        "y": 3
       },
       "id": 26,
       "options": {
@@ -204,7 +191,7 @@
         "h": 3,
         "w": 5,
         "x": 5,
-        "y": 5
+        "y": 3
       },
       "id": 27,
       "options": {
@@ -261,31 +248,6 @@
       "type": "stat"
     },
     {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "xIXR1_LMz"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 22,
-      "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "xIXR1_LMz"
-          },
-          "refId": "A"
-        }
-      ],
-      "type": "row"
-    },
-    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -295,7 +257,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 6
       },
       "id": 20,
       "panels": [],
@@ -349,7 +311,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -369,46 +331,21 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "currencyUSD"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "measurement-lab"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 7
       },
       "id": 12,
       "options": {
         "legend": {
           "calcs": [
-            "max"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -417,8 +354,8 @@
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -433,7 +370,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  --service.description AS metric,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL\nGROUP BY\n  date,\n  metric\n  --project\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL\nGROUP BY\n  date,\n  metric\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -456,7 +393,7 @@
           ]
         }
       ],
-      "title": "Costs by project (per day)",
+      "title": "Cost per project (per day)",
       "type": "timeseries"
     },
     {
@@ -493,7 +430,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -513,21 +450,21 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 7
       },
       "id": 14,
       "options": {
         "legend": {
           "calcs": [
-            "max"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -536,8 +473,8 @@
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -552,7 +489,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 0.01\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\nHAVING value > 0.01\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -575,7 +512,7 @@
           ]
         }
       ],
-      "title": "Costs by Service (per day) (all projects)",
+      "title": "Cost per service (per day)",
       "type": "timeseries"
     },
     {
@@ -634,44 +571,20 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Cloud Storage-Networking Traffic Egress GCP Inter Region within Northern America"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 15
       },
       "id": 15,
       "maxDataPoints": 20000,
       "options": {
         "legend": {
           "calcs": [
+            "mean",
             "max"
           ],
           "displayMode": "table",
@@ -681,8 +594,8 @@
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -697,7 +610,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  CONCAT(service.description,\n     CASE service.description\n     WHEN \"BigQuery\" THEN CONCAT(\"-\", sku.description)\n     WHEN \"Cloud Storage\" THEN CONCAT(\"-\", sku.description)\n     ELSE \"\"\n     END\n  ) AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 1\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\nHAVING value > 1\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -720,7 +633,105 @@
           ]
         }
       ],
-      "title": "Costs by Service (per hour) (all projects)",
+      "title": "Cost per service (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WW1Jk2sGk"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  (\n    (\n      increase(node_network_transmit_bytes_total{device=\"ens4\", node=~\"mlab[1-4].*\"}[1d])\n        and on(node) kube_node_labels{label_mlab_type=\"virtual\"}\n    ) / 2^30\n  ) * 0.10\n)",
+          "legendFormat": "mlab-oti",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated GCE egress network cost (per day) (mlab-oti)",
       "type": "timeseries"
     },
     {
@@ -733,7 +744,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 31
       },
       "id": 18,
       "panels": [],
@@ -788,7 +799,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -808,15 +819,15 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 32
       },
       "id": 16,
       "options": {
@@ -826,7 +837,7 @@
           ],
           "displayMode": "table",
           "placement": "right",
-          "showLegend": true,
+          "showLegend": false,
           "sortBy": "Max",
           "sortDesc": true
         },
@@ -847,7 +858,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  --service.description AS metric,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -870,7 +881,7 @@
           ]
         }
       ],
-      "title": "$project :: Costs by project (per day)",
+      "title": "Cost per day ($project)",
       "type": "timeseries"
     },
     {
@@ -907,7 +918,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -927,15 +938,15 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 32
       },
       "id": 11,
       "options": {
@@ -945,13 +956,13 @@
           ],
           "displayMode": "table",
           "placement": "right",
-          "showLegend": true,
+          "showLegend": false,
           "sortBy": "Max",
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -966,7 +977,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 0.01\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > 0.01\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -989,7 +1000,7 @@
           ]
         }
       ],
-      "title": "$project :: Costs by Service (per day)",
+      "title": "Cost per service (per day) ($project)",
       "type": "timeseries"
     },
     {
@@ -1046,21 +1057,23 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "currencyUSD"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 40
       },
       "id": 13,
       "maxDataPoints": 8000,
       "options": {
         "legend": {
           "calcs": [
+            "mean",
             "max"
           ],
           "displayMode": "table",
@@ -1070,8 +1083,8 @@
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1086,7 +1099,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  CONCAT(service.description,\n     CASE service.description\n     WHEN \"BigQuery\" THEN CONCAT(\"-\", sku.description)\n     WHEN \"Cloud Storage\" THEN CONCAT(\"-\", sku.description)\n     ELSE \"\"\n     END\n  ) AS metric,\n  --project.id AS project,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\n  --project\nHAVING value > 1\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > 1\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -1109,7 +1122,7 @@
           ]
         }
       ],
-      "title": "$project :: Costs by Service (per hour)",
+      "title": "Cost per service (per hour) ($project)",
       "type": "timeseries"
     }
   ],
@@ -1127,6 +1140,7 @@
         },
         "hide": 0,
         "includeAll": false,
+        "label": "Project",
         "multi": false,
         "name": "project",
         "options": [
@@ -1174,7 +1188,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -1194,6 +1208,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 46,
+  "version": 47,
   "weekStart": ""
 }


### PR DESCRIPTION
https://grafana.mlab-sandbox.measurementlab.net/d/a5mC51ZMk/gcp-billing

This PR takes the "GCP Billing" dashboard that @stephen-soltesz created with the following changes

* moves it from the "soltesz" folder to the "General" folder
* cleans it up (to my personal tastes)
  * resizes numerous panels
  * removes legend from some panels
  * changes hover tip to show "All" and sort desc
  * Sets data type to "Currency: US Dollars"
  * removes "stacked" graph display from most panels
  * renames panels slightly
  * removes any comments from BigQuery queries
  * reduces default range from 14d to 7d
  * various other tweaks I can't think of now
* adds a new panel for estimated GCE egress traffic costs per day

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/955)
<!-- Reviewable:end -->
