### PR TITLE
Eliminates all usage of "ndt.iupui" and "neubot.mlab"

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ For example:
             "service": "sidestream"
         },
         "targets": [
-            "npad.iupui.mlab4.mia03.measurement-lab.org:9090"
+            "ndt-mlab4-mia03.measurement-lab.org:9090"
         ]
     }
 ]

--- a/config/federation/grafana/dashboards/MLABNS_6_HourClients.json
+++ b/config/federation/grafana/dashboards/MLABNS_6_HourClients.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": false,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -14,25 +17,31 @@
   },
   "description": "Monitor behavior of clients running tests to NDT & Neubot every 6 hours",
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1554149766293,
+  "id": 69,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "The query used to collect these counts is based on the one used by mlab-ns-rate-limiter.\n\nTimestamps are offset 15m later than actual time.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 14,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -47,7 +56,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "10.2.2",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -62,6 +75,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "bq_mlabns_sixhour_requests",
           "format": "time_series",
           "interval": "5m",
@@ -70,17 +86,20 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (index)(8 * rate(sidestream_transmit_bytes_total{index=~\"neubot.mlab|ndt.iupui\"}[5m] offset 15m))",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (index)(8 * rate(sidestream_transmit_bytes_total{index=~\"neubot|ndt\"}[5m] offset 15m))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Bandwidth - {{index}}",
+          "range": true,
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Raw 5m Request Counts to MLAB-NS by 6-hour clients",
       "tooltip": {
         "shared": true,
@@ -89,9 +108,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -100,39 +117,35 @@
           "format": "short",
           "label": "mlab-ns Requests",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "bps",
           "label": "Sidestream Bandwidth",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
-  "refresh": false,
-  "schemaVersion": 16,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "tags": [],
+          "selected": false,
           "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "value": "000000008"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Datasource",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -175,5 +188,6 @@
   "timezone": "utc",
   "title": "MLAB-NS: 6-hour Client Counts",
   "uid": "CR4zGH6mk",
-  "version": 6
+  "version": 2,
+  "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
+++ b/config/federation/grafana/dashboards/MLABNS_PrometheusQueries.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -13,23 +16,20 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 357,
-  "iteration": 1628630520671,
+  "id": 89,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -57,7 +57,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -67,16 +67,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt_ssl$protocol\"} OR\n    script_success{service=\"ndt5_client\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt_ssl$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt_ssl$protocol\"} OR\n    script_success{service=\"ndt5_client\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt_ssl$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ndt5 (wss) $protocol: % up",
       "tooltip": {
         "shared": true,
@@ -85,33 +88,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "percentunit",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -119,12 +114,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -152,7 +144,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -162,16 +154,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt7$protocol\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt.iupui\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt.iupui\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt7$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"ndt7$protocol\"} OR\n    label_replace(((node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n      node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}) /\n        node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}),\n        \"experiment\", \"ndt\", \"\", \"\") < bool 0.95 OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"ndt\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"ndt\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"ndt7$protocol\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ndt7 $protocol: % up",
       "tooltip": {
         "shared": true,
@@ -180,33 +175,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "percentunit",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -214,14 +201,11 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
       },
+      "description": "",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -248,7 +232,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -258,16 +242,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} OR\n    probe_success{service=\"neubot_tls$protocol\", experiment=\"neubot\"} OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"neubot.mlab\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  min by (experiment, machine) (\n    probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} OR\n    probe_success{service=\"neubot_tls$protocol\", experiment=\"neubot\"} OR\n    label_replace(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"},\n      \"experiment\", \"neubot\", \"\", \"\") != bool 1 OR\n    label_replace(gmx_machine_maintenance, \"experiment\", \"neubot\", \"\", \"\") != bool 1\n  )\n) /\ncount(\n  probe_success{service=\"neubot$protocol\", experiment=\"neubot\"} unless on(machine)\n  (gmx_machine_maintenance == 1 unless on(machine) kube_node_status_condition)\n)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "neubot $protocol: % up",
       "tooltip": {
         "shared": true,
@@ -276,33 +263,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "percentunit",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -310,12 +289,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -343,7 +318,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -353,6 +328,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum (\n  node_filesystem_size_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"} -\n  node_filesystem_avail_bytes{cluster=\"platform\", mountpoint=\"/cache/data\"}\n)\n              ",
           "interval": "",
           "legendFormat": "",
@@ -360,9 +338,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Disk space used (sum)",
       "tooltip": {
         "shared": true,
@@ -371,33 +347,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "decbytes",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -405,12 +372,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -438,7 +401,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -448,6 +411,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(probe_success{service=\"ndt_ssl$protocol\"})",
           "interval": "",
           "legendFormat": "",
@@ -455,9 +421,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ndt5 (wss) $protocol: probe_success",
       "tooltip": {
         "shared": true,
@@ -466,33 +430,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -500,12 +456,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -533,7 +485,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -543,6 +495,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(probe_success{service=\"ndt7$protocol\"})",
           "interval": "",
           "legendFormat": "",
@@ -550,9 +505,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ndt7 $protocol: probe_success",
       "tooltip": {
         "shared": true,
@@ -561,33 +514,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -595,14 +540,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
+      "description": "",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -629,7 +570,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -639,6 +580,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(probe_success{service=\"neubot$protocol\", experiment=\"neubot\"})",
           "interval": "",
           "legendFormat": "",
@@ -646,9 +590,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "neubot $protocol: probe_success",
       "tooltip": {
         "shared": true,
@@ -657,33 +599,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -691,12 +625,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -724,7 +654,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -734,6 +664,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "count(gmx_machine_maintenance == 1)\n              ",
           "interval": "",
           "legendFormat": "",
@@ -741,9 +674,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "GMXed nodes (count)",
       "tooltip": {
         "shared": true,
@@ -752,33 +683,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -786,12 +708,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -819,7 +737,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -829,6 +747,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(script_success{service=\"ndt5_client\"})",
           "interval": "",
           "legendFormat": "",
@@ -836,9 +757,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ndt5 (wss) IPv4: e2e",
       "tooltip": {
         "shared": true,
@@ -847,33 +766,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -881,12 +792,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "uid": "$datasource"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -914,7 +821,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -924,12 +831,18 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "count(kube_node_spec_taint{cluster=\"platform\", key=\"lame-duck\"})\n              ",
           "interval": "",
           "legendFormat": "nodes",
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "count(lame_duck_experiment{cluster=\"platform\"} == 1)",
           "interval": "",
           "legendFormat": "experiments",
@@ -937,9 +850,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Lame-ducks (count)",
       "tooltip": {
         "shared": true,
@@ -948,39 +859,29 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
-  "refresh": false,
-  "schemaVersion": 26,
-  "style": "dark",
+  "refresh": "",
+  "schemaVersion": 38,
   "tags": [],
   "templating": {
     "list": [
@@ -988,9 +889,8 @@
         "current": {
           "selected": false,
           "text": "Prometheus (mlab-oti)",
-          "value": "Prometheus (mlab-oti)"
+          "value": "000000008"
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -1005,13 +905,11 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "IPv4",
           "value": ""
         },
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Protocol",
@@ -1044,5 +942,6 @@
   "timezone": "",
   "title": "MLAB-NS: Prometheus Queries",
   "uid": "T-t8rWwGz",
-  "version": 20
+  "version": 5,
+  "weekStart": ""
 }

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -259,10 +259,10 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+              "experiment", "ndt", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
           )
         ) /
         count(
@@ -291,10 +291,10 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+              "experiment", "ndt", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
           )
         ) /
         count(
@@ -323,10 +323,10 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+              "experiment", "ndt", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
           )
         ) /
         count(
@@ -356,10 +356,10 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+              "experiment", "ndt", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
           )
         ) /
         count(
@@ -387,11 +387,11 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
+              "experiment", "ndt", "", "") != bool 1 OR
             lame_duck_experiment{cluster="platform"} != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
         )
         ) /
         count(
@@ -419,11 +419,11 @@ groups:
             label_replace(((node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform", mountpoint="/cache/data"}),
-                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+                "experiment", "ndt", "", "") < bool 0.95 OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "ndt.iupui", "", "") != bool 1 OR
+              "experiment", "ndt", "", "") != bool 1 OR
             lame_duck_experiment{cluster="platform"} != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt", "", "") != bool 1
         )
         ) /
         count(
@@ -450,8 +450,8 @@ groups:
             probe_success{service="neubot"} OR
             probe_success{service="neubot_tls"} OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "neubot.mlab", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
+              "experiment", "neubot", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "neubot", "", "") != bool 1
           )
         ) /
         count(
@@ -478,8 +478,8 @@ groups:
             probe_success{service="neubot_ipv6"} OR
             probe_success{service="neubot_tls_ipv6"} OR
             label_replace(kube_node_spec_taint{cluster="platform", key="lame-duck"},
-              "experiment", "neubot.mlab", "", "") != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
+              "experiment", "neubot", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "neubot", "", "") != bool 1
           )
         ) /
         count(

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -335,12 +335,11 @@ scrape_configs:
       # consistency with our legacy way of doing things.
       #
       # TODO: In the future we may drop the 'experiment' label altogether in
-      # favor of some native k8s one (e.g., 'deployment'), or to at the very
-      # least shorten the name to just 'ndt'
+      # favor of some native k8s one (e.g., 'deployment').
       - source_labels: [deployment]
         regex: ndt.*
         target_label: experiment
-        replacement: ndt.iupui
+        replacement: ndt
 
       # Rewrite the machine label to make it easier to join these metrics with
       # existing metrics that use machine instead of the node label.
@@ -680,11 +679,9 @@ scrape_configs:
         replacement: ${1}
 
       # Create an "fqdn" label for each target host, which will vary depending
-      # on the service. TODO(kinkade): once the ".iupui" suffix is entirely
-      # retired from the platform, modify the regexp to simply use the entire
-      # experiment label's value.
+      # on the service.
       - source_labels: [__address__, experiment]
-        regex: (.*);([a-z0-9]+)\.?.*
+        regex: (.*);(.*)
         target_label: fqdn
         replacement: ${2}-${1}
 

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -50,7 +50,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=ndt7 \
       --label module=tcp_v4_tls_online \
       --project "${project}" \
-      --select "ndt.iupui" > \
+      --select "ndt" > \
           ${output}/blackbox-targets/ndt7.json
 
   # ndt7 SSL on port 443 over IPv6
@@ -61,7 +61,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label module=tcp_v6_tls_online \
       --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
-      --select "ndt.iupui" \
+      --select "ndt" \
       --decoration "v6" > \
           ${output}/blackbox-targets-ipv6/ndt7_ipv6.json
 
@@ -72,7 +72,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=ndt_raw \
       --label module=tcp_v4_online \
       --project "${project}" \
-      --select "ndt.iupui" > \
+      --select "ndt" > \
           ${output}/blackbox-targets/ndt_raw.json
 
   # NDT "raw" on port 3001 over IPv6
@@ -83,7 +83,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label module=tcp_v6_online \
       --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
-      --select "ndt.iupui" \
+      --select "ndt" \
       --decoration "v6" > \
           ${output}/blackbox-targets-ipv6/ndt_raw_ipv6.json
 
@@ -94,7 +94,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=ndt_ssl \
       --label module=tcp_v4_tls_online \
       --project "${project}" \
-      --select "ndt.iupui" > \
+      --select "ndt" > \
           ${output}/blackbox-targets/ndt_ssl.json
 
   # NDT SSL on port 3010 over IPv6
@@ -105,7 +105,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label module=tcp_v6_tls_online \
       --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
-      --select "ndt.iupui" \
+      --select "ndt" \
       --decoration "v6" > \
           ${output}/blackbox-targets-ipv6/ndt_ssl_ipv6.json
 
@@ -114,7 +114,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --sites="${sites}" \
       --template_target={{hostname}} \
       --label service=ndt5_client \
-      --label experiment=ndt.iupui \
+      --label experiment=ndt \
       --project "${project}" > \
           ${output}/script-targets/ndt5_client.json
 
@@ -134,7 +134,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=neubot \
       --label module=tcp_v4_online \
       --project "${project}" \
-      --select "neubot.mlab" > \
+      --select "neubot" > \
           ${output}/blackbox-targets/neubot.json
 
   # neubot on port 80 over IPv6
@@ -146,7 +146,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label __blackbox_port=${!bbe_port} \
       --decoration "v6" \
       --project "${project}" \
-      --select "neubot.mlab" > \
+      --select "neubot" > \
           ${output}/blackbox-targets-ipv6/neubot_ipv6.json
 
   # neubot TLS on port 443 over IPv4
@@ -156,7 +156,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label service=neubot_tls \
       --label module=tcp_v4_tls_online \
       --project "${project}" \
-      --select "neubot.mlab" > \
+      --select "neubot" > \
           ${output}/blackbox-targets/neubot_tls.json
 
   # neubot TLS on port 443 over IPv6
@@ -168,7 +168,7 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --label __blackbox_port=${!bbe_port} \
       --decoration "v6" \
       --project "${project}" \
-      --select "neubot.mlab" > \
+      --select "neubot" > \
           ${output}/blackbox-targets-ipv6/neubot_tls_ipv6.json
 
   # ICMP probe for platform switches


### PR DESCRIPTION
We haven't used experiment names or DNS names of "ndt.iupui" or "ndt-iupui" or "neubot.mlab" or "neubot-mlab" in a very long time. And, recently we even removed the experiments of those names from experiments.jsonnet in site. This PR remove all references to those old names  and replaces them, where appropriate, with just "ndt' and "neubot".

One of the primary changes in this PR is to remove "iupui" and "mlab" from the `--select` flag of mlabconfig.py, such that it generates blackbox_exporter and script_exporter targets with the proper names, which should clear a staging MlabNS_NdtMetricsMissing alert we got for missing metrics.

Though they aren't used any longer, and are probably broken in several ways, I also went ahead and removed references to those old experiment names from a couple of MLABNS dashboards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1028)
<!-- Reviewable:end -->
