### PR TITLE
Updates name of node pool for kube-ip

### DIFF
--- a/k8s/prometheus-federation/deployments/kubeip.yml
+++ b/k8s/prometheus-federation/deployments/kubeip.yml
@@ -32,7 +32,7 @@ spec:
             value: "prometheus-federation"
             # Nodepool to which KubeIP assigns addresses
           - name: "KUBEIP_NODEPOOL"
-            value: "static-public-ip"
+            value: "static-external-ip"
             # GCP Application Default Credentials (ADC)
             # See: https://cloud.google.com/docs/authentication/production
           - name: "GOOGLE_APPLICATION_CREDENTIALS"


### PR DESCRIPTION
We had a disk pressure issue on the static-public-ip nodes, which caused script-exporter to be evicted. It is not possible to resize the disks of an existing node pool. The only way to achieve this is to create a new node pool with the desired configurations and then migrate your workloads to this new node pool. I created a new node pool in mlab-oti named static-external-ip and migrated the workloads to this new node pool. This change configures kube-ip to be sure that those nodes get static IPv4 addresses. Meanwhile I have manually updated the kube-ip deployment in production with the change in this commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/973)
<!-- Reviewable:end -->
