### PR TITLE
Add prometheus variable

### DIFF
--- a/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 430,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -89,8 +88,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.001046069847020934,
-              0.019875327093397743
+              -0.0010763954493664726,
+              0.020451513537962977
             ],
             "type": "linear"
           }
@@ -183,8 +182,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.00315602951411648,
-              0.05996456076821312
+              -0.0031723594122624824,
+              0.060274828832987154
             ],
             "type": "linear"
           }
@@ -277,8 +276,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0005958825356060797,
-              0.011321768176515513
+              -0.0007333601562907096,
+              0.013933842969523482
             ],
             "type": "linear"
           }
@@ -451,7 +450,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "BigQuery (mlab-sandbox)",
           "value": "BigQuery (mlab-sandbox)"
         },
@@ -469,6 +468,23 @@
       },
       {
         "current": {
+          "selected": false,
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/Platform Cluster .*mlab-oti.*/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
           "selected": true,
           "text": [
             "lga"
@@ -479,7 +495,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "WW1Jk2sGk"
+          "uid": "${prometheus}"
         },
         "definition": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
         "hide": 0,
@@ -567,6 +583,6 @@
   "timezone": "",
   "title": "NDT: Metro Performance Distributions",
   "uid": "ZCG2vk8Vk",
-  "version": 17,
+  "version": 18,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
@@ -88,8 +88,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0010763954493664726,
-              0.020451513537962977
+              -0.0010875993975004274,
+              0.020664388552508118
             ],
             "type": "linear"
           }
@@ -182,8 +182,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0031723594122624824,
-              0.060274828832987154
+              -0.0031575176653435713,
+              0.05999283564152785
             ],
             "type": "linear"
           }
@@ -276,8 +276,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0007333601562907096,
-              0.013933842969523482
+              -0.0007428484769035815,
+              0.014114121061168047
             ],
             "type": "linear"
           }
@@ -450,11 +450,11 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "BigQuery (mlab-sandbox)",
-          "value": "BigQuery (mlab-sandbox)"
+          "selected": true,
+          "text": "BigQuery (mlab-oti)",
+          "value": "BigQuery (mlab-oti)"
         },
-        "hide": 0,
+        "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "datasource",
@@ -472,14 +472,14 @@
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
-        "hide": 2,
+        "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "prometheus",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/Platform Cluster .*mlab-oti.*/",
+        "regex": "/Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -583,6 +583,6 @@
   "timezone": "",
   "title": "NDT: Metro Performance Distributions",
   "uid": "ZCG2vk8Vk",
-  "version": 18,
+  "version": 19,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -76,8 +76,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.005871860730593608,
-              0.11156535388127854
+              -0.001042863436927351,
+              0.019814405301619667
             ],
             "type": "linear"
           }
@@ -172,8 +172,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.005031808906493818,
-              0.09560436922338256
+              -0.003202929744475193,
+              0.06085566514502866
             ],
             "type": "linear"
           }
@@ -268,8 +268,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.000919766422108618,
-              0.017475562020063742
+              -0.0006614702586459183,
+              0.012567934914272447
             ],
             "type": "linear"
           }
@@ -357,8 +357,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.00832269888407854,
-              0.15813127879749228
+              -0.0016076626861490546,
+              0.030545591036832034
             ],
             "type": "linear"
           }
@@ -454,8 +454,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.004116466423733763,
-              0.07821286205094151
+              -0.002131154867917453,
+              0.0404919424904316
             ],
             "type": "linear"
           }
@@ -629,7 +629,7 @@
           "text": "BigQuery (mlab-oti)",
           "value": "BigQuery (mlab-oti)"
         },
-        "hide": 0,
+        "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "datasource",
@@ -647,25 +647,33 @@
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
-        "hide": 2,
+        "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "prometheus",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "/Platform Cluster .*mlab-oti.*/",
+        "regex": "/Platform Cluster/",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "akl01"
+            "lga04",
+            "lga05",
+            "lga06",
+            "lga08",
+            "lga09"
           ],
           "value": [
-            "akl01"
+            "lga04",
+            "lga05",
+            "lga06",
+            "lga08",
+            "lga09"
           ]
         },
         "datasource": {
@@ -787,6 +795,6 @@
   "timezone": "",
   "title": "NDT: Site Performance Distributions",
   "uid": "ZeMq_Ya4k",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 428,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -77,8 +76,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0010608259132194094,
-              0.020155692351168777
+              -0.005871860730593608,
+              0.11156535388127854
             ],
             "type": "linear"
           }
@@ -173,8 +172,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.003137657931395629,
-              0.05961550069651694
+              -0.005031808906493818,
+              0.09560436922338256
             ],
             "type": "linear"
           }
@@ -269,8 +268,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0006491720471555683,
-              0.012334268895955798
+              -0.000919766422108618,
+              0.017475562020063742
             ],
             "type": "linear"
           }
@@ -358,8 +357,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.001631173495506043,
-              0.030992296414614817
+              -0.00832269888407854,
+              0.15813127879749228
             ],
             "type": "linear"
           }
@@ -455,8 +454,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.001995754663980842,
-              0.037919338615636
+              -0.004116466423733763,
+              0.07821286205094151
             ],
             "type": "linear"
           }
@@ -627,8 +626,8 @@
       {
         "current": {
           "selected": false,
-          "text": "BigQuery (mlab-sandbox)",
-          "value": "BigQuery (mlab-sandbox)"
+          "text": "BigQuery (mlab-oti)",
+          "value": "BigQuery (mlab-oti)"
         },
         "hide": 0,
         "includeAll": false,
@@ -644,25 +643,34 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "Platform Cluster (mlab-oti)"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/Platform Cluster .*mlab-oti.*/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
           "text": [
-            "lga04",
-            "lga05",
-            "lga06",
-            "lga08",
-            "lga09"
+            "akl01"
           ],
           "value": [
-            "lga04",
-            "lga05",
-            "lga06",
-            "lga08",
-            "lga09"
+            "akl01"
           ]
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "WW1Jk2sGk"
+          "uid": "${prometheus}"
         },
         "definition": "label_values(ndt_test_rate_mbps_count{site_type=~\"$type\"}, machine)",
         "hide": 0,
@@ -742,7 +750,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "on",
           "value": "on"
         },
@@ -779,6 +787,6 @@
   "timezone": "",
   "title": "NDT: Site Performance Distributions",
   "uid": "ZeMq_Ya4k",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
This change adds a hidden `${prometheus}` datasource variable so the `site` and `metro` variable lookup can refer to a local instance of the prometheus datasource, which varies per project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/985)
<!-- Reviewable:end -->
