### PR TITLE
Add alerts for the autoloader

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1330,7 +1330,7 @@ groups:
   - alert: Pipeline_AutoloaderDailyJobMissing
     expr: |
       sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily"}[6h])) == 0
-    for: 10m
+    for: 3h
     labels:
       repo: dev-tracker
       severity: ticket

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1298,7 +1298,8 @@ groups:
 # Pipeline_AutoloaderDownOrMissing fires when the autoloader is down or missing.
   - alert: Pipeline_AutoloaderDownOrMissing
     expr: |
-      up{container="autoloader"} == 0 OR absent(up{container="autoloader"})
+      up{container="autoloader", instance=~".*:9990"} == 0
+        OR absent(up{container="autoloader", instance=~".*:9990"})
     for: 10m
     labels:
       repo: dev-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1305,7 +1305,7 @@ groups:
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: The Pipeline autoloader down or missing.
+      summary: The Pipeline autoloader is down or missing.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdownormissing
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1
 

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1326,10 +1326,10 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=15
 
 # Pipeline_AutoloaderDailyJobErrorOrMissing fires when the autoloader's daily job for a datatype
-# has not run or has returned an error in 6 hours.
+# has not successfully run or has returned an error in 6 hours.
   - alert: Pipeline_AutoloaderDailyJobErrorOrMissing
     expr: |
-      sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily"}[6h])) == 0
+      sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily", status="OK"}[6h])) == 0
         OR sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily", status!="OK"}[6h])) > 0
     for: 3h
     labels:
@@ -1337,7 +1337,7 @@ groups:
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: The Pipeline autoloader has failed to run the daily job or the job has returned an error
+      summary: The Pipeline autoloader has failed to successfully run the daily job or the job has returned an error
         for {{ $labels.experiment}}.{{ $labels.datatype }}.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdailyjoberrorormissing
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=12

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1294,3 +1294,47 @@ groups:
       summary: Queries run by discuss@ users may be broken or return zero results.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_dailydiscussaccesszeroormissing
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/UTgnK-jMz/pipeline-overview?orgId=1&refresh=5m
+
+# Pipeline_AutoloaderDownOrMissing fires when the autoloader is down or missing.
+  - alert: Pipeline_AutoloaderDownOrMissing
+    expr: |
+      up{container="autoloader"} == 0 OR absent(up{container="autoloader"})
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: The Pipeline autoloader down or missing.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdownormissing
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1
+
+# Pipeline_AutoloaderCreateOrUpdateError fires when the autoloader fails to create or update
+# a dataset or table in BigQuery.
+  - alert: Pipeline_AutoloaderCreateOrUpdateError
+    expr: |
+      autoloader_bigquery_operations_total{operation=~"create.*|update.*", status!="OK"}
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: The Pipeline autoloader has failed to perform a {{ $labels.operation }} operation in BigQuery.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloadercreateorupdateerror
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=15
+
+# Pipeline_AutoloaderDailyJobMissing fires when the autoloader's daily job for a datatype
+# has not run in 6 hours.
+  - alert: Pipeline_AutoloaderDailyJobMissing
+    expr: |
+      sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily"}[6h])) == 0
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: The Pipeline autoloader has failed to run the daily job for {{ $labels.experiment}}.{{ $labels.datatype }}.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdailyjobmissing
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=12

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1314,7 +1314,7 @@ groups:
 # a dataset or table in BigQuery.
   - alert: Pipeline_AutoloaderCreateOrUpdateError
     expr: |
-      autoloader_bigquery_operations_total{operation=~"create.*|update.*", status!="OK"}
+      sum by (experiment, datatype) (increase(autoloader_bigquery_operations_total{operation=~"create.*|update.*", status!="OK"}[10m])) > 0
     for: 10m
     labels:
       repo: dev-tracker
@@ -1325,17 +1325,19 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloadercreateorupdateerror
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=15
 
-# Pipeline_AutoloaderDailyJobMissing fires when the autoloader's daily job for a datatype
-# has not run in 6 hours.
-  - alert: Pipeline_AutoloaderDailyJobMissing
+# Pipeline_AutoloaderDailyJobErrorOrMissing fires when the autoloader's daily job for a datatype
+# has not run or has returned an error in 6 hours.
+  - alert: Pipeline_AutoloaderDailyJobErrorOrMissing
     expr: |
       sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily"}[6h])) == 0
+        OR sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily", status!="OK"}[6h])) > 0
     for: 3h
     labels:
       repo: dev-tracker
       severity: ticket
       cluster: prometheus-federation
     annotations:
-      summary: The Pipeline autoloader has failed to run the daily job for {{ $labels.experiment}}.{{ $labels.datatype }}.
-      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdailyjobmissing
+      summary: The Pipeline autoloader has failed to run the daily job or the job has returned an error
+        for {{ $labels.experiment}}.{{ $labels.datatype }}.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdailyjoberrorormissing
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/OKQmdgs4k/pipeline-autoloader?orgId=1&viewPanel=12

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -401,7 +401,7 @@ scrape_configs:
         - 'etl_test_total'
         - 'up{container="downloader"}'
         - 'downloader_last_success_time_seconds'
-        - 'up{container="autoloader}'
+        - 'up{container="autoloader"}'
         - 'autoloader_bigquery_operations_total'
         - 'autoloader_duration_count'
     static_configs:

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -401,6 +401,9 @@ scrape_configs:
         - 'etl_test_total'
         - 'up{container="downloader"}'
         - 'downloader_last_success_time_seconds'
+        - 'up{container="autoloader}'
+        - 'autoloader_bigquery_operations_total'
+        - 'autoloader_duration_count'
     static_configs:
       - targets: ['prometheus-data-processing.{{PROJECT}}.measurementlab.net:9090']
 


### PR DESCRIPTION
This PR adds 3 new alerts to monitor the autoloader.

I have also updated the ops-tactical [wiki](https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#pipeline_autoloaderdownormissing) with troubleshooting information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/983)
<!-- Reviewable:end -->
