### PR TITLE
Fix wehe URL in script-monitoring config

### DIFF
--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -11,5 +11,5 @@ scripts:
   - name: 'wehe_client'
     script: >
       EXPERIMENT=wehe cache_exit_code.sh 600
-      curl http://${TARGET}/WHATISMYIPMAN
+      curl http://wehe-${TARGET}/WHATISMYIPMAN
     timeout: 50

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -11,6 +11,5 @@ scripts:
   - name: 'wehe_client'
     script: >
       EXPERIMENT=wehe cache_exit_code.sh 600
-      monitoring-token -machine=${TARGET} -service=wehe/replay --
-      wehe-client.sh -n applemusic -t wehe-cmdline/res/ -c
+      curl http://${TARGET}/WHATISMYIPMAN
     timeout: 50


### PR DESCRIPTION
This required `wehe-` to work as intended.

https://prometheus.mlab-sandbox.measurementlab.net/graph?g0.expr=script_success%7Bservice%3D%22wehe_client%22%7D%20%3D%3D%201&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/970)
<!-- Reviewable:end -->
