### PR TITLE
Use experiment/dataset where available

### DIFF
--- a/config/federation/grafana/dashboards/Pipeline_Overview.json
+++ b/config/federation/grafana/dashboards/Pipeline_Overview.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": false,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,12 +18,15 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "iteration": 1659993956987,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -29,6 +35,15 @@
       },
       "id": 90,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "type": "row"
     },
@@ -38,6 +53,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$Gardener2_DS"
       },
       "description": "Dates of the most recent updates to each Job state.\n\n\"Invalid date\" appears when Gardener has been restarted recently.  Haven't figured out how to suppress that.",
@@ -76,7 +92,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -86,12 +102,17 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
+          "editorMode": "code",
           "expr": "1000*quantile_over_time(0.8, gardener_state_date{state=~\"$states2\"}[5m])",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{datatype}} {{state}}",
+          "legendFormat": "{{experiment}}/{{datatype}} {{state}}",
+          "range": true,
           "refId": "E"
         }
       ],
@@ -172,7 +193,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -182,6 +203,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$PrometheusDS"
+          },
           "expr": "bq_gardener_parse_time_age_days",
           "format": "time_series",
           "instant": true,
@@ -273,7 +297,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -287,13 +311,15 @@
             "type": "prometheus",
             "uid": "${Gardener2_DS}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "4*sum by(deployment, datatype) (increase(gardener_completed_total[6h]))",
+          "expr": "4*sum by(experiment, datatype) (increase(gardener_completed_total[6h]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Completed {{datatype}}",
+          "legendFormat": "Completed {{experiment}}/{{datatype}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -379,7 +405,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -401,6 +427,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
           "expr": "sum by (instance)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[2m])/etl_num_cpu{container=\"etl-parser\"})",
           "format": "time_series",
           "interval": "60s",
@@ -410,6 +439,9 @@
           "step": 60
         },
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
           "expr": "avg by (pod_template_hash)(rate(process_cpu_seconds_total{container=\"etl-parser\"}[10m])/etl_num_cpu)",
           "format": "time_series",
           "interval": "60s",
@@ -419,6 +451,9 @@
           "step": 60
         },
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
           "expr": "avg by (pod_template_hash)(etl_num_cpu{container=\"etl-parser\"})",
           "format": "time_series",
           "interval": "60s",
@@ -477,6 +512,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
@@ -550,11 +587,13 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -628,7 +667,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -660,6 +699,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
           "expr": "sum by(container, instance) (process_resident_memory_bytes{container=~\"etl-.*\"})",
           "format": "time_series",
           "hide": false,
@@ -670,6 +712,9 @@
           "step": 60
         },
         {
+          "datasource": {
+            "uid": "$Gardener2_DS"
+          },
           "expr": "avg by(container, pod_template_hash) (process_resident_memory_bytes{container=~\"etl-.*|stats.*\"})",
           "format": "time_series",
           "hide": false,
@@ -753,7 +798,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.4",
+      "pluginVersion": "9.1.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -785,12 +830,14 @@
             "type": "prometheus",
             "uid": "${Gardener2_DS}"
           },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "sum by(version)(increase(query_cost_seconds_sum{}[24h]))",
           "hide": false,
           "interval": "",
           "intervalFactor": 5,
           "legendFormat": "0 weeks ago {{version}}",
+          "range": true,
           "refId": "B"
         },
         {
@@ -855,6 +902,10 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -908,7 +959,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -922,6 +973,7 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum  by(version, datatype, query)(rate(query_cost_seconds_sum{datatype=~\"$datatype\"}[1h])/rate(query_cost_seconds_count{}[1h]))",
               "format": "time_series",
@@ -929,6 +981,7 @@
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Slot Time per Query {{datatype}} {{query}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -1026,7 +1079,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1040,13 +1093,15 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "sum by(datatype)(rate(gardener_bytes_sum[24h]))",
+              "expr": "sum by(experiment, datatype)(rate(gardener_bytes_sum[24h]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{datatype}}",
+              "legendFormat": "{{experiment}}/{{datatype}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -1126,7 +1181,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1165,11 +1220,13 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:536",
               "format": "percentunit",
               "logBase": 1,
               "show": true
             },
             {
+              "$$hashKey": "object:537",
               "format": "short",
               "logBase": 1,
               "show": true
@@ -1224,7 +1281,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1244,13 +1301,15 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "avg by(datatype, year) (\n    rate(gardener_bytes_sum{}[1h]) /\n    rate(gardener_files_sum{}[1h]))",
+              "expr": "avg by(experiment, datatype, year) (\n    rate(gardener_bytes_sum{}[1h]) /\n    rate(gardener_files_sum{}[1h]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{year}} {{datatype}}",
+              "legendFormat": "{{experiment}}/{{datatype}} {{year}} ",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -1333,7 +1392,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1367,13 +1426,15 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "sum by(datatype) (gardener_tasks_in_flight{state=\"parsing\"}) # sum merges across restarts",
+              "expr": "sum by(experiment, datatype) (gardener_tasks_in_flight{state=\"parsing\"}) # sum merges across restarts",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{datatype}} ",
+              "legendFormat": "{{experiment}}/{{datatype}} ",
+              "range": true,
               "refId": "E"
             }
           ],
@@ -1454,7 +1515,7 @@
             "alertThreshold": false
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1468,13 +1529,15 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum by(experiment, datatype, year)(increase(gardener_files_sum[1h]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{experiment}} - {{datatype}} - {{year}}",
+              "legendFormat": "{{experiment}}/{{datatype}} - {{year}}",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -1523,6 +1586,8 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -1579,10 +1644,12 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -1591,10 +1658,12 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum by(status)(increase(gardener_warning_total[10m]))",
               "interval": "5m",
               "legendFormat": "{{status}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -1614,11 +1683,13 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "(sum by(datatype) (rate(gardener_jobs_total{status!=\"success\"}[10m])) / sum by(datatype) (rate(gardener_jobs_total[10m])))",
+              "expr": "(sum by(experiment, datatype) (rate(gardener_jobs_total{status!=\"success\"}[10m])) / sum by(experiment, datatype) (rate(gardener_jobs_total[10m])))",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{datatype}}",
+              "legendFormat": "{{experiment}}/{{datatype}}",
+              "range": true,
               "refId": "C"
             }
           ],
@@ -1668,7 +1739,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 0.5,
           "points": true,
           "renderer": "flot",
@@ -1682,18 +1753,21 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "histogram_quantile(0.90, sum(rate(gardener_state_time_histogram_bucket{datatype=~\"$datatype\"}[6h])) by (state, datatype, le))",
+              "expr": "histogram_quantile(0.90, sum(rate(gardener_state_time_histogram_bucket{datatype=~\"$datatype\"}[6h])) by (experiment, state, datatype, le))",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{datatype}}: {{state}}",
+              "legendFormat": "{{experiment}}/{{datatype}}: {{state}}",
+              "range": true,
               "refId": "D"
             }
           ],
           "thresholds": [
             {
+              "$$hashKey": "object:919",
               "colorMode": "critical",
               "fill": true,
               "line": true,
@@ -1736,11 +1810,24 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Gardener",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1785,7 +1872,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1800,12 +1887,14 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status!=\"OK\"}[120m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{worker}}",
+              "range": true,
               "refId": "F"
             }
           ],
@@ -1886,7 +1975,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1900,11 +1989,13 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "60*sum by (table) (rate(etl_gcs_retry_count[10m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{table}} Errors/Min",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -1978,7 +2069,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1992,10 +2083,12 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum by(table)(rate(etl_test_file_size_bytes_sum{}[30m]))",
               "interval": "",
               "legendFormat": "{{table}}",
+              "range": true,
               "refId": "C"
             }
           ],
@@ -2073,7 +2166,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2087,12 +2180,14 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "histogram_quantile(0.95, sum by(le, table, status) (rate(etl_insertion_time_seconds_bucket{service=\"etl-batch-parser\"}[5m])))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "0.95 {{status}} {{table}}",
+              "range": true,
               "refId": "B",
               "step": 10
             },
@@ -2182,7 +2277,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2197,12 +2292,14 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "sum by(worker) (rate(etl_worker_duration_seconds_count{status=\"OK\"}[120m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{worker}}",
+              "range": true,
               "refId": "F"
             }
           ],
@@ -2283,7 +2380,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2297,11 +2394,13 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "60*sum by (kind, table)(rate(etl_backend_failure_count[10m]))\n",
               "hide": false,
               "interval": "",
               "legendFormat": "{{table}} Failures/Min {{kind}}",
+              "range": true,
               "refId": "A"
             },
             {
@@ -2386,7 +2485,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.4",
+          "pluginVersion": "9.1.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2400,11 +2499,13 @@
                 "type": "prometheus",
                 "uid": "${Gardener2_DS}"
               },
+              "editorMode": "code",
               "exemplar": true,
               "expr": "histogram_quantile(0.5,sum by(le, table)(rate(etl_test_file_size_bytes_bucket{table=~\"$datatype\"}[1h])))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{table}}",
+              "range": true,
               "refId": "C"
             }
           ],
@@ -2441,19 +2542,28 @@
           }
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Parsers",
       "type": "row"
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "mlab-oti",
           "value": "mlab-oti"
         },
@@ -2522,7 +2632,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "complete"
           ],
@@ -2556,12 +2666,14 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "tcpinfo"
+            "annotation2",
+            "hopannotation2"
           ],
           "value": [
-            "tcpinfo"
+            "annotation2",
+            "hopannotation2"
           ]
         },
         "datasource": {
@@ -2587,7 +2699,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -2618,6 +2730,6 @@
   "timezone": "utc",
   "title": "Pipeline: Overview",
   "uid": "UTgnK-jMz",
-  "version": 17,
+  "version": 23,
   "weekStart": ""
 }


### PR DESCRIPTION
This change updates the `Pipeline: Overview` dashboard to include references to the experiment name with the datatype name where available. (Many metrics do not have the experiment label available https://github.com/m-lab/etl-gardener/issues/422 )

This change is part of changes to introduce data from wehe into the pipeline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/980)
<!-- Reviewable:end -->
