### PR TITLE
Add new alert for missing metrics

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -771,6 +771,20 @@ groups:
         be overloaded, or TCP pacing may be misconfigured on the node.
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/SuqnZ6Hiz/ops-switch-overview
 
+# Metrics needed for NDT S2C alert are missing.
+  - alert: DataQuality_TooManyNdtS2cTestsWithDiscards_MetricsMissing
+    expr: absent(bq_ndt_s2c_with_discards) OR absent(bq_ndt_s2c_total)
+    for: 30m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: The metrics needed to calculate NDT discard rates are missing.
+      description: Metrics are missing from the BigQuery Exporter. Check the
+        prometheus-federation cluster and bigquery-exporter configurations for errors
+        or recent changes.
+
 # The node_exporter running on eb.measurementlab.net is down.
   - alert: NodeExporterOnEbDownOrMissing
     expr: |


### PR DESCRIPTION
This change adds a new alert for missing metrics needed to calculate the discard rate per machine / site.

A recent configuration error went undetected for about six weeks. The root cause was another query in the bigquery exporter failing to run due to an underlying schema change.

This implies multiple flaws in the bigquery exporter:
* does not run subsequent queries if one fails -- I didn't think this was possible, but this seems to be.
* the bqx does not export summary metrics to generalize alerts on bqx errors or diagnose issues via a dashboard.
* the bqx does not export summary metrics to see / diagnose especially poor performing queries.

<img width="2459" alt="Screen Shot 2023-08-17 at 7 46 21 AM" src="https://github.com/m-lab/prometheus-support/assets/1085316/794a140c-3319-4a04-b701-a160fc26ed8f">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/997)
<!-- Reviewable:end -->
