### PR TITLE
Update alerts in BigQuery exporter 24h  deployment

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -841,13 +841,13 @@ groups:
 
 # GardenerHistoricalThroughputIsStalled fires when historical reprocessing for
 # datatypes under processing by the v2 pipeline falls below 1 date / day.
-# The bq_gardener_historical_throughput metric is under the bigquery exporter 3h
-# deployment, so the timeout for this alert is 4 hours.
+# The bq_gardener_historical_throughput metric is under the bigquery exporter 24h
+# deployment, so the timeout for this alert is 48 hours.
   - alert: GardenerHistoricalThroughputIsStalled
     expr: |
       increase(gardener_jobs_total{status="success", daily="false"}[1d]) > 0
         UNLESS ON(experiment, datatype) bq_gardener_historical_throughput > 0
-    for: 8h
+    for: 48h
     labels:
       repo: dev-tracker
       severity: ticket
@@ -863,7 +863,7 @@ groups:
   - alert: GardenerConfigDatatypeMissingInGardenerHistoricalThroughputQuery
     expr: |
       gardener_config_datatypes UNLESS ON(experiment, datatype) bq_gardener_historical_throughput
-    for: 8h
+    for: 48h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
This PR updates the threshold for the alerts using metrics in the BQ exporter 24h deployment to fire after 48h.