### PR TITLE
Add legend to GCP Billing 'Cost per service' panel

### DIFF
--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -1587,7 +1587,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "WW1Jk2sGk"
+          "value": "xXLAihsGz"
         },
         "hide": 0,
         "includeAll": false,

--- a/config/federation/grafana/dashboards/GCP_Billing.json
+++ b/config/federation/grafana/dashboards/GCP_Billing.json
@@ -1198,11 +1198,11 @@
       "options": {
         "legend": {
           "calcs": [
-            "max"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right",
-          "showLegend": false,
+          "showLegend": true,
           "sortBy": "Max",
           "sortDesc": true
         },
@@ -1587,7 +1587,7 @@
         "current": {
           "selected": false,
           "text": "Platform Cluster (mlab-oti)",
-          "value": "xXLAihsGz"
+          "value": "WW1Jk2sGk"
         },
         "hide": 0,
         "includeAll": false,
@@ -1624,6 +1624,6 @@
   "timezone": "",
   "title": "GCP Billing",
   "uid": "a5mC51ZMk",
-  "version": 58,
+  "version": 59,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a legend with mean costs per service to the "Cost per service (per day) (measurement-lab)" [panel](https://grafana.mlab-sandbox.measurementlab.net/d/a5mC51ZMk/gcp-billing?orgId=1&refresh=5m&from=now-8d&to=now-1d&viewPanel=11) in the GCP Billing dashboard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1038)
<!-- Reviewable:end -->
