### PR TITLE
Rename annotation tables

### DIFF
--- a/config/federation/bigquery/bq_daily_archive.sql.template
+++ b/config/federation/bigquery/bq_daily_archive.sql.template
@@ -8,7 +8,7 @@ WHERE -- The ETL SLO for reprocessing is two days, so only count archives from t
 UNION ALL
 
 -- Determines if reprocessing is working e2e.
-SELECT "annotation" as datatype, COUNT(DISTINCT parser.ArchiveURL ) AS value_count,
-FROM `{{PROJECT}}.raw_ndt.annotation`
+SELECT "annotation2" as datatype, COUNT(DISTINCT parser.ArchiveURL ) AS value_count,
+FROM `{{PROJECT}}.raw_ndt.annotation2`
 WHERE -- The ETL SLO for reprocessing is two days, so only count archives from two days ago.
   date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)

--- a/config/federation/bigquery/bq_gardener.sql.template
+++ b/config/federation/bigquery/bq_gardener.sql.template
@@ -43,21 +43,21 @@ WITH all_types AS (
   WHERE date > date('2019-01-01')
   UNION ALL
   SELECT
-    "raw_ndt.annotation" AS datatype,
+    "raw_ndt.annotation2" AS datatype,
     id,
     date,
     parser.Time as parseTime,
   FROM
-    `{{PROJECT}}.raw_ndt.annotation`
+    `{{PROJECT}}.raw_ndt.annotation2`
   WHERE date > date('2019-01-01')
   UNION ALL
   SELECT
-    "raw_ndt.hopannotation1" AS datatype,
+    "raw_ndt.hopannotation2" AS datatype,
     id,
     date,
     parser.Time as parseTime,
   FROM
-    `{{PROJECT}}.raw_ndt.hopannotation1`
+    `{{PROJECT}}.raw_ndt.hopannotation2`
   WHERE date > date('2019-01-01')
   UNION ALL
   SELECT

--- a/config/federation/bigquery/bq_gardener_historical.sql.template
+++ b/config/federation/bigquery/bq_gardener_historical.sql.template
@@ -24,22 +24,22 @@ WITH all_types AS (
     date > date('2019-01-01')
   UNION ALL
   SELECT
-    "annotation" AS datatype,
+    "annotation2" AS datatype,
     id,
     date,
     parser.Time as parseTime,
   FROM
-    `{{PROJECT}}.raw_ndt.annotation`
+    `{{PROJECT}}.raw_ndt.annotation2`
   WHERE
     date > date('2019-01-01')
   UNION ALL
   SELECT
-    "hopannotation1" AS datatype,
+    "hopannotation2" AS datatype,
     id,
     date,
     parser.Time as parseTime,
   FROM
-    `{{PROJECT}}.raw_ndt.hopannotation1`
+    `{{PROJECT}}.raw_ndt.hopannotation2`
   WHERE
     date > date('2019-01-01')
   UNION ALL

--- a/config/federation/bigquery/bq_gardener_parse_time.sql.template
+++ b/config/federation/bigquery/bq_gardener_parse_time.sql.template
@@ -25,12 +25,12 @@ FROM (
     FROM   `{{PROJECT}}.raw_ndt.ndt7`
     WHERE date > DATE('2019-01-01') -- satisfy required date filter.
   UNION ALL
-    SELECT "ndt/annotation" AS datatype, MIN(Parser.Time) AS min_parse_time
-    FROM   `{{PROJECT}}.raw_ndt.annotation`
+    SELECT "ndt/annotation2" AS datatype, MIN(Parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.annotation2`
     WHERE date > date('2019-01-01')
   UNION ALL
-    SELECT "ndt/hopannotation1" AS datatype, MIN(Parser.Time) AS min_parse_time
-    FROM   `{{PROJECT}}.raw_ndt.hopannotation1`
+    SELECT "ndt/hopannotation2" AS datatype, MIN(Parser.Time) AS min_parse_time
+    FROM   `{{PROJECT}}.raw_ndt.hopannotation2`
     WHERE date > date('2019-01-01')
   UNION ALL
     SELECT "ndt/pcap" AS datatype, MIN(Parser.Time) AS min_parse_time


### PR DESCRIPTION
This change modifies queries to use annotation2 and hopannotation2 datatypes in preparation for processing reannotated or renamed annotation archive types. Once the data pipeline is processing these datatypes, there should be no functional changes.

This change is part of the [Correcting Network Annotations](https://docs.google.com/document/d/1Aro-2G0pGBNfR5sweUcioraik3PXdZRwphwcZzkovB0/edit) design.

This change is part of steps to repair:
* https://github.com/m-lab/data-annotations/issues/34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/978)
<!-- Reviewable:end -->
