### PR TITLE
Removes ContainerLogsMissingInStackdriver alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -597,31 +597,6 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#locate_toomanyerrors
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5m&var-datasource=Prometheus%20%28mlab-oti%29&var-platformdatasource=Platform%20Cluster%20%28mlab-oti%29&var-bigquerydatasource=BigQuery%20%28mlab-oti%29&var-metro=All&var-experiment=ndt&viewPanel=4
 
-# If container logs for a node are missing in Stackdriver for too long, then
-# fire an alert, unless the node is in maintenance or lame-duck mode. This
-# somewhat awkward query discovers cases where the stackdriver metric has been
-# absent for too long, indicating a likely issue with the Vector pod on the
-# node, causing it to fail to upload container logs to Stackdriver.
-  - alert: PlatformCluster_ContainerLogsMissingInStackdriver
-    expr: |
-      kube_node_status_condition{condition="Ready", status="true", node=~"mlab[1-4].*"} == 1
-        unless on(machine) sum_over_time(
-          stackdriver_generic_node_logging_googleapis_com_user_platform_cluster_container_logs
-        [1h])
-        unless on(machine) (
-          gmx_machine_maintenance == 1 or
-          kube_node_spec_taint{cluster="platform", key="lame-duck"}
-        )
-    for: 24h
-    labels:
-      repo: ops-tracker
-      severity: ticket
-      cluster: platform
-    annotations:
-      summary: Container logs for a node are missing in Stackdriver for more than 24h.
-      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_containerlogsmissinginstackdriver
-      dashboard: https://grafana.mlab-oti.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
-
 # One or more generic (non-experiment specific) mlab-ns metrics is missing.
 # These are metrics that mlab-ns relies on to determine whether an experiment
 # should receive production traffic, so we need to make sure that the metrics


### PR DESCRIPTION
We recently stopped pushing experiment logs to GCP:

https://github.com/m-lab/k8s-support/pull/849

Vector should still be pushing logs from some containers like node-exporter, cAdvisor, flannel, etc. However, it would appear that these container produce very few logs and trigger this alert.

Vector is also still pushing kernel logs over above a certain level. Again, it seems that a good chunk of machines do not push kernel logs frequently enough to make a reliable alert.

All this said, we have observed that Vector sometimes gets into an error state with regard to GCP, which has previously only been visible because of the alert being removed by this commit. We need to figure out a way to alert when Vector cannot push logs to Stackdriver, but does not exit or produce anything but a log message. Maybe Vector can push its own logs to Stackdriver, and we can search for error messages in a custom log-based metric?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1007)
<!-- Reviewable:end -->
