### PR TITLE
Add new panels to show Memorystore request duration

### DIFF
--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -1818,7 +1818,7 @@
       "yBucketBound": "auto"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1844,7 +1844,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Duration of PUT requests (e.g., HSET, EXPIRE) from the Locate service to Memorystore (in seconds). These requests are used to write data.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1921,7 +1921,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(le) (increase(locate_memorystore_request_duration_bucket[5m]))",
+          "expr": "sum by(le) (increase(locate_memorystore_request_duration_bucket{type=\"put\"}[5m]))",
           "format": "heatmap",
           "interval": "5m",
           "legendFormat": "{{le}}",
@@ -1929,7 +1929,122 @@
           "refId": "A"
         }
       ],
-      "title": "Memorystore Request Duration",
+      "title": "Memorystore PUT Request Duration",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Duration of GET requests (e.g., HGETALL) from the Locate service to Memorystore (in seconds). These requests are used to import data.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 92
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 49,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Seconds",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(locate_memorystore_request_duration_bucket{type=\"get\"}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memorystore GET Request Duration",
       "tooltip": {
         "show": true,
         "showHistogram": true
@@ -2424,6 +2539,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 59,
+  "version": 60,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Locate_Service.json
+++ b/config/federation/grafana/dashboards/Locate_Service.json
@@ -1818,6 +1818,134 @@
       "yBucketBound": "auto"
     },
     {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 47,
+      "panels": [],
+      "title": "Memorystore",
+      "type": "row"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 48,
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Seconds",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.1.5",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(locate_memorystore_request_duration_bucket[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memorystore Request Duration",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "short",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -1827,7 +1955,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 103
       },
       "id": 12,
       "panels": [],
@@ -1909,7 +2037,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 92
+        "y": 104
       },
       "id": 2,
       "options": {
@@ -2008,7 +2136,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 92
+        "y": 104
       },
       "id": 4,
       "options": {
@@ -2052,7 +2180,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 114
       },
       "id": 16,
       "panels": [],
@@ -2130,7 +2258,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 115
       },
       "id": 6,
       "options": {
@@ -2296,6 +2424,6 @@
   "timezone": "",
   "title": "Locate Service",
   "uid": "8O9tInk4k",
-  "version": 58,
+  "version": 59,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a new "Memorystore" row containing histograms showing the duration of requests from the Locate to Memorystore.

- [PUT requests](https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m&var-datasource=Prometheus%20%28mlab-sandbox%29&var-platformdatasource=Platform%20Cluster%20%28mlab-sandbox%29&var-bigquerydatasource=BigQuery%20%28mlab-sandbox%29&var-experiment=ndt&var-metro=All&viewPanel=48)
- [GET requests](https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m&var-datasource=Prometheus%20%28mlab-sandbox%29&var-platformdatasource=Platform%20Cluster%20%28mlab-sandbox%29&var-bigquerydatasource=BigQuery%20%28mlab-sandbox%29&var-experiment=ndt&var-metro=All&viewPanel=49)

Happy to go over these over GVC if it's helpful!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/991)
<!-- Reviewable:end -->
