### PR TITLE
Adds OOM alerts and new OOM panel on SRE Overview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 76,
+  "id": 266,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -627,9 +627,10 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "",
+      "description": "1m rate of OOM log messages for a node",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -680,17 +681,19 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (log, priority) (stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_kernel_logs{priority=~\"[0-3]\"})",
+          "editorMode": "code",
+          "expr": "rate(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) * 60",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{log}}",
+          "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Kernel logs priority <=3",
+      "title": "OOM Events",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1181,7 +1184,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Prometheus (mlab-oti)",
           "value": "Prometheus (mlab-oti)"
         },
@@ -1200,7 +1203,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -1211,6 +1214,7 @@
         "name": "cluster",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "/Cluster/",
         "skipUrlSync": false,
@@ -1250,6 +1254,6 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 17,
+  "version": 49,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
+++ b/config/federation/grafana/dashboards/Ops_Tactical_SRE_Overview.json
@@ -622,105 +622,137 @@
       "type": "table-old"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "1m rate of OOM log messages for a node",
+      "description": "",
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "node_id"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Node"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Node"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 345
+              }
+            ]
+          }
+        ]
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 12,
         "y": 9
       },
-      "hiddenSeries": false,
       "id": 18,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": false,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
       },
-      "percentage": false,
       "pluginVersion": "9.1.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "datasource": {
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "rate(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) * 60",
-          "format": "time_series",
+          "exemplar": false,
+          "expr": "sum_over_time(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[$__range])",
+          "format": "table",
+          "instant": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{log}}",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "OOM Events",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
+      "transformations": [
         {
-          "format": "short",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "cluster": true,
+              "container": true,
+              "deployment": true,
+              "exported_namespace": true,
+              "instance": true,
+              "job": true,
+              "location": true,
+              "log": true,
+              "namespace": true,
+              "node": true,
+              "node_id": false,
+              "nodepool": true,
+              "pod": true,
+              "pod_template_hash": true,
+              "project_id": true,
+              "ready": true,
+              "run": true,
+              "unit": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
         }
       ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "table"
     },
     {
       "columns": [],
@@ -1203,7 +1235,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -1254,6 +1286,6 @@
   "timezone": "",
   "title": "Ops: Tactical & SRE Overview",
   "uid": "_fugwnWZk",
-  "version": 49,
+  "version": 50,
   "weekStart": ""
 }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1141,11 +1141,11 @@ groups:
         the kubelet logs (journalctl -u kubelet).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  # Fire an alert if the count of OOM log entries is greater than 1 over 2m.
-  # This should never really happen unless there is a serious resource issue,
-  # likely caused by a traffic spike to the machine.
+  # Fire an alert if the sum of OOM log entries over 5m is greater than 1 over
+  # 2m.  This should never really happen unless there is a serious resource
+  # issue, likely caused by a traffic spike to the machine.
   - alert: PlatformCluster_TooManyOOMEvents
-    expr: stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom > 1
+    expr: sum_over_time(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) > 1
     for: 2m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1141,9 +1141,10 @@ groups:
         the kubelet logs (journalctl -u kubelet).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  # Fire an alert if the sum of OOM log entries over 5m is greater than 1 over
-  # 2m.  This should never really happen unless there is a serious resource
-  # issue, likely caused by a traffic spike to the machine.
+  # Fire an alert if the sum of OOM log entries over a period of time is
+  # greater than a certain number. This should never really happen unless there
+  # is a serious resource issue, likely caused by a traffic spike to the
+  # machine.
   - alert: PlatformCluster_TooManyOOMEvents
     expr: sum_over_time(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) > 1
     for: 2m
@@ -1152,7 +1153,7 @@ groups:
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: A node has experienced too many OOM events (more than 0)
+      summary: A node has experienced too many OOM events
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanyoomevents
       dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1141,18 +1141,18 @@ groups:
         the kubelet logs (journalctl -u kubelet).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
-  # Fire an alert if the 1m rate of OOM log messages exceeds 1. OOM events
-  # should never really happen unless there is a serious resource issue, likely
-  # caused by a traffic spike to the machine.
+  # Fire an alert if the count of OOM log entries is greater than 1 over 2m.
+  # This should never really happen unless there is a serious resource issue,
+  # likely caused by a traffic spike to the machine.
   - alert: PlatformCluster_TooManyOOMEvents
-    expr: (rate(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) * 60) > 1
-    for: 1m
+    expr: stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom > 1
+    for: 2m
     labels:
       repo: ops-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: A node has experienced too many OOM events.
+      summary: A node has experienced too many OOM events (more than 0)
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanyoomevents
       dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1141,6 +1141,21 @@ groups:
         the kubelet logs (journalctl -u kubelet).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
 
+  # Fire an alert if the 1m rate of OOM log messages exceeds 1. OOM events
+  # should never really happen unless there is a serious resource issue, likely
+  # caused by a traffic spike to the machine.
+  - alert: PlatformCluster_TooManyOOMEvents
+    expr: (rate(stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom[5m]) * 60) > 1
+    for: 1m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: A node has experienced too many OOM events.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanyoomevents
+      dashboard: https://grafana.mlab-sandbox.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
+
 # BMC alerts
 # The Reboot API performs an E2E connection test on a BMC every time its
 # /v1/e2e endpoint is scraped, and reports failure via this metric.


### PR DESCRIPTION
This new alert and dashboard panel are based on a new [log-based metric in each project](https://console.cloud.google.com/logs/metrics?project=mlab-sandbox), named "platform_cluster_oom". The Logging query for the log-based metric is:

```
resource.type="generic_node"
resource.labels.location="<project>"
jsonPayload.message:"Out of memory"
```

Log-based metrics are 1m samples that reflect the delta from the previous sample. For this reason, the new resources do not do any sort of aggregation or rate calculations, but instead just use the raw values returned by the metric (`stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_oom`).

The alert is very sensitive, as OOM events shouldn't really every happen.

The new "OOM Events" panel on the SREOverview dashboard replaces the old, rather unhelpful panel "Kernel logs priority <=3", which we have never really used and the data was ill-defined.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/972)
<!-- Reviewable:end -->
