### PR TITLE
Update variable reference to ${bqSource}

### DIFF
--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -877,8 +877,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -996,8 +995,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1116,8 +1114,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1206,7 +1203,7 @@
         },
         "datasource": {
           "type": "doitintl-bigquery-datasource",
-          "uid": "${datasource}"
+          "uid": "${bqSource}"
         },
         "definition": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
         "hide": 0,
@@ -1224,7 +1221,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "BigQuery (mlab-oti)",
           "value": "BigQuery (mlab-oti)"
         },
@@ -1242,7 +1239,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Platform Cluster (mlab-oti)",
           "value": "Platform Cluster (mlab-oti)"
         },
@@ -1281,6 +1278,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 55,
+  "version": 56,
   "weekStart": ""
 }


### PR DESCRIPTION
This change fixes a missed variable rename. The variable query to identify GCP projects uses a named BQ datasource, but it was renamed to `$bqSource` in https://github.com/m-lab/prometheus-support/pull/988 -- panels that reference a datasource variable are updated automatically if the variable is renamed, but evidently references in variable definitions are not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/989)
<!-- Reviewable:end -->
