### PR TITLE
Revert wehe e2e test

### DIFF
--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -11,5 +11,6 @@ scripts:
   - name: 'wehe_client'
     script: >
       EXPERIMENT=wehe cache_exit_code.sh 600
-      curl http://wehe-${TARGET}/WHATISMYIPMAN
+      monitoring-token -machine=${TARGET} -service=wehe/replay --
+      wehe-client.sh -n applemusic -t wehe-cmdline/res/ -c
     timeout: 50


### PR DESCRIPTION
After the v0.2.6 update to wehe that reduced the traceroute timeouts, the script-exporter RAM usage appears back to workable levels.

This change reverts the script exporter configuration change to continue running the e2e test, to match configurations in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/971)
<!-- Reviewable:end -->
