### PR TITLE
Change federation-data-pipeline config to use the new domain name

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -57,6 +57,8 @@ sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH_PASS}}|'${!REBOOTAPI_BASIC_AUTH_PASS}'|g' \
     -e 's|{{PLATFORM_PROM_AUTH_USER}}|'${!PLATFORM_PROM_AUTH_USER}'|g' \
     -e 's|{{PLATFORM_PROM_AUTH_PASS}}|'${!PLATFORM_PROM_AUTH_PASS}'|g' \
+    -e 's|{{PROM_AUTH_USER}}|'${!PROM_AUTH_USER}'|g' \
+    -e 's|{{PROM_AUTH_PASS}}|'${!PROM_AUTH_PASS}'|g' \
     config/federation/prometheus/prometheus.yml.template > \
     config/federation/prometheus/prometheus.yml
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -389,6 +389,9 @@ scrape_configs:
     metrics_path: '/federate'
     # Allow more time, since the number of metrics may be large.
     scrape_timeout: 50s
+    basic_auth:
+      username: {{PROM_AUTH_USER}}
+      password: {{PROM_AUTH_PASS}}
     params:
       'match[]':
         - 'up{container="etl-gardener",instance=~".*:9090"}'
@@ -405,7 +408,7 @@ scrape_configs:
         - 'autoloader_bigquery_operations_total'
         - 'autoloader_duration_count'
     static_configs:
-      - targets: ['prometheus-data-pipeline.{{PROJECT}}.measurementlab.net:9090']
+      - targets: ['prometheus-data-pipeline-basic.{{PROJECT}}.measurementlab.net']
 
   # Scrape config for federation.
   #


### PR DESCRIPTION
The k8s service that allowed direct access to the data-pipeline Prometheus instance on port 9090 does not exist anymore since #1004. This config still relied on that service to ingest data from the data-pipeline Prometheus. This PR changes the config to use the new -basic endpoint with HTTP basic auth credentials.