### PR TITLE
Exclude 'Too Many Requests' from Locate errors

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -585,7 +585,7 @@ groups:
 # from Prometheus.
   - alert: Locate_TooManyErrors
     expr: |
-      (sum(rate(locate_requests_total{type="nearest", status!="OK"}[2m]))) /
+      (sum(rate(locate_requests_total{type="nearest", status!~"OK|Too Many Requests"}[2m]))) /
       sum(rate(locate_requests_total{type="nearest"}[2m])) > 0.001
     for: 2m
     labels:


### PR DESCRIPTION
This PR excludes the "Too Many Errors" request status type from the `Locate_TooManyErrors` alert since it does not indicate that the Locate is malfunctioning. 