### PR TITLE
fix(dashboard): Include new name for GCE egress in query

### DIFF
--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 339,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -860,7 +859,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress_sum\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  SUM(cost) as gce_egress_sum\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND (sku.description LIKE 'Network Internet Egress%' OR sku.description LIKE 'Network Internet Data Transfer Out %')\n  AND cost > 0\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date\nORDER BY\n  date\n",
           "refId": "B",
           "select": [
             [
@@ -914,7 +913,7 @@
           "orderBySort": "1",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  sku.description as metric,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND sku.description LIKE 'Network Internet Egress%'\n  AND cost > 10\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date, metric\nORDER BY\n  date, gce_egress\n",
+          "rawSql": "SELECT\n  TIMESTAMP_TRUNC(usage_start_time, DAY) AS date,\n  sku.description as metric,\n  SUM(cost) as gce_egress\nFROM\n  `mlab-oti.billing.unified`\nWHERE\n  $__timeFilter(usage_start_time)\n  AND service.description = 'Compute Engine'\n  AND (sku.description LIKE 'Network Internet Egress%' OR sku.description LIKE 'Network Internet Data Transfer Out %')\n  AND cost > 10\n  AND project.id = 'mlab-oti'\nGROUP BY\n  date, metric\nORDER BY\n  date, gce_egress\n",
           "refId": "C",
           "select": [
             [
@@ -1588,7 +1587,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "WW1Jk2sGk"
+          "value": "xXLAihsGz"
         },
         "hide": 0,
         "includeAll": false,
@@ -1625,6 +1624,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 57,
+  "version": 58,
   "weekStart": ""
 }


### PR DESCRIPTION
The GCE network egress dashboard panel stopped showing data after 2023-12-15. Looking more closely this is because the SKU for network egress (used to filter results) has changed names. This change adds both terms to the query.

Patterns previously matching:
* 'Network Internet Egress %'

Are now matched using:
* 'Network Internet Data Transfer Out %'

Historical data remains unchanged, so both expressions are needed in the query.

https://grafana.mlab-sandbox.measurementlab.net/d/a5mC51ZMk/gcp-billing?orgId=1&refresh=5m&viewPanel=31

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1024)
<!-- Reviewable:end -->
