### PR TITLE
Fix format for edit link

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -103,7 +103,7 @@ receivers:
       {{- if eq .Status "firing" -}}
       {{.CommonAnnotations.summary}}
       > {{if .CommonAnnotations.description}}{{.CommonAnnotations.description}}
-      {{- else}}*Please add an alert description!*{{end -}}
+      {{- else}}*Please add an alert description!*{{end}}
       <https://github.com/m-lab/prometheus-support/edit/main/config/federation/prometheus/alerts.yml|(edit...)>
       {{- end }}
       {{ range $key, $value := .CommonLabels }} {{ $key }}=*{{ $value }}*, {{ end }}


### PR DESCRIPTION
The alert messages in slack are meant to contain two distinct URLs.

* a link to the wiki alert description (working)
* a link to the alert definition with an edit link (broken)

Due to the template syntax using `{{ end  -}}`, all whitespace between the end of the wiki link and the start of the edit link was removed, making them appear to be a single URL, which was incorrect. This change removes the syntax that removes all whitespace, which preserves two separate links.

Correct behavior verified in the #alert-sandbox messages.

<img width="602" alt="Screen Shot 2023-08-09 at 6 59 09 PM" src="https://github.com/m-lab/prometheus-support/assets/1085316/29bd203c-3ebb-44e3-9c00-5c1a8c6731b7">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/993)
<!-- Reviewable:end -->
