### PR TITLE
Increase Prometheus request timeout

### DIFF
--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,8 +13,7 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: true
-  timeout: 180
+  editable: false
 
   jsonData:
     timeout: 180

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,8 +13,8 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: true
+  editable: false
 
   jsonData:
-    timeout: 180
+    timeout: 60
     timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,8 +13,7 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: false
-  timeout: 300s
+  editable: true
 
   jsonData:
     timeout: 300s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,8 +13,8 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: true
+  editable: false
 
   jsonData:
     timeout: 300s
-    timeInterval: 60s
+    timeInterval: 30s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -16,4 +16,5 @@ datasources:
   editable: false
 
   jsonData:
+    timeout: 300s
     timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,8 +13,8 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: false
+  editable: true
+  timeout: 300s
 
   jsonData:
-    timeout: 300s
     timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -16,5 +16,4 @@ datasources:
   editable: false
 
   jsonData:
-    timeout: 300s
     timeInterval: 30s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -16,4 +16,5 @@ datasources:
   editable: false
 
   jsonData:
-    timeInterval: 30s
+    timeout: 300s
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -14,7 +14,8 @@ datasources:
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: true
-  timeout: 300s
+  timeout: 180
 
   jsonData:
+    timeout: 180
     timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -14,6 +14,7 @@ datasources:
   isDefault: {{IS_DEFAULT}}
   version: 1
   editable: false
+  timeout: 300s
 
   jsonData:
     timeout: 300s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-oti.yml.template
@@ -13,7 +13,7 @@ datasources:
     basicAuthPassword: {{PROM_AUTH_PASS}}
   isDefault: {{IS_DEFAULT}}
   version: 1
-  editable: false
+  editable: true
 
   jsonData:
     timeout: 180

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-sandbox.yml.template
@@ -16,4 +16,5 @@ datasources:
   editable: false
 
   jsonData:
+    timeout: 60
     timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/prometheus-federation_mlab-staging.yml.template
@@ -16,4 +16,5 @@ datasources:
   editable: false
 
   jsonData:
+    timeout: 60
     timeInterval: 60s


### PR DESCRIPTION
Add a 60s timeout for requests to Prometheus datasources.

Not sure what the default was, but it was causing one of the mlab-ns queries in the Locate Service dashboard to time out with this message:

![Screenshot 2022-12-21 4 53 27 PM](https://user-images.githubusercontent.com/21001496/209009186-277e80a6-38e5-48cb-ab61-f4fd71623435.png)

[Example](https://grafana.mlab-oti.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m) of the above.

Data source documentation can be found [here](https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/964)
<!-- Reviewable:end -->
