### PR TITLE
Add visualizations for ranked server selection

### DIFF
--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -787,7 +787,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "OSuRJ_YMz"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -841,7 +841,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "OSuRJ_YMz"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(le) (increase(locate_server_distance_ranking_bucket{index=\"0\", le=~\".\"}[5m]))",
@@ -1111,8 +1111,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2171,6 +2170,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 56,
+  "version": 57,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -815,28 +815,6 @@
         "total": false,
         "values": false
       },
-      "libraryPanel": {
-        "meta": {
-          "connectedDashboards": 0,
-          "created": "2023-03-01T22:26:59Z",
-          "createdBy": {
-            "avatarUrl": "/avatar/8a3872d7a86e61570292511a809780e2",
-            "id": 59,
-            "name": "cristinaleon@google.com"
-          },
-          "folderName": "",
-          "folderUid": "",
-          "updated": "2023-03-01T22:28:55.578772459Z",
-          "updatedBy": {
-            "avatarUrl": "/avatar/8a3872d7a86e61570292511a809780e2",
-            "id": 59,
-            "name": "cristinaleon@google.com"
-          }
-        },
-        "name": "Server Ranking Histogram",
-        "uid": "tEL_5bx4k",
-        "version": 2
-      },
       "lines": false,
       "linewidth": 1,
       "links": [],
@@ -1370,8 +1348,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1465,8 +1442,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1560,8 +1536,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2196,6 +2171,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 55,
+  "version": 56,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -688,12 +688,220 @@
       "type": "barchart"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Selection Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(locate_server_distance_ranking_bucket{index=\"0\", le=~\".\"}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Server Ranking",
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 42,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Ranked Distance",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(locate_server_distance_ranking_bucket{index=\"0\", le=~\".\"}[5m])) ",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Server Ranking",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 41
       },
       "id": 29,
       "panels": [],
@@ -733,7 +941,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 42
       },
       "id": 10,
       "options": {
@@ -830,7 +1038,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 42
       },
       "id": 18,
       "options": {
@@ -925,7 +1133,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 51
       },
       "id": 26,
       "options": {
@@ -992,7 +1200,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 51
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1084,7 +1292,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 61
       },
       "id": 14,
       "panels": [],
@@ -1162,7 +1370,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 62
       },
       "id": 24,
       "options": {
@@ -1257,7 +1465,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 62
       },
       "id": 27,
       "options": {
@@ -1336,7 +1544,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1351,7 +1560,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 71
       },
       "id": 22,
       "options": {
@@ -1418,7 +1627,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 71
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1509,7 +1718,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 81
       },
       "id": 12,
       "panels": [],
@@ -1575,7 +1784,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1590,7 +1800,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 82
       },
       "id": 2,
       "options": {
@@ -1672,7 +1882,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1688,7 +1899,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 82
       },
       "id": 4,
       "options": {
@@ -1732,7 +1943,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 78
+        "y": 92
       },
       "id": 16,
       "panels": [],
@@ -1794,7 +2005,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1809,7 +2021,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 79
+        "y": 93
       },
       "id": 6,
       "options": {
@@ -1851,9 +2063,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus (mlab-sandbox)",
-          "value": "Prometheus (mlab-sandbox)"
+          "selected": true,
+          "text": "Prometheus (mlab-oti)",
+          "value": "Prometheus (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1871,8 +2083,8 @@
       {
         "current": {
           "selected": true,
-          "text": "Platform Cluster (mlab-sandbox)",
-          "value": "Platform Cluster (mlab-sandbox)"
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1890,8 +2102,8 @@
       {
         "current": {
           "selected": true,
-          "text": "BigQuery (mlab-sandbox)",
-          "value": "BigQuery (mlab-sandbox)"
+          "text": "BigQuery (mlab-oti)",
+          "value": "BigQuery (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -1939,13 +2151,9 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": [
-            "lga"
-          ],
-          "value": [
-            "lga"
-          ]
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "doitintl-bigquery-datasource",
@@ -1968,13 +2176,13 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 51,
+  "version": 54,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -777,123 +777,139 @@
           "refId": "A"
         }
       ],
-      "title": "Server Ranking",
+      "title": "Server Ranking Rate",
       "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "OSuRJ_YMz"
       },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
+          "links": []
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 14,
         "w": 12,
         "x": 12,
         "y": 27
       },
-      "heatmap": {},
-      "hideZeroBuckets": true,
-      "highlightCards": true,
-      "id": 42,
+      "hiddenSeries": false,
+      "id": 44,
       "legend": {
-        "show": true
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
       },
+      "libraryPanel": {
+        "meta": {
+          "connectedDashboards": 0,
+          "created": "2023-03-01T22:26:59Z",
+          "createdBy": {
+            "avatarUrl": "/avatar/8a3872d7a86e61570292511a809780e2",
+            "id": 59,
+            "name": "cristinaleon@google.com"
+          },
+          "folderName": "",
+          "folderUid": "",
+          "updated": "2023-03-01T22:28:55.578772459Z",
+          "updatedBy": {
+            "avatarUrl": "/avatar/8a3872d7a86e61570292511a809780e2",
+            "id": 59,
+            "name": "cristinaleon@google.com"
+          }
+        },
+        "name": "Server Ranking Histogram",
+        "uid": "tEL_5bx4k",
+        "version": 2
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
       "options": {
-        "calculate": false,
-        "calculation": {},
-        "cellGap": 2,
-        "cellValues": {},
-        "color": {
-          "exponent": 0.5,
-          "fill": "#b4ff00",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Oranges",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "showValue": "never",
-        "tooltip": {
-          "show": true,
-          "yHistogram": true
-        },
-        "yAxis": {
-          "axisLabel": "Ranked Distance",
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "short"
-        }
+        "alertThreshold": true
       },
+      "percentage": false,
       "pluginVersion": "9.1.5",
-      "reverseYBuckets": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:267",
+          "alias": "/.*/",
+          "color": "#70dbed"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "OSuRJ_YMz"
           },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum by(le) (increase(locate_server_distance_ranking_bucket{index=\"0\", le=~\".\"}[5m])) ",
+          "expr": "sum by(le) (increase(locate_server_distance_ranking_bucket{index=\"0\", le=~\".\"}[5m]))",
           "format": "heatmap",
+          "hide": false,
           "interval": "5m",
+          "intervalFactor": 1,
           "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Server Ranking",
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Server Ranking Histogram",
       "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "series",
         "show": true,
-        "showHistogram": true
+        "values": [
+          "total"
+        ]
       },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "short",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "yaxes": [
+        {
+          "$$hashKey": "object:230",
+          "format": "short",
+          "label": "Selection Count",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:231",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     },
     {
       "collapsed": false,
@@ -1784,8 +1800,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1882,8 +1897,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2005,8 +2019,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2063,7 +2076,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus (mlab-oti)",
           "value": "Prometheus (mlab-oti)"
         },
@@ -2082,7 +2095,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -2101,7 +2114,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "BigQuery (mlab-oti)",
           "value": "BigQuery (mlab-oti)"
         },
@@ -2183,6 +2196,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 54,
+  "version": 55,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a stacked area chart and a histogram showing the distribution of server selection ranking under the Rollout section.

https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/976)
<!-- Reviewable:end -->
