### PR TITLE
Make Locate_TooManyErrors a pageable alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -592,6 +592,7 @@ groups:
       repo: dev-tracker
       severity: page
       cluster: prometheus-federation
+      page_project: mlab-oti
     annotations:
       summary: The rate of Locate V2 nearest request errors is greater than 0.1%.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#locate_toomanyerrors

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -590,7 +590,7 @@ groups:
     for: 2m
     labels:
       repo: dev-tracker
-      severity: ticket
+      severity: page
       cluster: prometheus-federation
     annotations:
       summary: The rate of Locate V2 nearest request errors is greater than 0.1%.


### PR DESCRIPTION
This PR adds the `severity: page` label to the `Locate_TooManyErrors` alert following the discussion at the team meeting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1030)
<!-- Reviewable:end -->
