### PR TITLE
Add BigQuery billing metrics and alert

### DIFF
--- a/config/federation/bigquery/bq_billing.sql
+++ b/config/federation/bigquery/bq_billing.sql
@@ -27,7 +27,7 @@ WITH billing AS(
       WHEN DATE(usage_start_time) <= CURRENT_DATE() THEN "month"
       END
       AS period,
-    IF(service.description LIKE '%Storage%', "storage", "all") AS service,
+    service.description AS service,
     cost
   FROM
     `mlab-oti.billing.unified`
@@ -42,9 +42,14 @@ SELECT
   SUM(IF(period = "month", cost, 0)) AS value_average_monthly,
   365*SUM(IF(period = "month", cost, 0))/30 AS value_average_annual,
   -- Storage metrics.
-  SUM(IF(period = "month" AND service = "storage", cost, 0))/30 AS value_average_daily_storage,
-  SUM(IF(period = "today" AND service = "storage", cost, 0)) AS value_today_storage,
-  SUM(IF(period = "yesterday" AND service = "storage", cost, 0)) AS value_yesterday_storage,
-  SUM(IF(period = "before_yesterday" AND service = "storage", cost, 0)) AS value_before_yesterday_storage
+  SUM(IF(period = "month" AND service = "Cloud Storage", cost, 0))/30 AS value_average_daily_storage,
+  SUM(IF(period = "today" AND service = "Cloud Storage", cost, 0)) AS value_today_storage,
+  SUM(IF(period = "yesterday" AND service = "Cloud Storage", cost, 0)) AS value_yesterday_storage,
+  SUM(IF(period = "before_yesterday" AND service = "Cloud Storage", cost, 0)) AS value_before_yesterday_storage,
+  -- BigQuery metrics.
+  SUM(IF(period = "month" AND service = "BigQuery", cost, 0))/30 AS value_average_daily_bigquery,
+  SUM(IF(period = "today" AND service = "BigQuery", cost, 0)) AS value_today_bigquery,
+  SUM(IF(period = "yesterday" AND service = "BigQuery", cost, 0)) AS value_yesterday_bigquery,
+  SUM(IF(period = "before_yesterday" AND service = "BigQuery", cost, 0)) AS value_before_yesterday_bigquery
 FROM
   billing

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1363,3 +1363,23 @@ groups:
       summary: Daily storage costs are 50% over the average storage costs for the month.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#billing_dailystorageincrease
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/d8145875-e912-484e-b8f2-b77f63bd28a3/cloud-storage-usage?orgId=1
+
+# Billing_DailyBigQueryIncrease fires when the daily BigQuery costs for any of the last 3 days is 2x
+# the average BigQuery costs for the last 30 days.
+# Because the GCP billing export may take over a day to complete, the alert checks as far as 2 days back
+# to get an accurate measure of the daily costs. That said, even if only with partial data, we
+# opportunistically also check today's and yesterday's cost.
+  - alert: Billing_DailyBigQueryIncrease
+    expr: |
+     bq_billing_today_bigquery > bq_billing_average_daily_bigquery * 2
+      OR bq_billing_yesterday_bigquery > bq_billing_average_daily_bigquery * 2
+      OR bq_billing_before_yesterday_bigquery > bq_billing_average_daily_bigquery * 2
+    for: 10m
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: Daily BigQuery costs are 2x the average BigQuery costs for the month.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#billing_dailybigqueryincrease
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/f4efc343-661f-4899-a00f-a4ffeb294e5d/bigquery-usage?orgId=1&from=now-7d&to=now


### PR DESCRIPTION
This PR adds metrics and an alert to monitor BigQuery usage cost increases (2x the monthly average).

Similar work was done to monitor GCS costs (https://github.com/m-lab/prometheus-support/pull/1033).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1037)
<!-- Reviewable:end -->
