### PR TITLE
Use LEFT JOIN to include NULL values

### DIFF
--- a/config/federation/bigquery/bq_annotation.sql
+++ b/config/federation/bigquery/bq_annotation.sql
@@ -11,19 +11,19 @@
 
 WITH recent_ndt_tcpinfo AS (
   SELECT "ndt/tcpinfo" AS datatype, client.Geo.Latitude, client.Geo.Longitude, systems.ASNs AS asn
-  FROM `measurement-lab.ndt.tcpinfo`, UNNEST(client.Network.Systems) AS systems
+  FROM `measurement-lab.ndt.tcpinfo` LEFT JOIN UNNEST(client.Network.Systems) AS systems
   WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), recent_ndt_ndt7 AS (
   SELECT "ndt/ndt7" AS datatype, client.Geo.Latitude, client.Geo.Longitude, systems.ASNs AS asn
-  FROM   `measurement-lab.ndt.ndt7`, UNNEST(client.Network.Systems) AS systems
+  FROM   `measurement-lab.ndt.ndt7` LEFT JOIN UNNEST(client.Network.Systems) AS systems
   WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), recent_ndt_ndt5 AS (
   SELECT "ndt/ndt5" AS datatype, client.Geo.Latitude, client.Geo.Longitude, systems.ASNs AS asn
-  FROM   `measurement-lab.ndt.ndt5`, UNNEST(client.Network.Systems) AS systems
+  FROM   `measurement-lab.ndt.ndt5` LEFT JOIN UNNEST(client.Network.Systems) AS systems
   WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 ), recent_ndt_scamper1 AS (
   SELECT "ndt/scamper1" AS datatype, client.Geo.Latitude, client.Geo.Longitude, systems.ASNs AS asn
-  FROM   `measurement-lab.ndt.scamper1`, UNNEST(client.Network.Systems) AS systems
+  FROM   `measurement-lab.ndt.scamper1` LEFT JOIN UNNEST(client.Network.Systems) AS systems
   WHERE date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 )
 


### PR DESCRIPTION
This change is an update in response to the ["unsafe UUIDs" incident][1] 2022-11-30. Between 2022-11-08 and 2022-11-30 the NDT server was started without the `-uuid-prefix-file` flag which resulted in UUIDs with the "unsafe" string while other sidecar data (e.g. annotation) used the correct UUID. This mismatch results in the two datatypes failing to join.

The `bq_annotation.sql` query and corresponding [alert][2] should have discovered this case but failed due to the exclusion of all rows with "null" annotations, which caused the "total" count to only match the rows with non-null annotations (which defeats the purpose of this metric).

This change corrects the queries to count the true "total" rows so that the alert denominator is correct.

[1]: https://docs.google.com/document/d/1-epJWfGtmNevb07sqjjk9lEh9V2qm3xlI8jG85EZ1Wo/edit#
[2]: https://github.com/m-lab/prometheus-support/blob/main/config/federation/prometheus/alerts.yml#L928 

This approach can be verified using the following modified form of the alert query, which groups by date for ndt7 only.

```
WITH  recent_ndt_ndt7 AS (
  SELECT date, "ndt/ndt7" AS datatype, client.Geo.Latitude, client.Geo.Longitude, systems.ASNs AS asn
  FROM   `measurement-lab.ndt.ndt7` LEFT JOIN UNNEST(client.Network.Systems) AS systems
  WHERE date BETWEEN "2022-11-01" AND "2022-11-30"
)

SELECT
  date,
  COUNTIF(Latitude IS NOT NULL AND Longitude IS NOT NULL) AS value_geo_success,
  COUNTIF(asn IS NOT NULL AND ARRAY_LENGTH(asn) != 0) AS value_asn_success,
  COUNT(*) AS value_total,
  datatype

FROM (
   SELECT * FROM recent_ndt_ndt7
)
GROUP BY
  date, datatype

ORDER BY
  date
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/961)
<!-- Reviewable:end -->
