### PR TITLE
Turn off debug logging for script-exporter

### DIFF
--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -37,7 +37,7 @@ spec:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:
         - name: LOGX_DEBUG
-          value: 'false'
+          value: ''
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -36,8 +36,6 @@ spec:
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:
-        - name: LOGX_DEBUG
-          value: ''
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -37,7 +37,7 @@ spec:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:
         - name: LOGX_DEBUG
-          value: 'true'
+          value: 'false'
         - name: MONITORING_SIGNER_KEY
           value: /keys/monitoring-signer-key.json
         - name: LOCATE_URL


### PR DESCRIPTION
Debug logging is only useful when you are debugging, and we are not debugging script-exporter. Furthermore, the log is appended to on every test, and eventually the logs get big and fill up the root filesystem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/974)
<!-- Reviewable:end -->
