### PR TITLE
Move from doitintl BigQuery plugin to the Grafana official one

### DIFF
--- a/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-oti.yml.template
@@ -1,7 +1,7 @@
 apiVersion: 1
 
 datasources:
-  - name: Google BigQuery (mlab-staging)
+  - name: Google BigQuery (mlab-oti)
     type: grafana-bigquery-datasource
     access: proxy
     isDefault: {{IS_DEFAULT}}
@@ -9,4 +9,4 @@ datasources:
     enabled: true
     jsonData:
       authenticationType: gce
-      defaultProject: mlab-staging
+      defaultProject: mlab-oti

--- a/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-oti.yml.template
+++ b/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-oti.yml.template
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Google BigQuery (mlab-staging)
+    type: grafana-bigquery-datasource
+    access: proxy
+    isDefault: {{IS_DEFAULT}}
+    editable: false
+    enabled: true
+    jsonData:
+      authenticationType: gce
+      defaultProject: mlab-staging

--- a/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-sandbox.yml.template
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Google BigQuery (mlab-sandbox)
+    type: grafana-bigquery-datasource
+    access: proxy
+    isDefault: {{IS_DEFAULT}}
+    editable: false
+    enabled: true
+    jsonData:
+      authenticationType: gce
+      defaultProject: mlab-sandbox

--- a/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-staging.yml.template
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Google BigQuery (mlab-staging)
+    type: grafana-bigquery-datasource
+    access: proxy
+    isDefault: {{IS_DEFAULT}}
+    editable: false
+    enabled: true
+    jsonData:
+      authenticationType: gce
+      defaultProject: mlab-staging

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -36,9 +36,14 @@ spec:
         env:
         - name: GF_PATHS_PROVISIONING
           value: "/etc/provisioning"
-          # doitintl-bigquery-datasource adds the BigQuery datasource.
+          # This semicolon-separated list of plugins will be installed on
+          # server startup.
+          #
+          # Note: The "doitintl" BQ plugin is unmantained and deprecated in
+          # favor of the official one maintained by Grafana. Some dashboards
+          # still use datasources created with this plugin.
         - name: GF_INSTALL_PLUGINS
-          value: "doitintl-bigquery-datasource"
+          value: "doitintl-bigquery-datasource;grafana-bigquery-datasource"
         - name: GF_SECURITY_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -36,14 +36,14 @@ spec:
         env:
         - name: GF_PATHS_PROVISIONING
           value: "/etc/provisioning"
-          # This semicolon-separated list of plugins will be installed on
+          # This comma-separated list of plugins will be installed on
           # server startup.
           #
           # Note: The "doitintl" BQ plugin is unmantained and deprecated in
           # favor of the official one maintained by Grafana. Some dashboards
           # still use datasources created with this plugin.
         - name: GF_INSTALL_PLUGINS
-          value: "doitintl-bigquery-datasource;grafana-bigquery-datasource"
+          value: "doitintl-bigquery-datasource,grafana-bigquery-datasource"
         - name: GF_SECURITY_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The `doitintl-bigquery-datasource` plugin [was deprecated](https://github.com/doitintl/bigquery-grafana) in Dec 2022. This PR installs the official Grafana BigQuery plugin and sets up datasources for every project. 

A subsequent PR will migrate the dashboards that are currently using the doitintl plugin to this new one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/999)
<!-- Reviewable:end -->
