### PR TITLE
Discover projects with BQ query

### DIFF
--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 339,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -878,8 +877,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -997,8 +995,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1200,56 +1197,27 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "mlab-oti",
-          "value": "mlab-oti"
+          "selected": true,
+          "text": "measurement-lab",
+          "value": "measurement-lab"
         },
+        "datasource": {
+          "type": "doitintl-bigquery-datasource",
+          "uid": "0zzHsf77z"
+        },
+        "definition": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
         "hide": 0,
         "includeAll": false,
         "label": "Project",
         "multi": false,
         "name": "project",
-        "options": [
-          {
-            "selected": false,
-            "text": "mlab-sandbox",
-            "value": "mlab-sandbox"
-          },
-          {
-            "selected": false,
-            "text": "mlab-staging",
-            "value": "mlab-staging"
-          },
-          {
-            "selected": true,
-            "text": "mlab-oti",
-            "value": "mlab-oti"
-          },
-          {
-            "selected": false,
-            "text": "measurement-lab",
-            "value": "measurement-lab"
-          },
-          {
-            "selected": false,
-            "text": "mlab-ns",
-            "value": "mlab-ns"
-          },
-          {
-            "selected": false,
-            "text": "mlab-collaboration",
-            "value": "mlab-collaboration"
-          },
-          {
-            "selected": false,
-            "text": "mlab-edgenet",
-            "value": "mlab-edgenet"
-          }
-        ],
-        "query": "mlab-sandbox,mlab-staging,mlab-oti,measurement-lab,mlab-ns,mlab-collaboration,mlab-edgenet",
-        "queryValue": "",
+        "options": [],
+        "query": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -1274,6 +1242,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 50,
+  "version": 53,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -349,7 +349,7 @@
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "sortBy": "Max",
+          "sortBy": "Mean",
           "sortDesc": true
         },
         "tooltip": {
@@ -877,7 +877,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -995,7 +996,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1114,7 +1116,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1162,7 +1165,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > 1\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > .1\nORDER BY\n  date\n",
           "refId": "A",
           "select": [
             [
@@ -1197,13 +1200,13 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "measurement-lab",
           "value": "measurement-lab"
         },
         "datasource": {
           "type": "doitintl-bigquery-datasource",
-          "uid": "0zzHsf77z"
+          "uid": "${datasource}"
         },
         "definition": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
         "hide": 0,
@@ -1218,6 +1221,23 @@
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "BigQuery (mlab-oti)",
+          "value": "BigQuery (mlab-oti)"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "doitintl-bigquery-datasource",
+        "refresh": 1,
+        "regex": "/mlab-oti/",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },
@@ -1242,6 +1262,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 53,
+  "version": 54,
   "weekStart": ""
 }


### PR DESCRIPTION
This change updates the set of `project` variable values from a static list to the result of a dynamic BigQuery query.

The static list was missing a partnership project. So, a dynamic query ensures that all known GCP projects are available for selection.

```
SELECT project.id
FROM `mlab-oti.billing.unified`
WHERE project.id IS NOT NULL
GROUP BY project.id
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/987)
<!-- Reviewable:end -->
