### PR TITLE
Lower alert threshold for network annotations

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -906,11 +906,15 @@ groups:
         triggering archive.
 
 # NDT_AsnAnnotationRatioTooLowOrMissing fires when the client annotations on NDT
-# tests appear to have too many failures or the bq_ndt_annotation_* metrics
+# tests appear to have too many failures or the bq_annotation_* metrics
 # disappear.
+# NOTE: the threshold is significantly lower than the geo annotations because in
+# practice we typically observe about 89-90% success rate, due to ~10% of
+# lookups affirmatively not being found in the routeview dataset, i.e.
+# `client.Network.Missing=True`.
   - alert: DataPipeline_AsnAnnotationRatioTooLowOrMissing
     expr: |
-      bq_annotation_asn_success / bq_annotation_total < 0.98
+      bq_annotation_asn_success / bq_annotation_total < 0.88
         or absent(bq_annotation_asn_success / bq_annotation_total)
     for: 3h
     labels:


### PR DESCRIPTION
This change lowers the threshold for successful network annotations based on observation of actual annotation success rates. The lower threshold in practice was previously missed due to https://github.com/m-lab/prometheus-support/pull/961

This change will prevent alerts firing for expected conditions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/962)
<!-- Reviewable:end -->
