### PR TITLE
Removes the flag --monitoring.metrics-interval

### DIFF
--- a/k8s/prometheus-federation/deployments/stackdriver.yml
+++ b/k8s/prometheus-federation/deployments/stackdriver.yml
@@ -31,8 +31,6 @@ spec:
         args: [
           # Metrics are available with some delay, so look 5 minutes in the past.
           "--monitoring.metrics-offset=5m",
-          # Prometheus scrapes every minute, so look at a 1 minute window.
-          "--monitoring.metrics-interval=1m",
           "--google.project-id={{GCLOUD_PROJECT}}",
           # Metrics are gauges, representing counts over the sampled interval.
           "--monitoring.metrics-type-prefixes=logging.googleapis.com/user",


### PR DESCRIPTION
For some reason, with metrics-interval=1m, stackdriver_exporter was not ingesting any metrics for container logs. The default for this flag is 5m, and removing the flag resolved the issue of alerts firing in staging about container logs missing in Stackdriver for a bunch of nodes.

This behavior of stackdriver_exporter has apparently impacted others. And based on what some have said in [one particular issue](https://github.com/prometheus-community/stackdriver_exporter/issues/26#issuecomment-407110782), setting the flag to a higher value shouldn't impact the results:

> You should be able to set the interval to something like 6 hours and it won't break the other services because it only uses the latest metrics, so you'll just be pulling more data than necessary but it shouldn't break the metrics (as far as I know). I'd try that and see, you'll just need to note somewhere that the bigquery ones are from 6 hours ago and they're not current, though they'll look like their current from Prometheus's point of view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/965)
<!-- Reviewable:end -->
