### PR TITLE
Add ndt7 metrics dashboard

### DIFF
--- a/config/federation/grafana/dashboards/BigQuery_NDT7_Metrics.json
+++ b/config/federation/grafana/dashboards/BigQuery_NDT7_Metrics.json
@@ -24,14 +24,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 452,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -119,7 +118,7 @@
           "dataset": "ndt",
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "format": 0,
@@ -157,7 +156,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -243,7 +242,7 @@
           "dataset": "ndt",
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "format": 0,
@@ -281,7 +280,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -365,7 +364,7 @@
           "dataset": "ndt",
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "format": 0,
@@ -403,7 +402,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -487,7 +486,7 @@
           "dataset": "ndt",
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "format": 0,
@@ -525,7 +524,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -642,7 +641,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "format": 1,
@@ -678,7 +677,25 @@
   "schemaVersion": 38,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Google BigQuery (mlab-oti)",
+          "value": "PE8D1C7E267159A85"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "grafana-bigquery-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-30d",
@@ -688,6 +705,6 @@
   "timezone": "",
   "title": "BigQuery: NDT7 Metrics",
   "uid": "bfb0b878-ce73-45a4-b0b2-6881a401cea2",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/BigQuery_NDT7_Metrics.json
+++ b/config/federation/grafana/dashboards/BigQuery_NDT7_Metrics.json
@@ -1,0 +1,693 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 452,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PE8D1C7E267159A85"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Test Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "maxDataPoints": 16000,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "dataset": "ndt",
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PE8D1C7E267159A85"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "location": "US",
+          "partitioned": true,
+          "partitionedField": "date",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "WITH clients AS (\n SELECT\n  TIMESTAMP(date) as time,\n  (SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata WHERE metadata.Name = \"client_name\") as client_name\nFROM `measurement-lab.ndt.ndt7`\nWHERE\n  date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\n AND raw.Download is not NULL \n)\n\nSELECT\n  time, IF(client_name IS NULL, \"UNNAMED\", client_name) as metric, COUNT(*) as total\nFROM clients\nGROUP BY time, metric\nHAVING total > 10\nORDER BY time\n",
+          "refId": "A",
+          "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "ndt7"
+        }
+      ],
+      "title": "NDT7 Downloads per day by client_name",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PE8D1C7E267159A85"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Test Percent",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "dataset": "ndt",
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PE8D1C7E267159A85"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "location": "US",
+          "partitioned": true,
+          "partitionedField": "date",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "WITH ndt7 AS (\nSELECT *, metadata\nFROM `measurement-lab.ndt.ndt7`, UNNEST(raw.Download.ServerMetadata) as metadata\nWHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n AND server.Site is not NULL\n AND raw.Download is not NULL \n AND metadata.Name = \"type\"\n)\n\n/*\nSELECT TIMESTAMP(date) as time, \"virtual\" as metric, COUNTIF(metadata.Value=\"virtual\")/COUNT(*) as ratio FROM ndt7 GROUP BY date, metric\nUNION ALL \nSELECT TIMESTAMP(date) as time, \"physical\" as metric, COUNTIF(metadata.Value=\"physical\")/COUNT(*) as ratio FROM ndt7 GROUP BY date, metric\n*/\n\nSELECT time, metric, total / SUM(total) OVER(partition by time) as ratio FROM (\nSELECT TIMESTAMP(date) as time, metadata.Value as metric, COUNT(*) as total FROM ndt7 GROUP BY date, metric\n) order by time\n\n/*SELECT\n    date, COUNTIF(metadata.Value=\"virtual\") as virtual_total, COUNTIF(metadata.Value=\"physical\") as physical_total, COUNT(*) as total, COUNTIF(metadata.Value=\"virtual\")/COUNT(*) as virtual_ratio\nFROM `measurement-lab.ndt.ndt7`, UNNEST(raw.Download.ServerMetadata) as metadata\nWHERE\n     date > \"2022-10-01\"\n\nGROUP BY date\nORDER BY date\n*/\n\n",
+          "refId": "A",
+          "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "ndt7"
+        }
+      ],
+      "title": "Percentage of NDT7 Downloads to Virtual Machines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PE8D1C7E267159A85"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Test Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "dataset": "ndt",
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PE8D1C7E267159A85"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "location": "US",
+          "partitioned": true,
+          "partitionedField": "date",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT TIMESTAMP(date), CONCAT(server.Site, \"-\", metadata.Value) as metric, count(*) as total \nFROM `measurement-lab.ndt.ndt7`, UNNEST(raw.Download.ServerMetadata) as metadata\nWHERE date between  \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\n AND raw.Download is not NULL \n AND metadata.Name = \"zone\"\n AND server.Site is not NULL\nGROUP BY date, metric\norder by date ",
+          "refId": "A",
+          "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "ndt7"
+        }
+      ],
+      "title": "NDT7 Downloads per day by GCP Zone",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PE8D1C7E267159A85"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Test Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "dataset": "ndt",
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PE8D1C7E267159A85"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "location": "US",
+          "partitioned": true,
+          "partitionedField": "date",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": " \n  SELECT\n    TIMESTAMP(date),\n    client.Geo.CountryCode as metric,\n    COUNT(*) as total,\n  FROM\n    `measurement-lab.ndt.ndt7`\n  WHERE\n    date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    AND server.Geo.Longitude IS NOT NULL\n    AND server.Geo.Latitude IS NOT NULL\n    AND client.Geo.Longitude IS NOT NULL\n    AND client.Geo.Latitude IS NOT NULL\n    AND raw.Download is not NULL\n    AND client.Geo.CountryCode = server.Geo.CountryCode\n  GROUP BY date, metric\n  ORDER BY date ",
+          "refId": "A",
+          "sharded": false,
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "ndt7"
+        }
+      ],
+      "title": "Total tests per Country per day",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PE8D1C7E267159A85"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "green",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 19,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 7,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "value",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.6,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "value",
+                  "fixed": 1,
+                  "max": 7,
+                  "min": 1
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "geohash": "metricx",
+              "latitude": "latitude",
+              "longitude": "longitude",
+              "mode": "coords"
+            },
+            "name": "Layer 3",
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "coords",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 2
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PE8D1C7E267159A85"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "US",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "WITH ndt7 AS (\n  SELECT\n    a.MeanThroughputMbps as rate,\n    client.Geo.Latitude AS latitude,\n    client.Geo.Longitude AS longitude,\n  FROM\n    `measurement-lab.ndt.ndt7`\n  WHERE\n      date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n    -- Basic test quality filters for safe division.\n    AND raw.Download is not NULL\n),\ntests AS (\nSELECT\n  latitude, longitude,\n  APPROX_QUANTILES(rate, 10)[OFFSET(5)] AS value,\n  COUNT(*) as value_tests,\nFROM\n  ndt7\nGROUP BY\n  latitude, longitude\nHAVING\n  value_tests > 10\n  AND value IS NOT NULL\n  AND latitude IS NOT NULL and longitude IS NOT NULL\n)\n\nSELECT CURRENT_TIMESTAMP() as time,\n   latitude, longitude, value\nFROM tests\nLIMIT 2500\n",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "NDT7 Download Median Rate per unique Lat/Lon pair",
+      "type": "geomap"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "BigQuery: NDT7 Metrics",
+  "uid": "bfb0b878-ce73-45a4-b0b2-6881a401cea2",
+  "version": 3,
+  "weekStart": ""
+}


### PR DESCRIPTION
This change adds a dashboard to our set of supported dashboards so that two often referenced panels are always available.

The most important panels are:
* percentage of tests targeting virtual servers
* counts of tests by client_name -  showing relative distribution and scale of various client integrations
* counts of daily tests by country and gcp region

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1026)
<!-- Reviewable:end -->
