### PR TITLE
Increase autoload daily job alert threshold to account for deployments

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1336,7 +1336,7 @@ groups:
     expr: |
       sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily", status="OK"}[6h])) == 0
         OR sum by (experiment, datatype) (increase(autoloader_duration_count{period="daily", status!="OK"}[6h])) > 0
-    for: 3h
+    for: 6h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
Increasing the alert threshold to 6 hours to account for gaps when there are deployments.