### PR TITLE
Update limit for GardenerFailureRateTooHighOrMissing to prevent false alarms

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -879,9 +879,8 @@ groups:
 # GardenerFailureRateTooHigh fires when the number of failed Gardener jobs
 # in the last day rises above 1%.
   - alert: GardenerFailureRateTooHighOrMissing
-    expr: (sum(rate(gardener_jobs_total{status!="success"}[1d])) by (experiment, datatype) /
-      sum(rate(gardener_jobs_total[1d])) by (experiment, datatype)) > 0.01
-    for: 10m
+    expr: (sum(increase(gardener_jobs_total{status!="success"}[1d])) by (experiment, datatype) > 3
+    for: 24h
     labels:
       repo: dev-tracker
       severity: ticket

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -879,7 +879,7 @@ groups:
 # GardenerFailureRateTooHigh fires when the number of failed Gardener jobs
 # in the last day rises above 1%.
   - alert: GardenerFailureRateTooHighOrMissing
-    expr: (sum(increase(gardener_jobs_total{status!="success"}[1d])) by (experiment, datatype) > 3
+    expr: sum(increase(gardener_jobs_total{status!="success"}[1d])) by (experiment, datatype) > 3
     for: 24h
     labels:
       repo: dev-tracker


### PR DESCRIPTION
For what seems like years, the `GardenerFailureRateTooHighOrMissing` will fire periodically and then clear. https://github.com/m-lab/dev-tracker/issues/744 This occurs regularly with the historical reprocessing. This change modifies the alert threshold to greater than 3 failures for more than 24h.

The primary observation is that the total number of failed jobs (not the rate) that trigger this alert is rarely above 3. While any failure is cause for concern (the data has not changed, so it's either random or static failure), until we can investigate the root cause and distinguish between failures that are due to some random event or the same file every time, we can prevent the alert from firing for less critical conditions.

I was surprised to see that the failures occur before the historical reset, closer to current dates. The failures always seem to be "daily=false" for the historical pipeline. I could not identify specific dates yet. But believe I could with more investigation.

See:
* An example from Oct contrasting the date processing of Gardner, the total jobs failed from gardener, the total jobs, the new threshold and the original alert threshold.
* [Prometheus mlab-staging](https://prometheus-data-pipeline.mlab-staging.measurementlab.net/graph?g0.expr=(gardener_state_date%7Bdatatype%3D%22scamper1%22%2C%20experiment%3D%22ndt%22%2C%20state%3D~%22complete%22%7D-time())%20%2F%2086400&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=4w&g0.end_input=2023-10-27%2015%3A46%3A23&g0.moment_input=2023-10-27%2015%3A46%3A23&g1.expr=sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1h%5D))&g1.tab=0&g1.stacked=0&g1.show_exemplars=0&g1.range_input=4w&g1.end_input=2023-10-27%2015%3A46%3A25&g1.moment_input=2023-10-27%2015%3A46%3A25&g1.step_input=300&g2.expr=(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bdatatype%3D%22scamper1%22%7D%5B1d%5D)))%20&g2.tab=0&g2.stacked=0&g2.show_exemplars=0&g2.range_input=4w&g2.end_input=2023-10-27%2015%3A47%3A09&g2.moment_input=2023-10-27%2015%3A47%3A09&g3.expr=sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1d%5D))%3E%203&g3.tab=0&g3.stacked=0&g3.show_exemplars=0&g3.range_input=4w&g3.end_input=2023-10-27%2015%3A47%3A09&g3.moment_input=2023-10-27%2015%3A47%3A09&g4.expr=(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1d%5D))%20%2F%20(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%5B1d%5D)))%20)&g4.tab=0&g4.stacked=0&g4.show_exemplars=0&g4.range_input=4w&g4.end_input=2023-10-27%2015%3A47%3A09&g4.moment_input=2023-10-27%2015%3A47%3A09)
* [Prometheus mlab-oti](https://prometheus-data-pipeline.mlab-oti.measurementlab.net/graph?g0.expr=(gardener_state_date%7Bdatatype%3D%22scamper1%22%2C%20experiment%3D%22ndt%22%2C%20state%3D~%22complete%22%7D-time())%20%2F%2086400&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=4w&g0.end_input=2023-10-27%2015%3A46%3A23&g0.moment_input=2023-10-27%2015%3A46%3A23&g1.expr=sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1h%5D))&g1.tab=0&g1.stacked=0&g1.show_exemplars=0&g1.range_input=4w&g1.end_input=2023-10-27%2015%3A46%3A25&g1.moment_input=2023-10-27%2015%3A46%3A25&g1.step_input=300&g2.expr=(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bdatatype%3D%22scamper1%22%7D%5B1d%5D)))%20&g2.tab=0&g2.stacked=0&g2.show_exemplars=0&g2.range_input=4w&g2.end_input=2023-10-27%2015%3A47%3A09&g2.moment_input=2023-10-27%2015%3A47%3A09&g3.expr=sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1d%5D))%3E%203&g3.tab=0&g3.stacked=0&g3.show_exemplars=0&g3.range_input=4w&g3.end_input=2023-10-27%2015%3A47%3A09&g3.moment_input=2023-10-27%2015%3A47%3A09&g4.expr=(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%7Bstatus!%3D%22success%22%7D%5B1d%5D))%20%2F%20(sum%20by(experiment%2C%20datatype%2C%20daily)%20(increase(gardener_jobs_total%5B1d%5D)))%20)&g4.tab=0&g4.stacked=0&g4.show_exemplars=0&g4.range_input=4w&g4.end_input=2023-10-27%2015%3A47%3A09&g4.moment_input=2023-10-27%2015%3A47%3A09)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1023)
<!-- Reviewable:end -->
