### PR TITLE
Upgrade to Grafana v10.2.2 & fix broken dashboards due to upgrade

### DIFF
--- a/config/federation/grafana/dashboards/Alert_DownloaderIsFailingToUpdate.json
+++ b/config/federation/grafana/dashboards/Alert_DownloaderIsFailingToUpdate.json
@@ -4,7 +4,10 @@
       {
         "$$hashKey": "object:2035",
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": false,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -14,18 +17,72 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 56,
+  "id": 218,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 75600
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -33,30 +90,26 @@
         "y": 0
       },
       "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "$$hashKey": "object:2106",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "time() - (downloader_last_success_time_seconds!=0) > (21 * 60 * 60)",
           "format": "time_series",
           "hide": true,
@@ -66,6 +119,9 @@
         },
         {
           "$$hashKey": "object:2107",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "time() - (downloader_last_success_time_seconds!=0)",
           "format": "time_series",
           "intervalFactor": 1,
@@ -74,68 +130,77 @@
         },
         {
           "$$hashKey": "object:2108",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "C"
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 75600,
-          "yaxis": "left"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Time Since Last Success (with alert threshold)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "dtdurations",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -143,30 +208,26 @@
         "y": 9
       },
       "id": 5,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "$$hashKey": "object:2204",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "downloader_downloader_routeviews_url_error_count  ",
           "format": "time_series",
           "hide": false,
@@ -176,6 +237,9 @@
         },
         {
           "$$hashKey": "object:2205",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "downloader_download_failed_count",
           "format": "time_series",
           "intervalFactor": 1,
@@ -184,71 +248,41 @@
         },
         {
           "$$hashKey": "object:2206",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "downloader_error_count",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "C"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Any Downloader Errors",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 16,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "Data Proc (mlab-oti)",
-          "value": "Data Proc (mlab-oti)"
+          "selected": false,
+          "text": "Data Pipeline (mlab-oti)",
+          "value": "PF9C96A8C3A5902C3"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Datasource",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
-        "regex": "Data Proc .*",
+        "regex": "/Data Pipeline/",
+        "skipUrlSync": false,
         "type": "datasource"
       }
     ]
@@ -285,5 +319,6 @@
   "timezone": "",
   "title": "Alert: DownloaderIsFailingToUpdate",
   "uid": "ZGuYht1mk",
-  "version": 78
+  "version": 78,
+  "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 339,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -40,10 +41,15 @@
       },
       "id": 8,
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "* GCP Billing data is exported per billing account to tables in `mlab-staging.billing.*` and `mlab-oti.billing.*`\n* Partial data is exported hourly, but complete usage for a given hour may not be available until 2 days later\n* Because of the above, the default time range excludes the last 24h",
         "mode": "markdown"
       },
-      "pluginVersion": "9.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -70,7 +76,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "",
@@ -116,20 +122,24 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 1,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "2",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  SUM(cost)/7 AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  DATE(usage_start_time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 8 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)\n  AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL",
           "refId": "A",
@@ -143,6 +153,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -159,7 +186,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "",
@@ -205,20 +232,24 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.1.5",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 1,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "2",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  365*SUM(cost)/7 AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  DATE(usage_start_time) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 8 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)\n  AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL",
           "refId": "A",
@@ -232,6 +263,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -274,7 +322,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "",
@@ -284,6 +332,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -297,6 +346,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -363,11 +413,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND usage_start_time IS NOT NULL AND project.id IS NOT NULL AND cost IS NOT NULL\nGROUP BY\n  date,\n  metric\nORDER BY\n  date\n",
           "refId": "A",
@@ -381,6 +434,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -397,7 +467,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "fieldConfig": {
@@ -406,6 +476,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -419,6 +490,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -482,11 +554,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\nHAVING value > 0.01\nORDER BY\n  date\n",
           "refId": "A",
@@ -500,6 +575,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -516,7 +608,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "Recent data may be delayed by 48 hours",
@@ -526,6 +618,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -539,6 +632,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 0,
             "pointSize": 5,
@@ -603,11 +697,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\nGROUP BY\n  date,\n  metric\nHAVING value > 1\nORDER BY\n  date\n",
           "refId": "A",
@@ -621,6 +718,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -647,6 +761,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -660,6 +775,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -734,12 +850,15 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress_sum\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
           "refId": "B",
@@ -753,6 +872,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -768,12 +904,15 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  sku.description as metric,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 10\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date, metric\nORDER BY\n  date, gce_egress\n",
           "refId": "C",
@@ -787,6 +926,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -830,7 +986,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "",
@@ -840,6 +996,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -853,6 +1010,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -877,7 +1035,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -918,11 +1077,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  project.id AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nORDER BY\n  date\n",
           "refId": "A",
@@ -936,6 +1098,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -952,7 +1131,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "fieldConfig": {
@@ -961,6 +1140,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -974,6 +1154,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -995,7 +1176,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1036,11 +1218,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) AND project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > 0.01\nORDER BY\n  date\n",
           "refId": "A",
@@ -1054,6 +1239,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -1070,7 +1272,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${bqSource}"
       },
       "description": "Recent data may be delayed by 48 hours",
@@ -1080,6 +1282,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1093,6 +1296,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 0,
             "pointSize": 5,
@@ -1114,7 +1318,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1156,11 +1361,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${bqSource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, HOUR) AS date,\n  service.description AS metric,\n  SUM(cost) AS value,\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time) and project.id = \"$project\"\nGROUP BY\n  date,\n  metric\nHAVING value > .1\nORDER BY\n  date\n",
           "refId": "A",
@@ -1174,6 +1382,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -1190,8 +1415,7 @@
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
@@ -1205,14 +1429,137 @@
           "type": "doitintl-bigquery-datasource",
           "uid": "${bqSource}"
         },
-        "definition": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Project",
         "multi": false,
         "name": "project",
         "options": [],
-        "query": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
+        "query": {
+          "0": "S",
+          "1": "E",
+          "2": "L",
+          "3": "E",
+          "4": "C",
+          "5": "T",
+          "6": " ",
+          "7": "p",
+          "8": "r",
+          "9": "o",
+          "10": "j",
+          "11": "e",
+          "12": "c",
+          "13": "t",
+          "14": ".",
+          "15": "i",
+          "16": "d",
+          "17": " ",
+          "18": "F",
+          "19": "R",
+          "20": "O",
+          "21": "M",
+          "22": " ",
+          "23": "`",
+          "24": "m",
+          "25": "l",
+          "26": "a",
+          "27": "b",
+          "28": "-",
+          "29": "o",
+          "30": "t",
+          "31": "i",
+          "32": ".",
+          "33": "b",
+          "34": "i",
+          "35": "l",
+          "36": "l",
+          "37": "i",
+          "38": "n",
+          "39": "g",
+          "40": ".",
+          "41": "u",
+          "42": "n",
+          "43": "i",
+          "44": "f",
+          "45": "i",
+          "46": "e",
+          "47": "d",
+          "48": "`",
+          "49": " ",
+          "50": "W",
+          "51": "H",
+          "52": "E",
+          "53": "R",
+          "54": "E",
+          "55": " ",
+          "56": "p",
+          "57": "r",
+          "58": "o",
+          "59": "j",
+          "60": "e",
+          "61": "c",
+          "62": "t",
+          "63": ".",
+          "64": "i",
+          "65": "d",
+          "66": " ",
+          "67": "I",
+          "68": "S",
+          "69": " ",
+          "70": "N",
+          "71": "O",
+          "72": "T",
+          "73": " ",
+          "74": "N",
+          "75": "U",
+          "76": "L",
+          "77": "L",
+          "78": " ",
+          "79": "G",
+          "80": "R",
+          "81": "O",
+          "82": "U",
+          "83": "P",
+          "84": " ",
+          "85": "B",
+          "86": "Y",
+          "87": " ",
+          "88": "p",
+          "89": "r",
+          "90": "o",
+          "91": "j",
+          "92": "e",
+          "93": "c",
+          "94": "t",
+          "95": ".",
+          "96": "i",
+          "97": "d",
+          "editorMode": "code",
+          "format": 1,
+          "location": "US",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT project.id FROM `mlab-oti.billing.unified` WHERE project.id IS NOT NULL GROUP BY project.id",
+          "refId": "tempvar",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1222,15 +1569,15 @@
       {
         "current": {
           "selected": false,
-          "text": "BigQuery (mlab-oti)",
-          "value": "BigQuery (mlab-oti)"
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
         },
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "bqSource",
         "options": [],
-        "query": "doitintl-bigquery-datasource",
+        "query": "grafana-bigquery-datasource",
         "queryValue": "",
         "refresh": 1,
         "regex": "/mlab-oti/",
@@ -1241,7 +1588,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "Platform Cluster (mlab-oti)"
+          "value": "WW1Jk2sGk"
         },
         "hide": 0,
         "includeAll": false,
@@ -1278,6 +1625,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 56,
+  "version": 57,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/K8s_SiteOverviewTerse.json
+++ b/config/federation/grafana/dashboards/K8s_SiteOverviewTerse.json
@@ -68,6 +68,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -81,6 +82,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -187,6 +189,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -200,6 +203,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -218,8 +222,6 @@
           },
           "links": [],
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -284,6 +286,7 @@
           "exemplar": true,
           "expr": "avg by (site) (\n  node_memory_Active_bytes{site=\"$site\"}\n  + node_memory_Active_anon_bytes\n  + node_memory_Active_file_bytes\n)",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Used",
@@ -319,6 +322,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -332,6 +336,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -432,6 +437,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -445,6 +451,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -577,6 +584,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -590,6 +598,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -684,16 +693,15 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "Platform Cluster (mlab-oti)"
+          "value": "WW1Jk2sGk"
         },
         "hide": 0,
         "includeAll": false,
@@ -710,14 +718,14 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
-            "virtual",
-            "physical"
+            "physical",
+            "virtual"
           ],
           "value": [
-            "virtual",
-            "physical"
+            "physical",
+            "virtual"
           ]
         },
         "hide": 0,
@@ -810,6 +818,6 @@
   "timezone": "",
   "title": "k8s: Site Overview Terse",
   "uid": "082q1knVz",
-  "version": 19,
+  "version": 24,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_CanaryValidation.json
+++ b/config/federation/grafana/dashboards/NDT_CanaryValidation.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -19,15 +22,19 @@
     ]
   },
   "description": "This dashboard allows to compare the production version of ndt-server with the current canary release(s).",
-  "editable": false,
-  "gnetId": null,
+  "editable": true,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1639523959931,
+  "id": 369,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -36,11 +43,23 @@
       },
       "id": 24,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Summary",
       "type": "row"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Variation in the weighted average of download speeds worldwide, averaged over the selected time range to get a single value.",
       "fieldConfig": {
         "defaults": {
@@ -94,14 +113,20 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 1,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -122,6 +147,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -139,7 +181,10 @@
       "type": "stat"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Variation in the weighted average of logMeanMinRTT for all metros, averaged over the selected time range to get a single value.",
       "fieldConfig": {
         "defaults": {
@@ -180,14 +225,20 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.1.1",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 1,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -208,6 +259,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -226,7 +294,10 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -235,11 +306,23 @@
       },
       "id": 12,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Global Stats",
       "type": "row"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Weighted Geometric Mean of log_mean_speed for all metros",
       "fieldConfig": {
         "defaults": {
@@ -247,6 +330,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -259,6 +345,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -337,17 +424,24 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -368,6 +462,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -385,7 +496,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Weighted Geometric Mean of logMeanMinRTT for all metros",
       "fieldConfig": {
         "defaults": {
@@ -393,6 +507,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -405,6 +522,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -467,17 +585,24 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -498,6 +623,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -515,7 +657,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -523,6 +668,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
@@ -534,6 +682,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -617,17 +766,24 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -648,6 +804,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -661,6 +834,9 @@
         },
         {
           "dataset": "statistics",
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "format": "time_series",
           "group": [],
           "hide": false,
@@ -696,6 +872,9 @@
           ]
         },
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "format": "time_series",
           "group": [],
           "hide": false,
@@ -731,7 +910,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Weighted Geometric Mean of log_mean_speed for all metros, by client",
       "fieldConfig": {
         "defaults": {
@@ -739,6 +921,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -751,6 +936,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -813,18 +999,25 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -845,6 +1038,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -862,7 +1072,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -870,6 +1083,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -881,6 +1097,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -926,18 +1143,25 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -958,6 +1182,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -976,7 +1217,10 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "xIXR1_LMz"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -985,11 +1229,23 @@
       },
       "id": 10,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "xIXR1_LMz"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Download Stats ($metro)",
       "type": "row"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -997,6 +1253,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1008,6 +1267,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1054,18 +1314,25 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -1086,6 +1353,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -1103,13 +1387,18 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1121,6 +1410,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1166,15 +1456,20 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "format": "time_series",
           "group": [],
           "metricColumn": "none",
@@ -1214,7 +1509,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1222,6 +1519,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1233,6 +1533,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1279,15 +1580,20 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
           "dataset": "statistics",
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "format": "time_series",
           "group": [],
           "hide": false,
@@ -1328,7 +1634,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${datasource}",
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
       "description": "",
       "gridPos": {
         "h": 9,
@@ -1375,9 +1684,14 @@
       "targets": [
         {
           "dataset": "statistics",
-          "format": "time_series",
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
@@ -1398,6 +1712,23 @@
             ]
           ],
           "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "table": "ndt_canary_gfr",
           "timeColumn": "test_date",
           "timeColumnType": "DATE",
@@ -1411,6 +1742,9 @@
         },
         {
           "dataset": "statistics",
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "format": "time_series",
           "group": [],
           "hide": false,
@@ -1451,7 +1785,10 @@
       "type": "ae3e-plotly-panel"
     },
     {
-      "datasource": "Platform Cluster (mlab-oti)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WW1Jk2sGk"
+      },
       "description": "NOTE: This should be normalized by number of tests, instead of the raw errors per minute.",
       "fieldConfig": {
         "defaults": {
@@ -1459,6 +1796,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1470,6 +1810,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1515,14 +1856,20 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WW1Jk2sGk"
+          },
           "exemplar": true,
           "expr": "60 * avg(\n     label_replace(\n     rate(ndt7_client_sender_errors_total{deployment=\"ndt\", machine=~\".*$metro.*\"}[$interval]),\n      \"site\",\n      \"$1\",\n      \"machine\",\n      \"mlab[1-4]-([a-zA-Z]{3}\\\\d{2}).+\"\n    )\n) by (site, deployment)",
           "interval": "",
@@ -1530,6 +1877,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WW1Jk2sGk"
+          },
           "exemplar": true,
           "expr": "60 * avg(\n     label_replace(\n     rate(ndt7_client_sender_errors_total{deployment=\"$canary\", machine=~\".*$metro.*\"}[$interval]),\n      \"site\",\n      \"$1\",\n      \"machine\",\n      \"mlab[1-4]-([a-zA-Z]{3}\\\\d{2}).+\"\n    )\n) by (site, deployment)",
           "hide": false,
@@ -1544,43 +1895,37 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 30,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
-          "text": "BigQuery (mlab-oti)",
-          "value": "BigQuery (mlab-oti)"
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
         "multi": false,
         "name": "datasource",
         "options": [],
-        "query": "doitintl-bigquery-datasource",
+        "query": "grafana-bigquery-datasource",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "mlab-oti",
           "value": "mlab-oti"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "project",
         "options": [
@@ -1606,19 +1951,18 @@
         "type": "custom"
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "mlab-oti.statistics.ndt_canary_2021",
           "value": "mlab-oti.statistics.ndt_canary_2021"
         },
-        "datasource": "BigQuery (mlab-oti)",
+        "datasource": {
+          "uid": "BigQuery (mlab-oti)"
+        },
         "definition": "SELECT CONCAT(table_catalog, \".\", table_schema, \".\", table_name) FROM `$project.statistics.INFORMATION_SCHEMA.TABLES` WHERE STARTS_WITH(table_name, 'ndt') OR STARTS_WITH(table_name, 'gfr')",
         "description": "",
-        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "table",
         "options": [],
@@ -1630,7 +1974,6 @@
         "type": "query"
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
           "text": [
@@ -1640,13 +1983,12 @@
             "lga"
           ]
         },
-        "datasource": "BigQuery (mlab-oti)",
+        "datasource": {
+          "uid": "BigQuery (mlab-oti)"
+        },
         "definition": "SELECT DISTINCT METRO FROM $table",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": true,
         "name": "metro",
         "options": [],
@@ -1666,10 +2008,7 @@
           "text": "10m",
           "value": "10m"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
-        "label": null,
         "name": "interval",
         "options": [
           {
@@ -1720,19 +2059,17 @@
         "type": "interval"
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "ist",
           "value": "ist"
         },
-        "datasource": "BigQuery (mlab-oti)",
+        "datasource": {
+          "uid": "BigQuery (mlab-oti)"
+        },
         "definition": "SELECT DISTINCT clientName FROM $table",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
         "multi": false,
         "name": "client",
         "options": [],
@@ -1749,10 +2086,7 @@
           "text": "5000",
           "value": "5000"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
-        "label": null,
         "name": "nclients",
         "options": [
           {
@@ -1766,16 +2100,16 @@
         "type": "textbox"
       },
       {
-        "allValue": null,
         "current": {
           "selected": false,
           "text": "ndt-canary",
           "value": "ndt-canary"
         },
-        "datasource": "BigQuery (mlab-oti)",
+        "datasource": {
+          "uid": "BigQuery (mlab-oti)"
+        },
         "definition": "SELECT DISTINCT NDTVersion FROM $table",
         "description": "The canary version to compare",
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Canary version",
@@ -1799,5 +2133,6 @@
   "timezone": "",
   "title": "NDT: Canary Validation",
   "uid": "kFrLGgLVu",
-  "version": 2
+  "version": 78,
+  "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_EarlyExit.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyExit.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 438,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -42,7 +43,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -85,8 +86,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.000987165223714056,
-              0.018906215497638143
+              -0.001024012632533507,
+              0.0198703998906092
             ],
             "title": {
               "text": "Frequency"
@@ -95,7 +96,7 @@
           }
         },
         "onclick": "",
-        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
+        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
       },
       "targets": [
         {
@@ -103,11 +104,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), ndt7_and_offset AS (\n\n  SELECT *, ARRAY_LENGTH(raw.Download.ServerMeasurements) AS dlm_length, \n  IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS test_type\n  FROM ndt.ndt7\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download is not NULL \n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n   AND (\"ist\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n\n), pdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF(a.MeanThroughputMbps BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM ndt7_and_offset, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
           "refId": "A",
@@ -121,6 +125,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -137,7 +158,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -180,8 +201,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.009137562669518637,
-              0.17361369072085409
+              -0.00968565641076581,
+              0.18402747180455034
             ],
             "title": {
               "text": "Frequency"
@@ -190,7 +211,7 @@
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
+        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
       },
       "targets": [
         {
@@ -198,11 +219,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), ndt7_and_offset AS (\n\n  SELECT *, ARRAY_LENGTH(raw.Download.ServerMeasurements) AS dlm_length, \n  IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS test_type\n  FROM ndt.ndt7\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download is not NULL \n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n   AND (\"ist\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n\n), pdf_sort AS (\n\n  SELECT bucket_left, bucket_right, test_type, IF(raw.Download.ServerMeasurements[OFFSET(dlm_length-1)].TCPInfo.BytesSent/1e6 BETWEEN bucket_left AND bucket_right, 1, 0) AS present,\n  FROM ndt7_and_offset, steps\n\n), pdf_totals AS (  \n\n  SELECT \n    bucket_left AS bytes_sent,\n    test_type,\n    sum(present) AS total_observations, \n  FROM pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n\n), pdf_total_bytes  AS (\n\n  SELECT total_observations, test_type, trunc(bytes_sent,2) as bytes_sent, bytes_sent*total_observations AS total_bytes,\n  FROM pdf_totals\n  ORDER BY bytes_sent\n\n), cdf_tests_and_bytes AS (\n\n  SELECT  \n    bytes_sent AS byte_sent_bucket,\n    test_type,\n    total_bytes AS total_bytes_transmitted,\n    total_bytes / SUM(total_bytes) OVER (PARTITION BY test_type) AS normalized,\n    SUM(total_bytes) OVER (ORDER BY bytes_sent ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_bytes_transmitted_cumulative,\n    SUM(total_observations) OVER (ORDER BY bytes_sent ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_tests_cumulative,\n  FROM pdf_total_bytes\n  ORDER BY bytes_sent\n)\n\nSELECT byte_sent_bucket, normalized, test_type\nFROM cdf_tests_and_bytes",
           "refId": "A",
@@ -216,6 +240,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -245,7 +286,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -254,6 +295,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "Percent",
@@ -267,6 +309,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 6,
@@ -330,14 +373,17 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
           "hide": false,
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH ndt7 AS (\n  SELECT\n    *,\n    IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS typ\n  FROM\n    ndt.ndt7\n  WHERE\n    date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    AND raw.Download is not NULL \n    AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n    AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n    AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n),\n\nagg AS (\n  SELECT\n    TIMESTAMP(date) AS time,\n    typ AS metric,\n    COUNT(*) AS total\n  FROM\n    ndt7\n  GROUP BY\n    date,\n    metric\n)\n\nSELECT\n  time,\n  metric,\n  total / SUM(total) OVER(partition BY time) AS ratio\nFROM\n  agg",
+          "rawSql": "WITH ndt7 AS (\n  SELECT\n    *,\n    IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS typ\n  FROM\n    ndt.ndt7\n  WHERE\n    date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    AND raw.Download is not NULL \n    AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n    AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n    AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n),\n\nagg AS (\n  SELECT\n    TIMESTAMP(date) AS time,\n    typ AS metric,\n    COUNT(*) AS total\n  FROM\n    ndt7\n  GROUP BY\n    date,\n    metric\n)\n\nSELECT\n  time,\n  metric,\n  total / SUM(total) OVER(partition BY time) AS ratio\nFROM\n  agg\nORDER BY time ASC",
           "refId": "B",
           "select": [
             [
@@ -349,6 +395,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -365,7 +428,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -376,6 +439,7 @@
             "seriesBy": "min"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "Test Count",
@@ -389,6 +453,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 6,
@@ -450,13 +515,16 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH ndt7 AS (\n  SELECT\n    *,\n    IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS typ\n  FROM\n    ndt.ndt7\n  WHERE\n    date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    AND raw.Download is not NULL \n    AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n    AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n    AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n)\n\nSELECT\n  TIMESTAMP(date) AS time,\n  typ AS metric,\n  COUNT(*) AS total\nFROM\n  ndt7\nGROUP BY\n  date,\n  metric",
+          "rawSql": "WITH ndt7 AS (\n  SELECT\n    *,\n    IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"Early exit\", \"Full test\") AS typ\n  FROM\n    ndt.ndt7\n  WHERE\n    date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    AND raw.Download is not NULL \n    AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n    AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n    AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n)\n\nSELECT\n  TIMESTAMP(date) AS time,\n  typ AS metric,\n  COUNT(*) AS total\nFROM\n  ndt7\nGROUP BY\n  date,\n  metric\nORDER BY time ASC",
           "refId": "A",
           "select": [
             [
@@ -468,6 +536,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -484,7 +569,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -493,6 +578,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "TB Transferred",
@@ -506,6 +592,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -567,13 +654,16 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH\n ndt7 AS (\n SELECT\n   id,\n   date, \n   IF (\"virtual\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ServerMetadata) AS metadata), \"Virtual\", \"Physical\") AS machine,\n   ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked/1000000 AS totalMB\n FROM\n   ndt.ndt7\n WHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n)\n\nSELECT TIMESTAMP(date) AS time, machine AS metric, SUM(totalMB) / 1000000 AS totalTB \nFROM ndt7 \nGROUP BY date, machine",
+          "rawSql": "WITH\n ndt7 AS (\n SELECT\n   id,\n   date, \n   IF (\"virtual\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ServerMetadata) AS metadata), \"Virtual\", \"Physical\") AS machine,\n   ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked/1000000 AS totalMB\n FROM\n   ndt.ndt7\n WHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n)\n\nSELECT TIMESTAMP(date) AS time, machine AS metric, SUM(totalMB) / 1000000 AS totalTB \nFROM ndt7 \nGROUP BY date, machine\nORDER BY time ASC",
           "refId": "A",
           "select": [
             [
@@ -585,6 +675,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -602,7 +709,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -611,6 +718,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "TB Transferred",
@@ -624,6 +732,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -685,13 +794,16 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH\n ndt7 AS (\n SELECT\n   id,\n   date, \n   IF (\"virtual\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ServerMetadata) AS metadata), \"Virtual\", \"Physical\") AS machine,\n   IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"early exit\", \"full test\") AS length,\n   ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked/1000000 AS totalMB\n FROM\n   ndt.ndt7\n WHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n),\n\nagg AS (\n  SELECT TIMESTAMP(date) AS time, machine, length, SUM(totalMB) / 1000000 AS totalTB \n  FROM ndt7 \n  GROUP BY date, machine, length\n)\n\nSELECT time, CONCAT(machine, ' - ', length) AS metric, totalTB\nFROM agg",
+          "rawSql": "WITH\n ndt7 AS (\n SELECT\n   id,\n   date, \n   IF (\"virtual\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ServerMetadata) AS metadata), \"Virtual\", \"Physical\") AS machine,\n   IF (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata), \"early exit\", \"full test\") AS length,\n   ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked/1000000 AS totalMB\n FROM\n   ndt.ndt7\n WHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\n),\n\nagg AS (\n  SELECT TIMESTAMP(date) AS time, machine, length, SUM(totalMB) / 1000000 AS totalTB \n  FROM ndt7 \n  GROUP BY date, machine, length\n)\n\nSELECT time, CONCAT(machine, ' - ', length) AS metric, totalTB\nFROM agg\nORDER BY time ASC",
           "refId": "A",
           "select": [
             [
@@ -703,6 +815,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "TIMESTAMP",
           "where": [
@@ -719,16 +848,16 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 37,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
-          "text": "BigQuery (mlab-oti)",
-          "value": "BigQuery (mlab-oti)"
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
         },
         "hide": 0,
         "includeAll": false,
@@ -736,10 +865,10 @@
         "multi": false,
         "name": "datasource",
         "options": [],
-        "query": "doitintl-bigquery-datasource",
+        "query": "grafana-bigquery-datasource",
         "queryValue": "",
         "refresh": 1,
-        "regex": "/^BigQuery \\(/",
+        "regex": "/^Google BigQuery/",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -802,7 +931,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -864,6 +993,6 @@
   "timezone": "",
   "title": "NDT: Early Exit",
   "uid": "W8JPPzzIz",
-  "version": 32,
+  "version": 34,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Metro_Performance_Distributions.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 429,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -44,7 +45,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -88,14 +89,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0010875993975004274,
-              0.020664388552508118
+              -0.0014820288296077358,
+              0.02815854776254698
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -103,11 +104,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
@@ -121,6 +125,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -137,7 +158,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "description": "",
@@ -182,14 +203,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0031575176653435713,
-              0.05999283564152785
+              -0.0031141137971075687,
+              0.05916816214504381
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -197,11 +218,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 300, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
@@ -215,6 +239,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -231,7 +272,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "description": "",
@@ -276,14 +317,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0007428484769035815,
-              0.014114121061168047
+              -0.0006716650081073675,
+              0.012761635154039982
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -291,11 +332,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "-- $__timeFilter(date) --date BETWEEN \"2023-03-04\" AND \"2023-03-04\"\nSELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}\")",
           "refId": "A",
@@ -309,6 +353,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -325,7 +386,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -334,6 +395,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -347,6 +409,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -409,13 +472,16 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(date)\n AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\nGROUP by date, metric\nORDER BY date, metric",
+          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(TIMESTAMP(date))\n AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\nGROUP by date, metric\nORDER BY date, metric",
           "refId": "A",
           "select": [
             [
@@ -427,6 +493,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -442,24 +525,23 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "BigQuery (mlab-oti)",
-          "value": "BigQuery (mlab-oti)"
+          "selected": false,
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
         },
         "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "datasource",
         "options": [],
-        "query": "doitintl-bigquery-datasource",
+        "query": "grafana-bigquery-datasource",
         "queryValue": "",
         "refresh": 1,
         "regex": "/(mlab-oti|mlab-staging|mlab-sandbox)/",
@@ -470,7 +552,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "Platform Cluster (mlab-oti)"
+          "value": "WW1Jk2sGk"
         },
         "hide": 1,
         "includeAll": false,
@@ -515,7 +597,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "physical",
             "virtual"
@@ -583,6 +665,6 @@
   "timezone": "",
   "title": "NDT: Metro Performance Distributions",
   "uid": "ZCG2vk8Vk",
-  "version": 19,
+  "version": 4,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
+++ b/config/federation/grafana/dashboards/NDT_Site_Performance_Distributions.json
@@ -24,12 +24,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 428,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -76,14 +77,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.001042863436927351,
-              0.019814405301619667
+              -0.0014937454961432444,
+              0.028381164426721645
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -91,11 +92,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
@@ -109,6 +113,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -125,7 +146,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -172,14 +193,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.003202929744475193,
-              0.06085566514502866
+              -0.001901695239360797,
+              0.03613220954785514
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -187,11 +208,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(0.1, 300, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
@@ -205,6 +229,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -221,7 +262,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -268,14 +309,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0006614702586459183,
-              0.012567934914272447
+              -0.0007089041339997292,
+              0.013469178545994854
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -283,11 +324,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\n\nFROM `ops.ndt7_download_pdf`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\")",
           "refId": "A",
@@ -301,6 +345,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE"
         }
@@ -310,7 +371,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "gridPos": {
@@ -357,14 +418,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0016076626861490546,
-              0.030545591036832034
+              -0.0016833042883833992,
+              0.031982781479284586
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -372,11 +433,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_upload_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\", \"${maskUpload}\" = \"on\")",
           "refId": "A",
@@ -390,6 +454,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -406,7 +487,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "description": "",
@@ -454,14 +535,14 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.002131154867917453,
-              0.0404919424904316
+              -0.0016650735351178233,
+              0.03163639716723864
             ],
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values.buffer;\nvar y = data.series[0].fields[1].values.buffer;\nvar names = data.series[0].fields[2].values.buffer;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
       },
       "targets": [
         {
@@ -469,11 +550,14 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "table",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
           "rawSql": "SELECT\n  xright,\n  CASE \"$mode\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_upload_pdf`(0.1, 500, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${site:regex}\", \"${maskUpload}\" = \"on\")",
           "refId": "A",
@@ -487,6 +571,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -503,7 +604,7 @@
     },
     {
       "datasource": {
-        "type": "doitintl-bigquery-datasource",
+        "type": "grafana-bigquery-datasource",
         "uid": "${datasource}"
       },
       "fieldConfig": {
@@ -512,6 +613,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -525,6 +627,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -584,13 +687,16 @@
             "type": "doitintl-bigquery-datasource",
             "uid": "${datasource}"
           },
-          "format": "time_series",
+          "editorMode": "code",
+          "format": 0,
           "group": [],
+          "location": "US",
           "metricColumn": "none",
           "orderByCol": "1",
           "orderBySort": "1",
+          "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(date)\n AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\nGROUP by date, server.Site\nORDER BY date, server.Site  ",
+          "rawSql": "SELECT TIMESTAMP_TRUNC(a.TestTime, HOUR) as date, server.Site as metric, COUNT(*) as total\nFROM `measurement-lab.ndt_intermediate.extended_ndt7_downloads`\nWHERE\n   $__timeFilter(TIMESTAMP(date))\n AND REGEXP_CONTAINS(server.Site, \"${site:regex}\")\nGROUP by date, server.Site\nORDER BY date, server.Site  ",
           "refId": "A",
           "select": [
             [
@@ -602,6 +708,23 @@
               }
             ]
           ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
           "timeColumn": "-- time --",
           "timeColumnType": "DATE",
           "where": [
@@ -617,24 +740,23 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
           "selected": false,
-          "text": "BigQuery (mlab-oti)",
-          "value": "BigQuery (mlab-oti)"
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
         },
         "hide": 1,
         "includeAll": false,
         "multi": false,
         "name": "datasource",
         "options": [],
-        "query": "doitintl-bigquery-datasource",
+        "query": "grafana-bigquery-datasource",
         "queryValue": "",
         "refresh": 1,
         "regex": "/(mlab-oti|mlab-staging|mlab-sandbox)/",
@@ -645,7 +767,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "Platform Cluster (mlab-oti)"
+          "value": "WW1Jk2sGk"
         },
         "hide": 1,
         "includeAll": false,
@@ -665,15 +787,13 @@
             "lga04",
             "lga05",
             "lga06",
-            "lga08",
-            "lga09"
+            "lga08"
           ],
           "value": [
             "lga04",
             "lga05",
             "lga06",
-            "lga08",
-            "lga09"
+            "lga08"
           ]
         },
         "datasource": {
@@ -698,7 +818,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "physical",
             "virtual"
@@ -795,6 +915,6 @@
   "timezone": "",
   "title": "NDT: Site Performance Distributions",
   "uid": "ZeMq_Ya4k",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -43,7 +43,7 @@ spec:
           # favor of the official one maintained by Grafana. Some dashboards
           # still use datasources created with this plugin.
         - name: GF_INSTALL_PLUGINS
-          value: "doitintl-bigquery-datasource,grafana-bigquery-datasource"
+          value: "doitintl-bigquery-datasource,grafana-bigquery-datasource,nline-plotlyjs-panel"
         - name: GF_SECURITY_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -25,7 +25,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/grafana/grafana/tags/ for the current
       # stable version.
-      - image: grafana/grafana:9.1.5
+      - image: grafana/grafana:10.2.2
         name: grafana-server
         # NOTE: the official Grafana Docker images may set various environment
         # variables which will override configurations in grafana.ini (which is

--- a/k8s/prometheus-federation/deployments/grafana.yml
+++ b/k8s/prometheus-federation/deployments/grafana.yml
@@ -38,12 +38,8 @@ spec:
           value: "/etc/provisioning"
           # This comma-separated list of plugins will be installed on
           # server startup.
-          #
-          # Note: The "doitintl" BQ plugin is unmantained and deprecated in
-          # favor of the official one maintained by Grafana. Some dashboards
-          # still use datasources created with this plugin.
         - name: GF_INSTALL_PLUGINS
-          value: "doitintl-bigquery-datasource,grafana-bigquery-datasource,nline-plotlyjs-panel"
+          value: "grafana-bigquery-datasource,ae3e-plotly-panel"
         - name: GF_SECURITY_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
For the most part, the only dashboards that were broken were ones relying on the doitintl BigQuery plugin and/or the ae3e Plotly Panel plugin. There were a few other small breakages that I took care of too.

NOTE: I _only_ modified/fixed provisioned dashboards. Any adhoc dashboards in sandbox that people have created and use regularly may still be broken. The most common fixes are:

* Modify any datasource variable to use the newer Google BigQuery plugin from Grafana.
* For BigQuery panels, make sure that "Format" for each query panel has an appropriate value (e.g., Table, Time Series).
* In the "Script" section of Plotly Panel configurations remove the `.buffered` field from data sources, since it no longer exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1019)
<!-- Reviewable:end -->
