### PR TITLE
Add Plotly dashboards for NDT performance distributions using BigQuery datasource

### DIFF
--- a/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 425,
+  "id": 430,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -46,7 +46,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 10,
@@ -80,8 +80,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              3.470000000000003
+              -0.9899999999999997,
+              3.5500000000000025
             ],
             "type": "log"
           },
@@ -89,8 +89,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0013482310722225798,
-              0.025616390372229014
+              -0.001046069847020934,
+              0.019875327093397743
             ],
             "type": "linear"
           }
@@ -102,7 +102,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -110,7 +110,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -139,7 +139,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "description": "",
       "gridPos": {
@@ -174,8 +174,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              2.670000000000002
+              -0.9899999999999997,
+              2.4700000000000024
             ],
             "type": "log"
           },
@@ -183,8 +183,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0019026585042473884,
-              0.03615051158070038
+              -0.00315602951411648,
+              0.05996456076821312
             ],
             "type": "linear"
           }
@@ -196,7 +196,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -204,7 +204,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 300, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -233,7 +233,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "description": "",
       "gridPos": {
@@ -268,8 +268,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -6.009999999999999,
-              -0.010000000000039328
+              -5.989999999999998,
+              0.009999999999961536
             ],
             "type": "log"
           },
@@ -277,8 +277,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0005549481496206475,
-              0.0105440148427923
+              -0.0005958825356060797,
+              0.011321768176515513
             ],
             "type": "linear"
           }
@@ -290,7 +290,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -298,7 +298,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-6, 0, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.LossRate BETWEEN xleft AND xright, 1, 0) AS lossrate_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(lossrate_present) AS lossrate_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    lossrate_bin_count,\n    SUM(lossrate_bin_count) OVER (partition by site) AS lossrate_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    SAFE_DIVIDE(lossrate_bin_count, lossrate_site_sum) AS lossrate_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    lossrate_site_pdf, SUM(lossrate_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS lossrate_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN lossrate_site_pdf\n    ELSE lossrate_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm",
+          "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -327,7 +327,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -408,7 +408,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "time_series",
           "group": [],
@@ -452,11 +452,29 @@
       {
         "current": {
           "selected": true,
+          "text": "BigQuery (mlab-sandbox)",
+          "value": "BigQuery (mlab-sandbox)"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "doitintl-bigquery-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/(mlab-oti|mlab-staging|mlab-sandbox)/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
           "text": [
-            "atl"
+            "lga"
           ],
           "value": [
-            "atl"
+            "lga"
           ]
         },
         "datasource": {
@@ -542,7 +560,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},

--- a/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
@@ -1,0 +1,554 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 425,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "panels": [],
+      "repeat": "metro",
+      "repeatDirection": "h",
+      "title": "${metro}",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 11,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              3.470000000000003
+            ],
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0013482310722225798,
+              0.025616390372229014
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download Mbps ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 12,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              2.670000000000002
+            ],
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0019026585042473884,
+              0.03615051158070038
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download MinRTT ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 13,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -6.009999999999999,
+              -0.010000000000039328
+            ],
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0005549481496206475,
+              0.0105440148427923
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-6, 0, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.LossRate BETWEEN xleft AND xright, 1, 0) AS lossrate_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(lossrate_present) AS lossrate_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    lossrate_bin_count,\n    SUM(lossrate_bin_count) OVER (partition by site) AS lossrate_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    SAFE_DIVIDE(lossrate_bin_count, lossrate_site_sum) AS lossrate_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    lossrate_site_pdf, SUM(lossrate_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS lossrate_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN lossrate_site_pdf\n    ELSE lossrate_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download LossRate ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 16,
+      "maxDataPoints": 80000,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(date)\n AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\nGROUP by date, metric\nORDER BY date, metric",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Test Counts (hourly, downloads only)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "atl"
+          ],
+          "value": [
+            "atl"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "WW1Jk2sGk"
+        },
+        "definition": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "metro",
+        "options": [],
+        "query": {
+          "query": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/mlab[1-4].([a-z]{3}).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "physical",
+            "virtual"
+          ],
+          "value": [
+            "physical",
+            "virtual"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "physical",
+            "value": "physical"
+          },
+          {
+            "selected": true,
+            "text": "virtual",
+            "value": "virtual"
+          }
+        ],
+        "query": "physical,virtual",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "pdf",
+          "value": "pdf"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "mode",
+        "options": [
+          {
+            "selected": true,
+            "text": "pdf",
+            "value": "pdf"
+          },
+          {
+            "selected": false,
+            "text": "cdf",
+            "value": "cdf"
+          }
+        ],
+        "query": "pdf,cdf",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NDT: Metro Performance Distributions",
+  "uid": "ZCG2vk8Vk",
+  "version": 17,
+  "weekStart": ""
+}

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -24,14 +24,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 413,
+  "id": 431,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 16,
@@ -65,8 +65,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              3.470000000000003
+              -0.9899999999999997,
+              3.5500000000000025
             ],
             "title": {
               "text": "Mbps"
@@ -77,8 +77,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0010525970212179744,
-              0.019999343403141516
+              -0.0010608259132194094,
+              0.020155692351168777
             ],
             "type": "linear"
           }
@@ -90,7 +90,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -98,7 +98,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `mlab-sandbox.ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -127,7 +127,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 16,
@@ -161,8 +161,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              2.670000000000002
+              -0.9899999999999997,
+              2.4700000000000024
             ],
             "title": {
               "text": "Milliseconds"
@@ -173,8 +173,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.003160780886527397,
-              0.06005483684402054
+              -0.003137657931395629,
+              0.05961550069651694
             ],
             "type": "linear"
           }
@@ -186,7 +186,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -194,7 +194,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 300, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -223,7 +223,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 16,
@@ -257,8 +257,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -6.009999999999999,
-              -0.010000000000039328
+              -5.989999999999998,
+              0.009999999999961536
             ],
             "title": {
               "text": "Loss ratio"
@@ -269,8 +269,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0006508626390695986,
-              0.012366390142322372
+              -0.0006491720471555683,
+              0.012334268895955798
             ],
             "type": "linear"
           }
@@ -282,7 +282,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -290,7 +290,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-6, 0, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.LossRate BETWEEN xleft AND xright, 1, 0) AS lossrate_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(lossrate_present) AS lossrate_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    lossrate_bin_count,\n    SUM(lossrate_bin_count) OVER (partition by site) AS lossrate_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    SAFE_DIVIDE(lossrate_bin_count, lossrate_site_sum) AS lossrate_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    lossrate_site_pdf, SUM(lossrate_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS lossrate_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN lossrate_site_pdf\n    ELSE lossrate_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -303,14 +303,7 @@
             ]
           ],
           "timeColumn": "-- time --",
-          "timeColumnType": "DATE",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
+          "timeColumnType": "DATE"
         }
       ],
       "title": "Download LossRate ($mode)",
@@ -319,7 +312,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 16,
@@ -365,8 +358,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.013869715071140563,
-              0.2635245863516707
+              -0.013599027856240472,
+              0.25838152926856894
             ],
             "type": "linear"
           }
@@ -378,7 +371,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -415,7 +408,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "description": "",
       "gridPos": {
@@ -462,8 +455,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.006858042074228344,
-              0.13030279941033854
+              -0.006795339531599387,
+              0.12911145110038835
             ],
             "type": "linear"
           }
@@ -475,7 +468,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "table",
           "group": [],
@@ -512,7 +505,7 @@
     {
       "datasource": {
         "type": "doitintl-bigquery-datasource",
-        "uid": "0zzHsf77z"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -590,7 +583,7 @@
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
-            "uid": "0zzHsf77z"
+            "uid": "${datasource}"
           },
           "format": "time_series",
           "group": [],
@@ -631,6 +624,24 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "BigQuery (mlab-sandbox)",
+          "value": "BigQuery (mlab-sandbox)"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "doitintl-bigquery-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/(mlab-oti|mlab-staging|mlab-sandbox)/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {
           "selected": true,

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 431,
+  "id": 428,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -98,7 +98,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `mlab-sandbox.ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
           "select": [
             [
@@ -346,8 +346,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              3.470000000000003
+              -0.9899999999999997,
+              3.5500000000000025
             ],
             "title": {
               "text": "Mbps"
@@ -358,8 +358,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.013599027856240472,
-              0.25838152926856894
+              -0.001631173495506043,
+              0.030992296414614817
             ],
             "type": "linear"
           }
@@ -379,7 +379,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_uploads`\n  WHERE -- date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n    $__timeFilter(date) \n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n   AND IF(\"${maskUpload}\" = \"off\", TRUE, NOT a.MeanThroughputMbps BETWEEN 0.42 AND 0.43)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n\n",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_upload_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\", \"${maskUpload}\" = \"on\")",
           "refId": "A",
           "select": [
             [
@@ -443,8 +443,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -1.01,
-              2.670000000000002
+              -0.9899999999999997,
+              2.6900000000000026
             ],
             "title": {
               "text": "Milliseconds"
@@ -455,8 +455,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.006795339531599387,
-              0.12911145110038835
+              -0.001995754663980842,
+              0.037919338615636
             ],
             "type": "linear"
           }
@@ -476,7 +476,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_uploads`\n  WHERE -- date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n       $__timeFilter(date) \n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n   AND IF(\"${maskUpload}\" = \"off\", TRUE, NOT a.MeanThroughputMbps BETWEEN 0.42 AND 0.43)\n\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n\n",
+          "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_upload_pdf`(0.1, 500, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\", \"${maskUpload}\" = \"on\")",
           "refId": "A",
           "select": [
             [
@@ -626,7 +626,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "BigQuery (mlab-sandbox)",
           "value": "BigQuery (mlab-sandbox)"
         },
@@ -742,9 +742,9 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "off",
-          "value": "off"
+          "selected": true,
+          "text": "on",
+          "value": "on"
         },
         "description": "Masks the Upload spike at 0.4Mbps",
         "hide": 0,
@@ -754,12 +754,12 @@
         "name": "maskUpload",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "off",
             "value": "off"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "on",
             "value": "on"
           }
@@ -779,6 +779,6 @@
   "timezone": "",
   "title": "NDT: Site Performance Distributions",
   "uid": "ZeMq_Ya4k",
-  "version": 23,
+  "version": 2,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -1,0 +1,773 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 413,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              3.470000000000003
+            ],
+            "title": {
+              "text": "Mbps"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0010525970212179744,
+              0.019999343403141516
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download Mbps ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 12,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              2.670000000000002
+            ],
+            "title": {
+              "text": "Milliseconds"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.003160780886527397,
+              0.06005483684402054
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download MinRTT ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 13,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -6.009999999999999,
+              -0.010000000000039328
+            ],
+            "title": {
+              "text": "Loss ratio"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0006508626390695986,
+              0.012366390142322372
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-6, 0, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\n  WHERE $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.LossRate BETWEEN xleft AND xright, 1, 0) AS lossrate_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(lossrate_present) AS lossrate_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    lossrate_bin_count,\n    SUM(lossrate_bin_count) OVER (partition by site) AS lossrate_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    SAFE_DIVIDE(lossrate_bin_count, lossrate_site_sum) AS lossrate_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    lossrate_site_pdf, SUM(lossrate_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS lossrate_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN lossrate_site_pdf\n    ELSE lossrate_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Download LossRate ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 14,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              3.470000000000003
+            ],
+            "title": {
+              "text": "Mbps"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.013869715071140563,
+              0.2635245863516707
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 3.5, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_uploads`\n  WHERE -- date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n    $__timeFilter(date) \n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n   AND IF(\"${maskUpload}\" = \"off\", TRUE, NOT a.MeanThroughputMbps BETWEEN 0.42 AND 0.43)\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MeanThroughputMbps BETWEEN xleft AND xright, 1, 0) AS mbps_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(mbps_present) AS mbps_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    mbps_bin_count,\n    SUM(mbps_bin_count) OVER (partition by site) AS mbps_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_bin_count / mbps_site_sum AS mbps_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    mbps_site_pdf, SUM(mbps_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS mbps_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN mbps_site_pdf\n    ELSE mbps_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Upload Mbps ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 15,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -1.01,
+              2.670000000000002
+            ],
+            "title": {
+              "text": "Milliseconds"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.006858042074228344,
+              0.13030279941033854
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "WITH xbins AS (\n\n  SELECT x, POW(10, x-.01) AS xleft, POW(10, x+.01) AS xright\n  FROM UNNEST(GENERATE_ARRAY(-1, 2.7, .02)) AS x\n\n), ndt7 AS (\n\n  SELECT *\n  FROM `measurement-lab.ndt_intermediate.extended_ndt7_uploads`\n  WHERE -- date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\n       $__timeFilter(date) \n   AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\n   AND (filter.IsComplete AND filter.IsProduction AND NOT filter.IsError AND NOT filter.IsOAM AND NOT filter.IsPlatformAnomaly\n        AND NOT filter.IsSmall AND NOT filter.IsShort AND NOT filter.IsLong AND NOT filter._IsRFC1918)\n   AND IF(\"${maskUpload}\" = \"off\", TRUE, NOT a.MeanThroughputMbps BETWEEN 0.42 AND 0.43)\n\n\n), ndt7_into_xbins AS (\n\n  SELECT\n    xleft, xright, server.Site as site,\n    IF(a.MinRTT BETWEEN xleft AND xright, 1, 0) AS minrtt_present,\n  FROM ndt7, xbins\n\n), ndt7_xbins_counts AS (  \n\n  SELECT\n    xleft, site,\n    SUM(minrtt_present) AS minrtt_bin_count,\n  FROM   ndt7_into_xbins\n  GROUP BY xleft, site\n  ORDER BY xleft\n\n), ndt7_xbins_counts_site_sum AS (\n\n  SELECT  \n    xleft,\n    site,\n    minrtt_bin_count,\n    SUM(minrtt_bin_count) OVER (partition by site) AS minrtt_site_sum,\n  FROM ndt7_xbins_counts\n  ORDER BY xleft\n\n), pdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_bin_count / minrtt_site_sum AS minrtt_site_pdf,\n  FROM ndt7_xbins_counts_site_sum\n\n), cdf_norm AS (\n\n  SELECT\n    xleft,\n    site,\n    minrtt_site_pdf, SUM(minrtt_site_pdf) OVER (PARTITION BY site ORDER BY xleft ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS minrtt_site_cdf,\n  FROM pdf_norm\n\n)\n\nSELECT\n  xleft,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN minrtt_site_pdf\n    ELSE minrtt_site_cdf\n  END AS data,\n  site,\n\nFROM cdf_norm\n\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Upload MinRTT ($mode)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "doitintl-bigquery-datasource",
+        "uid": "0zzHsf77z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 16,
+      "maxDataPoints": 80000,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "0zzHsf77z"
+          },
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "rawQuery": true,
+          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(date)\n AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\nGROUP by date, server.Site\nORDER BY date, server.Site  ",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "-- time --",
+          "timeColumnType": "DATE",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Test Counts (hourly, download only)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "lga04",
+            "lga05",
+            "lga06",
+            "lga08",
+            "lga09"
+          ],
+          "value": [
+            "lga04",
+            "lga05",
+            "lga06",
+            "lga08",
+            "lga09"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "WW1Jk2sGk"
+        },
+        "definition": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "site",
+        "options": [],
+        "query": {
+          "query": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/mlab[1-4].([a-z]{3}[0-9t]{2}).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "physical",
+            "virtual"
+          ],
+          "value": [
+            "physical",
+            "virtual"
+          ]
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "physical",
+            "value": "physical"
+          },
+          {
+            "selected": true,
+            "text": "virtual",
+            "value": "virtual"
+          }
+        ],
+        "query": "physical,virtual",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "pdf",
+          "value": "pdf"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "mode",
+        "options": [
+          {
+            "selected": true,
+            "text": "pdf",
+            "value": "pdf"
+          },
+          {
+            "selected": false,
+            "text": "cdf",
+            "value": "cdf"
+          }
+        ],
+        "query": "pdf,cdf",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "off",
+          "value": "off"
+        },
+        "description": "Masks the Upload spike at 0.4Mbps",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Hide Upload Spike",
+        "multi": false,
+        "name": "maskUpload",
+        "options": [
+          {
+            "selected": true,
+            "text": "off",
+            "value": "off"
+          },
+          {
+            "selected": false,
+            "text": "on",
+            "value": "on"
+          }
+        ],
+        "query": "off,on",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NDT: Site Performance Distributions",
+  "uid": "ZeMq_Ya4k",
+  "version": 23,
+  "weekStart": ""
+}


### PR DESCRIPTION
The [Plotly Grafana panel type](https://grafana.com/grafana/plugins/ae3e-plotly-panel/) supports any visualization supported by the Plotly javascript library. The combination of the BigQuery datasource with the Plotly panel type means that we could support visualizations directly from BigQuery using any javascript Plotly library.

This change adds two new dashboards using this combination to visualize PDFs (or CDFs) of NDT7 download (and upload) performance metrics.
* [NDT: Metro Performance Distributions](https://grafana.mlab-sandbox.measurementlab.net/d/ZCG2vk8Vk/ndt-metro-performance-distributions?from=now-14d&to=now)
* [NDT: Site Performance Distributions](https://grafana.mlab-sandbox.measurementlab.net/d/ZeMq_Ya4k/ndt-site-performance-distributions?orgId=1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/984)
<!-- Reviewable:end -->
