### PR TITLE
Update build of alertmanager-github-receiver

### DIFF
--- a/k8s/prometheus-federation/deployments/github-receiver.yml
+++ b/k8s/prometheus-federation/deployments/github-receiver.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: github-receiver
-        image: measurementlab/alertmanager-github-receiver:v0.10
+        image: measurementlab/alertmanager-github-receiver:v0.11
         env:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:


### PR DESCRIPTION
This change updates the alertmanager-github-receiver to the latest version, the last update was from June 2020.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/966)
<!-- Reviewable:end -->
