### PR TITLE
Add new panels showing weekly test count and data volume

### DIFF
--- a/config/federation/grafana/dashboards/NDT_EarlyExit.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyExit.json
@@ -944,7 +944,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  COUNT(*) AS testCount\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  COUNT(*) AS testCount\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND DATE_TRUNC(date, WEEK) != DATE_TRUNC(CURRENT_DATE, WEEK)\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "select": [
             [
@@ -1084,7 +1084,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  SUM(ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked)/1000000000000 AS totalTB\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  SUM(ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked)/1000000000000 AS totalTB\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND DATE_TRUNC(date, WEEK) != DATE_TRUNC(CURRENT_DATE, WEEK)\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "select": [
             [
@@ -1129,7 +1129,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "tags": [],
   "templating": {
@@ -1274,6 +1274,6 @@
   "timezone": "",
   "title": "NDT: Early Exit",
   "uid": "W8JPPzzIz",
-  "version": 35,
+  "version": 39,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/NDT_EarlyExit.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyExit.json
@@ -888,7 +888,7 @@
               "mode": "off"
             }
           },
-          "decimals": 0,
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -944,7 +944,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  COUNT(*) AS testCount\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  COUNT(*) AS testCount\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "select": [
             [
@@ -984,7 +984,7 @@
           ]
         }
       ],
-      "title": "Weekly Tests",
+      "title": "Weekly Tests (IST)",
       "transformations": [],
       "type": "timeseries"
     },
@@ -1084,7 +1084,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  SUM(ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked)/1000000000000 AS totalTB\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  SUM(ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked)/1000000000000 AS totalTB\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND (\"ist\" IN ( SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata))\n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
           "refId": "A",
           "select": [
             [
@@ -1124,7 +1124,7 @@
           ]
         }
       ],
-      "title": "Weekly Data Transferred (combined)",
+      "title": "Weekly Data Transferred (IST)",
       "transformations": [],
       "type": "timeseries"
     }

--- a/config/federation/grafana/dashboards/NDT_EarlyExit.json
+++ b/config/federation/grafana/dashboards/NDT_EarlyExit.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 438,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -86,8 +85,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.001024012632533507,
-              0.0198703998906092
+              -0.0010087298937641136,
+              0.019376447510975305
             ],
             "title": {
               "text": "Frequency"
@@ -201,8 +200,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.00968565641076581,
-              0.18402747180455034
+              -0.009505293176164416,
+              0.18060057034712387
             ],
             "title": {
               "text": "Frequency"
@@ -846,9 +845,291 @@
       "title": "Amount of Data Transferred (split)",
       "transformations": [],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Test Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "group": [],
+          "location": "US",
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  COUNT(*) AS testCount\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Weekly Tests",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "TB Transferred",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "doitintl-bigquery-datasource",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "group": [],
+          "location": "US",
+          "metricColumn": "none",
+          "orderByCol": "1",
+          "orderBySort": "1",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT \n  TIMESTAMP_TRUNC(TIMESTAMP(date), WEEK, \"UTC\") AS time,\n  SUM(ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)].TCPInfo.BytesAcked)/1000000000000 AS totalTB\nFROM \n  ndt.ndt7\nWHERE\n   date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download IS NOT NULL\n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0 \n   AND REGEXP_CONTAINS(SUBSTR(server.Site, 0, 3), '${metro:regex}')\n   AND REGEXP_CONTAINS(server.Site, '${site:regex}')\n   AND REGEXP_CONTAINS(CAST(client.Network.ASNumber AS string), \"${as:regex}\")\nGROUP BY time\nORDER BY time",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "-- value --"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "timeColumn": "-- time --",
+          "timeColumnType": "TIMESTAMP",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Weekly Data Transferred (combined)",
+      "transformations": [],
+      "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": false,
   "schemaVersion": 38,
   "tags": [],
   "templating": {
@@ -986,13 +1267,13 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-4M",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "NDT: Early Exit",
   "uid": "W8JPPzzIz",
-  "version": 34,
+  "version": 35,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds 2 new panels showing the weekly test count and data volume for IST tests.

- [Test count](https://grafana.mlab-sandbox.measurementlab.net/d/W8JPPzzIz/ndt3a-early-exit?orgId=1&viewPanel=15).
- [Data volume](https://grafana.mlab-sandbox.measurementlab.net/d/W8JPPzzIz/ndt3a-early-exit?orgId=1&viewPanel=16).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1021)
<!-- Reviewable:end -->
