### PR TITLE
Add Prometheus and health panels to Locate dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,20 +24,821 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1661804115489,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "id": 14,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of currently active Heartbeat connections.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(locate_current_heartbeat_connections)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Heartbeat Connections",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The 5 min rate of Heartbeat connection requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-purple",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(locate_requests_total{type=\"heartbeat\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Heartbeat Connection Request Rate (5 min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in number of port checks grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 9
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "exemplar": true,
+          "expr": "sum by(status)(increase(heartbeat_port_checks_total[10m]))",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Port Checks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in number of health checks grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 9
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total[10m]))",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Checks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in Requests to the Kubernetes API Server grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 17
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "exemplar": true,
+          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total[10m]))",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Increase in Prometheus health collections grouped by code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 17
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (code) (increase(prometheus_health_collection_duration_count[10m]))",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prometheus Health Collections",
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Kubernetes API server request duration in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 25
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 20,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "exemplar": true,
+          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes API Server Request Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Prometheus health collection duration in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 25
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 25,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 1,
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(prometheus_health_collection_duration_bucket{}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prometheus Health Collection Request Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
       "id": 12,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Nearest",
       "type": "row"
     },
@@ -51,6 +855,8 @@
             "mode": "fixed"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -102,17 +908,19 @@
         "h": 9,
         "w": 9,
         "x": 0,
-        "y": 1
+        "y": 34
       },
       "id": 2,
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -143,6 +951,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -191,19 +1001,21 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 8,
+        "w": 9,
         "x": 9,
-        "y": 1
+        "y": 34
       },
       "id": 4,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.4",
@@ -225,418 +1037,27 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
-      },
-      "id": 14,
-      "panels": [],
-      "title": "Heartbeat",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Number of currently active Heartbeat connections.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "light-purple",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 11
-      },
-      "id": 10,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.3.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "sum(locate_current_heartbeat_connections)",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Current Heartbeat Connections",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "The 5 min rate of Heartbeat connection requests.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "light-purple",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 9,
-        "y": 11
-      },
-      "id": 18,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "sum(rate(locate_requests_total{type=\"heartbeat\"}[5m]))",
-          "interval": "",
-          "legendFormat": "Rate",
-          "refId": "A"
-        }
-      ],
-      "title": "Heartbeat Connection Request Rate (5 min)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Increase in Requests to the Kubernetes API Server grouped by status.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 19
-      },
-      "id": 22,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total[10m]))",
-          "interval": "",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Kubernetes Requests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Increase in number of port checks grouped by status.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 9,
-        "y": 19
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_port_checks_total[10m]))",
-          "interval": "",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Port Checks",
-      "type": "timeseries"
-    },
-    {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 27
-      },
-      "heatmap": {},
-      "hideZeroBuckets": true,
-      "highlightCards": true,
-      "id": 20,
-      "legend": {
-        "show": true
-      },
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{}[5m]))",
-          "format": "heatmap",
-          "interval": "5m",
-          "legendFormat": "{{le}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Kubernetes API Server Request Time",
-      "tooltip": {
-        "show": true,
-        "showHistogram": true
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "short",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 16,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "App Engine",
       "type": "row"
     },
@@ -652,6 +1073,8 @@
             "mode": "continuous-GrYlRd"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -700,17 +1123,19 @@
         "h": 8,
         "w": 9,
         "x": 0,
-        "y": 36
+        "y": 44
       },
       "id": 6,
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -730,7 +1155,7 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 34,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -756,7 +1181,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-sandbox)",
           "value": "Platform Cluster (mlab-sandbox)"
         },
@@ -776,13 +1201,13 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 24,
+  "version": 25,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -122,7 +122,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Connection rate",
+            "axisLabel": "Connection rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -217,7 +217,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of collections",
+            "axisLabel": "Number of collections / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -454,7 +454,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks",
+            "axisLabel": "Number of checks / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -549,7 +549,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks",
+            "axisLabel": "Number of checks / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -644,7 +644,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of requests",
+            "axisLabel": "Number of requests / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -881,7 +881,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request rate",
+            "axisLabel": "Request rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -980,7 +980,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Failure rate",
+            "axisLabel": "Failure rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1105,7 +1105,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Success rate",
+            "axisLabel": "Success rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1274,6 +1274,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 33,
+  "version": 35,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -122,7 +122,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Connection rate / min",
+            "axisLabel": "Connection rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -217,7 +217,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of collections / min",
+            "axisLabel": "Number of collections",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -454,7 +454,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks / min",
+            "axisLabel": "Number of checks",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -525,7 +525,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_port_checks_total{deployment=~\"$experiment.*\"}[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_port_checks_total{workload=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -549,7 +549,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks / min",
+            "axisLabel": "Number of checks",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -620,7 +620,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{deployment=~\"$experiment.*\"}[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{workload=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -644,7 +644,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of requests / min",
+            "axisLabel": "Number of requests",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -715,7 +715,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total{deployment=~\"$experiment.*\"}[10m])/10)",
+          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total{workload=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -816,7 +816,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{deployment=~\"$experiment.*\"}[5m]))",
+          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{workload=~\"$experiment.*\"}[5m]))",
           "format": "heatmap",
           "interval": "5m",
           "legendFormat": "{{le}}",
@@ -881,7 +881,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request rate / min",
+            "axisLabel": "Request rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -980,7 +980,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Failure rate / min",
+            "axisLabel": "Failure rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1105,7 +1105,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Success rate / min",
+            "axisLabel": "Success rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1274,6 +1274,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 35,
+  "version": 33,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -405,7 +405,7 @@
         "type": "prometheus",
         "uid": "${platformdatasource}"
       },
-      "description": "Increase in Requests to the Kubernetes API Server grouped by status.",
+      "description": "Increase in requests to the Kubernetes API Server grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -95,10 +95,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(locate_current_heartbeat_connections)",
+          "expr": "sum(locate_current_heartbeat_connections{experiment=~\"$experiment\"})",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -523,7 +525,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_port_checks_total{deployment=~\"$deployment\"}[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_port_checks_total{deployment=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -618,7 +620,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{deployment=~\"$deployment\"}[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{deployment=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -713,7 +715,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total{deployment=~\"$deployment\"}[10m])/10)",
+          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total{deployment=~\"$experiment.*\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -814,7 +816,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{deployment=~\"$deployment\"}[5m]))",
+          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{deployment=~\"$experiment.*\"}[5m]))",
           "format": "heatmap",
           "interval": "5m",
           "legendFormat": "{{le}}",
@@ -1231,29 +1233,29 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "ndt",
-            "ndt-virtual"
+            "msak",
+            "ndt"
           ],
           "value": [
-            "ndt",
-            "ndt-virtual"
+            "msak",
+            "ndt"
           ]
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${platformdatasource}"
+          "uid": "${datasource}"
         },
-        "definition": "label_values(heartbeat_port_checks_total, deployment)",
+        "definition": "label_values(locate_current_heartbeat_connections, experiment)",
         "hide": 0,
         "includeAll": false,
-        "label": "Deployment",
+        "label": "Experiment",
         "multi": true,
-        "name": "deployment",
+        "name": "experiment",
         "options": [],
         "query": {
-          "query": "label_values(heartbeat_port_checks_total, deployment)",
+          "query": "label_values(locate_current_heartbeat_connections, experiment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -523,7 +523,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_port_checks_total[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_port_checks_total{deployment=~\"$deployment\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -618,7 +618,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{}[10m])/10)",
+          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{deployment=~\"$deployment\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -713,7 +713,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total[10m])/10)",
+          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total{deployment=~\"$deployment\"}[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -812,11 +812,13 @@
             "type": "prometheus",
             "uid": "${platformdatasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{}[5m]))",
+          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{deployment=~\"$deployment\"}[5m]))",
           "format": "heatmap",
           "interval": "5m",
           "legendFormat": "{{le}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -1225,6 +1227,39 @@
         "regex": "/Platform Cluster \\(/",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "ndt-virtual",
+            "ndt"
+          ],
+          "value": [
+            "ndt-virtual",
+            "ndt"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${platformdatasource}"
+        },
+        "definition": "label_values(heartbeat_port_checks_total, deployment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": true,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(heartbeat_port_checks_total, deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -1236,6 +1271,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 29,
+  "version": 32,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -879,7 +879,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of requests",
+            "axisLabel": "Request rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -951,14 +951,16 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(locate_requests_total{type=\"nearest\"})",
+          "expr": "sum(rate(locate_requests_total{type=\"nearest\"}[10m])/10)",
           "interval": "",
           "legendFormat": "Requests",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Number of Client Requests",
+      "title": "Client Request Rate (per min)",
       "type": "timeseries"
     },
     {
@@ -1051,14 +1053,14 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "100 * (sum by (status) (locate_requests_total{type=\"nearest\", status!=\"OK\"})\n/ ignoring (status) group_left \nsum(locate_requests_total{type=\"nearest\"}))\n\n",
+          "expr": "100 * (sum by (status) (increase(locate_requests_total{type=\"nearest\", status!=\"OK\"}[10m])/10)\n/ ignoring (status) group_left \nsum(increase(locate_requests_total{type=\"nearest\"}[10m])/10))\n",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Client Request Failure Rate",
+      "title": "Client Request Failure Rate (per min)",
       "type": "timeseries"
     },
     {
@@ -1092,7 +1094,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The rate at which App Engine successfully returns the client's country (i.e., country!=\"ZZ). ",
+      "description": "The rate at which App Engine successfully returns the client's country (i.e., country != \"ZZ\"). ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1119,7 +1121,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1129,8 +1131,6 @@
             }
           },
           "mappings": [],
-          "max": 100,
-          "noValue": "100",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1148,8 +1148,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
         "y": 52
       },
@@ -1174,17 +1174,18 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "100 * (sum(locate_app_engine_total{country!=\"ZZ\"})) / sum(locate_app_engine_total)",
+          "expr": "100 * (sum(rate(locate_app_engine_total{country!=\"ZZ\"}[10m])/10) / (sum(rate(locate_app_engine_total[10m])/10)))",
           "interval": "",
           "legendFormat": "Rate",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "App Engine Country Success Rate",
+      "title": "App Engine Country Success Rate (per min)",
       "type": "timeseries"
     }
   ],
+  "refresh": "5s",
   "schemaVersion": 37,
   "style": "dark",
   "tags": [],
@@ -1230,14 +1231,14 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
-            "ndt-virtual",
-            "ndt"
+            "ndt",
+            "ndt-virtual"
           ],
           "value": [
-            "ndt-virtual",
-            "ndt"
+            "ndt",
+            "ndt-virtual"
           ]
         },
         "datasource": {
@@ -1271,6 +1272,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 32,
+  "version": 33,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -122,7 +122,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Connection rate",
+            "axisLabel": "Connection rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -217,7 +217,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of collections",
+            "axisLabel": "Number of collections / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -454,7 +454,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks",
+            "axisLabel": "Number of checks / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -549,7 +549,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of checks",
+            "axisLabel": "Number of checks / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -644,7 +644,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of requests",
+            "axisLabel": "Number of requests / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -881,7 +881,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Request rate",
+            "axisLabel": "Request rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -980,7 +980,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Failure rate",
+            "axisLabel": "Failure rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1105,7 +1105,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Success rate",
+            "axisLabel": "Success rate / min",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1274,6 +1274,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 33,
+  "version": 37,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -110,7 +110,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The 5 min rate of Heartbeat connection requests.",
+      "description": "The 1 min rate of Heartbeat connection requests.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -120,7 +120,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Connection rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -191,14 +191,14 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(locate_requests_total{type=\"heartbeat\"}[5m]))",
+          "expr": "sum(rate(locate_requests_total{type=\"heartbeat\"}[10m])/10)",
           "interval": "",
           "legendFormat": "Rate",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Heartbeat Connection Request Rate (5 min)",
+      "title": "Heartbeat Connection Request Rate (per min)",
       "type": "timeseries"
     },
     {
@@ -206,7 +206,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Increase in Prometheus health collections grouped by code.",
+      "description": "One minute Increase in Prometheus health collections grouped by code.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -215,7 +215,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Number of collections",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -293,7 +293,7 @@
           "refId": "A"
         }
       ],
-      "title": "Prometheus Health Collections",
+      "title": "Prometheus Health Collections (per min)",
       "type": "timeseries"
     },
     {
@@ -372,6 +372,7 @@
           "yHistogram": true
         },
         "yAxis": {
+          "axisLabel": "Seconds",
           "axisPlacement": "left",
           "reverse": false,
           "unit": "short"
@@ -387,7 +388,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(le) (increase(prometheus_health_collection_duration_bucket{}[5m]))",
+          "expr": "sum by(le) (increase(prometheus_health_collection_duration_bucket[5m]))",
           "format": "heatmap",
           "interval": "5m",
           "legendFormat": "{{le}}",
@@ -442,7 +443,7 @@
         "type": "prometheus",
         "uid": "${platformdatasource}"
       },
-      "description": "Increase in number of port checks grouped by status.",
+      "description": "One minute increase in number of port checks grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -451,7 +452,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Number of checks",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -529,7 +530,7 @@
           "refId": "A"
         }
       ],
-      "title": "Port Checks",
+      "title": "Port Checks (per min)",
       "type": "timeseries"
     },
     {
@@ -537,7 +538,7 @@
         "type": "prometheus",
         "uid": "${platformdatasource}"
       },
-      "description": "Increase in number of health checks grouped by status.",
+      "description": "One minute increase in number of health checks grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -546,7 +547,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Number of checks",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -624,7 +625,7 @@
           "refId": "A"
         }
       ],
-      "title": "Health Checks",
+      "title": "Health Checks (per min)",
       "type": "timeseries"
     },
     {
@@ -632,7 +633,7 @@
         "type": "prometheus",
         "uid": "${platformdatasource}"
       },
-      "description": "Increase in requests to the Kubernetes API Server grouped by status.",
+      "description": "One minute increase in requests to the Kubernetes API Server grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -641,7 +642,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Number of requests",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -719,7 +720,7 @@
           "refId": "A"
         }
       ],
-      "title": "Kubernetes Requests",
+      "title": "Kubernetes Requests (per min)",
       "type": "timeseries"
     },
     {
@@ -797,6 +798,7 @@
           "yHistogram": true
         },
         "yAxis": {
+          "axisLabel": "Seconds",
           "axisPlacement": "left",
           "reverse": false,
           "unit": "short"
@@ -875,7 +877,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Number of requests",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -962,20 +964,21 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The hourly rate at which client requests returned status != \"OK\".",
+      "description": "The rate at which client requests returned status != \"OK\".",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-RdYlGr",
+            "seriesBy": "last"
           },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Failure rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -983,7 +986,7 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 4,
             "scaleDistribution": {
               "type": "linear"
@@ -999,7 +1002,8 @@
             }
           },
           "mappings": [],
-          "max": 1,
+          "max": 100,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1043,14 +1047,16 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "(sum by (status) (rate(locate_requests_total{type=\"nearest\", status!=\"OK\"}[1h]))\n/ ignoring (status) group_left \nsum(rate(locate_requests_total{type=\"nearest\"}[1h])))",
+          "expr": "100 * (sum by (status) (locate_requests_total{type=\"nearest\", status!=\"OK\"})\n/ ignoring (status) group_left \nsum(locate_requests_total{type=\"nearest\"}))\n\n",
           "interval": "",
           "legendFormat": "{{status}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Client Request Failure Rate (Hourly)",
+      "title": "Client Request Failure Rate",
       "type": "timeseries"
     },
     {
@@ -1084,7 +1090,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The hourly rate at which App Engine successfully returns the client's country.",
+      "description": "The rate at which App Engine successfully returns the client's country (i.e., country!=\"ZZ). ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1093,7 +1099,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "Success rate",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1121,6 +1127,8 @@
             }
           },
           "mappings": [],
+          "max": 100,
+          "noValue": "100",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1162,14 +1170,16 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "(sum(rate(locate_app_engine_total{country!=\"\"}[1h])) /\nsum(rate(locate_app_engine_total[1h])))",
+          "expr": "100 * (sum(locate_app_engine_total{country!=\"ZZ\"})) / sum(locate_app_engine_total)",
           "interval": "",
           "legendFormat": "Rate",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "App Engine Country Success Rate (Hourly)",
+      "title": "App Engine Country Success Rate",
       "type": "timeseries"
     }
   ],

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -405,7 +405,7 @@
         "type": "prometheus",
         "uid": "${platformdatasource}"
       },
-      "description": "Increase in requests to the Kubernetes API Server grouped by status.",
+      "description": "Increase in Requests to the Kubernetes API Server grouped by status.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -777,7 +777,6 @@
         },
         "yAxis": {
           "axisPlacement": "left",
-          "decimals": 1,
           "reverse": false,
           "unit": "short"
         }
@@ -1162,7 +1161,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus (mlab-sandbox)",
           "value": "Prometheus (mlab-sandbox)"
         },
@@ -1181,7 +1180,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Platform Cluster (mlab-sandbox)",
           "value": "Platform Cluster (mlab-sandbox)"
         },

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -29,28 +29,15 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "xIXR1_LMz"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 14,
+      "id": 29,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "xIXR1_LMz"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Health",
+      "title": "Health Signals from Locate Service",
       "type": "row"
     },
     {
@@ -83,8 +70,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 9,
+        "h": 9,
+        "w": 12,
         "x": 0,
         "y": 1
       },
@@ -178,9 +165,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 9,
+        "h": 9,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
       "id": 18,
@@ -202,295 +189,16 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "sum(rate(locate_requests_total{type=\"heartbeat\"}[5m]))",
           "interval": "",
           "legendFormat": "Rate",
-          "refId": "A"
-        }
-      ],
-      "title": "Heartbeat Connection Request Rate (5 min)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Increase in number of port checks grouped by status.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 9
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_port_checks_total[10m]))",
-          "interval": "",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Port Checks",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Increase in number of health checks grouped by status.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 9,
-        "y": 9
-      },
-      "id": 27,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total[10m]))",
-          "interval": "",
-          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Health Checks",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Increase in requests to the Kubernetes API Server grouped by status.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 17
-      },
-      "id": 22,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total[10m]))",
-          "interval": "",
-          "legendFormat": "{{status}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Kubernetes Requests",
+      "title": "Heartbeat Connection Request Rate (5 min)",
       "type": "timeseries"
     },
     {
@@ -552,10 +260,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 9,
-        "y": 17
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 10
       },
       "id": 26,
       "options": {
@@ -578,7 +286,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (code) (increase(prometheus_health_collection_duration_count[10m]))",
+          "expr": "sum by (code) (increase(prometheus_health_collection_duration_count[10m])/10)",
           "interval": "",
           "legendFormat": "{{status}}",
           "range": true,
@@ -587,118 +295,6 @@
       ],
       "title": "Prometheus Health Collections",
       "type": "timeseries"
-    },
-    {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${platformdatasource}"
-      },
-      "description": "Kubernetes API server request duration in seconds.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 0,
-        "y": 25
-      },
-      "heatmap": {},
-      "hideZeroBuckets": true,
-      "highlightCards": true,
-      "id": 20,
-      "legend": {
-        "show": true
-      },
-      "options": {
-        "calculate": false,
-        "calculation": {},
-        "cellGap": 2,
-        "cellValues": {},
-        "color": {
-          "exponent": 0.5,
-          "fill": "#b4ff00",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Oranges",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "showValue": "never",
-        "tooltip": {
-          "show": true,
-          "yHistogram": true
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "short"
-        }
-      },
-      "pluginVersion": "9.1.5",
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${platformdatasource}"
-          },
-          "exemplar": true,
-          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{}[5m]))",
-          "format": "heatmap",
-          "interval": "5m",
-          "legendFormat": "{{le}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Kubernetes API Server Request Time",
-      "tooltip": {
-        "show": true,
-        "showHistogram": true
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "short",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
     },
     {
       "cards": {},
@@ -731,10 +327,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 9,
-        "x": 9,
-        "y": 25
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 10
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -825,7 +421,430 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 20
+      },
+      "id": 14,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Health Signals from Heartbeat Service",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in number of port checks grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(status)(increase(heartbeat_port_checks_total[10m])/10)",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Port Checks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in number of health checks grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(status)(increase(heartbeat_health_endpoint_checks_total{}[10m])/10)",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Checks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Increase in requests to the Kubernetes API Server grouped by status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (status) (increase(heartbeat_kubernetes_requests_total[10m])/10)",
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes Requests",
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${platformdatasource}"
+      },
+      "description": "Kubernetes API server request duration in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 20,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${platformdatasource}"
+          },
+          "exemplar": true,
+          "expr": "sum by(le) (increase(heartbeat_kubernetes_request_time_histogram_bucket{}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kubernetes API Server Request Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
       },
       "id": 12,
       "panels": [],
@@ -904,10 +923,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 9,
+        "h": 10,
+        "w": 12,
         "x": 0,
-        "y": 34
+        "y": 41
       },
       "id": 2,
       "options": {
@@ -999,10 +1018,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 9,
-        "x": 9,
-        "y": 34
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 41
       },
       "id": 4,
       "options": {
@@ -1044,7 +1063,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 16,
       "panels": [],
@@ -1119,10 +1138,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 9,
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 44
+        "y": 52
       },
       "id": 6,
       "options": {
@@ -1207,6 +1226,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 25,
+  "version": 29,
   "weekStart": ""
 }


### PR DESCRIPTION
https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service

This PR adds 3 new panels to the dashboard. One for /health checks (Health Checks) and two for Prometheus health collections (Prometheus Health Collections and Prometheus Health Collection Request Time). 

It also moves the "Health" row to the top.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/959)
<!-- Reviewable:end -->
