### PR TITLE
Replace wehe client with curl in script-exporter config

### DIFF
--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -11,6 +11,5 @@ scripts:
   - name: 'wehe_client'
     script: >
       EXPERIMENT=wehe cache_exit_code.sh 600
-      monitoring-token -machine=${TARGET} -service=wehe/replay --
-      wehe-client.sh -n applemusic -t wehe-cmdline/res/ -c
+      curl http://${TARGET}/WHATISMYIPMAN
     timeout: 50


### PR DESCRIPTION
This PR implements a workaround for the script-exporter pods' memory exhaustion issue we have noticed in staging. It's possible for the wehe-cmdline client to take > 1 minute to fully complete a test now.

This changes the script to a much simpler `curl`, which will have exit code zero when the server is reachable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/969)
<!-- Reviewable:end -->
