### PR TITLE
Specify the prometheus scrape interval

### DIFF
--- a/config/federation/grafana/provisioning/datasources/data-processing_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/data-processing_mlab-oti.yml.template
@@ -20,3 +20,5 @@ datasources:
   # <bool> allow users to edit datasources from the UI.
   editable: false
 
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/data-processing_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/data-processing_mlab-sandbox.yml.template
@@ -20,3 +20,5 @@ datasources:
   # <bool> allow users to edit datasources from the UI.
   editable: false
 
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/data-processing_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/data-processing_mlab-staging.yml.template
@@ -20,3 +20,5 @@ datasources:
   # <bool> allow users to edit datasources from the UI.
   editable: false
 
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-oti.yml.template
@@ -16,3 +16,5 @@ datasources:
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: false
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-sandbox.yml.template
@@ -16,3 +16,5 @@ datasources:
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: false
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/platform-cluster_mlab-staging.yml.template
@@ -16,3 +16,5 @@ datasources:
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: false
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -15,3 +15,5 @@ datasources:
   version: 1
   editable: false
 
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-sandbox.yml.template
@@ -15,3 +15,5 @@ datasources:
   version: 1
   editable: false
 
+  jsonData:
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-staging.yml.template
@@ -15,3 +15,5 @@ datasources:
   version: 1
   editable: false
 
+  jsonData:
+    timeInterval: 60s


### PR DESCRIPTION
This change specifies the scrape interval for prometheus data sources so that we can take advantage of https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/957)
<!-- Reviewable:end -->
