### PR TITLE
Updates Prometheus version from v2.31.1 to v2.51.2

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -42,7 +42,7 @@ spec:
       containers:
       # Check https://hub.docker.com/r/prom/prometheus/tags/ for the current
       # stable version.
-      - image: prom/prometheus:v2.31.1
+      - image: prom/prometheus:v2.51.2
         # Note: the container name appears to be ignored and the actual pod name
         # is derived from the Deployment.metadata.name. However, removing this
         # value results in a configuration error.


### PR DESCRIPTION
v2.31.1 was released in late 2021! I gave a quick look over the changeslogs for each minor version update, and I didn't see anything that would obviously affect our deployment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1041)
<!-- Reviewable:end -->
