### PR TITLE
Add an alert for Locate V2 request errors

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -37,6 +37,19 @@ groups:
       description: '{{ $labels.instance }} of job {{ $labels.job }} has been down
         for more than 10 minutes.'
 
+# TooManyProcessRestarts: a process has restarted more than twice in the last hour.
+  - alert: TooManyProcessRestarts
+    expr: resets(process_cpu_seconds_total[1h]) > 2
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: Instance {{ $labels.instance }} has restarted more than twice in the
+        last hour.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#toomanyprocessrestarts
+
 ##
 ## SLOs
 ##

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -568,19 +568,19 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#mlabns_serverresponsemetricmissing
 
 # The alert Locate_TooManyErrors will fire when the rate of /nearest requests to the
-# Locate V2 is greater than 1% for 2 minutes. The locate_requests_total metrics come
+# Locate V2 is greater than 0.1% for 2 minutes. The locate_requests_total metrics come
 # from Prometheus.
   - alert: Locate_TooManyErrors
     expr: |
-      (sum (locate_requests_total{type="nearest", status!="OK"}) /
-      sum(locate_requests_total{type="nearest"})) > 0.01
+      (sum(rate(locate_requests_total{type="nearest", status!="OK"}[10m])/10) /
+      sum(rate(locate_requests_total{type="nearest"}[10m])/10)) > 0.001
     for: 2m
     labels:
       repo: dev-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: The rate of Locate V2 nearest request errors is greater than 1%.
+      summary: The rate of Locate V2 nearest request errors is greater than 0.1%.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#locate_toomanyerrors
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m&var-datasource=Prometheus%20%28mlab-oti%29&var-platformdatasource=Platform%20Cluster%20%28mlab-oti%29&var-bigquerydatasource=BigQuery%20%28mlab-oti%29&var-metro=All&var-experiment=ndt&viewPanel=4
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -37,16 +37,16 @@ groups:
       description: '{{ $labels.instance }} of job {{ $labels.job }} has been down
         for more than 10 minutes.'
 
-# TooManyProcessRestarts: a process has restarted more than twice in the last hour.
+# TooManyProcessRestarts: a process has restarted more than five times in the last hour.
   - alert: TooManyProcessRestarts
-    expr: resets(process_cpu_seconds_total[1h]) > 2
+    expr: resets(process_cpu_seconds_total[1h]) > 5
     for: 10m
     labels:
       repo: dev-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: Instance {{ $labels.instance }} has restarted more than twice in the
+      summary: Instance {{ $labels.instance }} has restarted more than five times in the
         last hour.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#toomanyprocessrestarts
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -567,6 +567,23 @@ groups:
       summary: A critical metric about mlab-ns is missing.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#mlabns_serverresponsemetricmissing
 
+# The alert Locate_TooManyErrors will fire when the rate of /nearest requests to the
+# Locate V2 is greater than 1% for 2 minutes. The locate_requests_total metrics come
+# from Prometheus.
+  - alert: Locate_TooManyErrors
+    expr: |
+      (sum (locate_requests_total{type="nearest", status!="OK"}) /
+      sum(locate_requests_total{type="nearest"})) > 0.01
+    for: 2m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: The rate of Locate V2 nearest request errors is greater than 1%.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#locate_toomanyerrors
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m&var-datasource=Prometheus%20%28mlab-oti%29&var-platformdatasource=Platform%20Cluster%20%28mlab-oti%29&var-bigquerydatasource=BigQuery%20%28mlab-oti%29&var-metro=All&var-experiment=ndt&viewPanel=4
+
 # If container logs for a node are missing in Stackdriver for too long, then
 # fire an alert, unless the node is in maintenance or lame-duck mode. This
 # somewhat awkward query discovers cases where the stackdriver metric has been

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -572,8 +572,8 @@ groups:
 # from Prometheus.
   - alert: Locate_TooManyErrors
     expr: |
-      (sum(rate(locate_requests_total{type="nearest", status!="OK"}[10m])/10) /
-      sum(rate(locate_requests_total{type="nearest"}[10m])/10)) > 0.001
+      (sum(rate(locate_requests_total{type="nearest", status!="OK"}[2m]))) /
+      sum(rate(locate_requests_total{type="nearest"}[2m])) > 0.001
     for: 2m
     labels:
       repo: dev-tracker


### PR DESCRIPTION
This PR adds a new alert for the rate of Locate V2 request errors.
A description for the alert has also been added under https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#locate_toomanyerrors.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/968)
<!-- Reviewable:end -->
