### PR TITLE
Add distinct pod labels for 3h and 5m configs

### DIFF
--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      run: bigquery-exporter
+      run: bigquery-exporter-3h
   template:
     metadata:
       labels:
-        run: bigquery-exporter
+        run: bigquery-exporter-3h
       annotations:
         prometheus.io/scrape: 'true'
     spec:

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      run: bigquery-exporter
+      run: bigquery-exporter-5m
   template:
     metadata:
       labels:
-        run: bigquery-exporter
+        run: bigquery-exporter-5m
       annotations:
         prometheus.io/scrape: 'true'
     spec:


### PR DESCRIPTION
This change corrects a configuration error that used the same pod spec labels and selectors for two distinct configurations: bigquery-exporter-3h and bigquery-exporter-5m. This configuration error merges the logs from both deployments in GCP cloud console - making diagnostics harder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/995)
<!-- Reviewable:end -->
