### PR TITLE
Add initial dashboard to visualize packet testing results

### DIFF
--- a/config/federation/grafana/dashboards/Packet_Testing.json
+++ b/config/federation/grafana/dashboards/Packet_Testing.json
@@ -1,0 +1,840 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 465,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "panels": [],
+      "title": "Packet Pair",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "bucketOffset": 0,
+        "bucketSize": 50,
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "count"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT m.Bandwidth \nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND m.Packets[SAFE_OFFSET(0)].Gap = 0",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Bandwidth (Mbps)",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "options": {
+        "displayLabels": [
+          "name",
+          "value"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Packet size (bytes)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 9,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Size AS string) As size_bytes\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size_bytes",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Average bandwidth (Mbps) for size (bytes)",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Gap"
+          }
+        ]
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Gap size (microseconds)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Gap AS string) As gap_usecs\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY gap_usecs",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Average bandwidth (Mbps) for gap (microseconds)",
+      "type": "barchart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Packet Train",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 1,
+      "options": {
+        "bucketOffset": 0,
+        "bucketSize": 50,
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "count"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT m.Bandwidth \nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Bandwidth (Mbps)",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 6,
+      "options": {
+        "displayLabels": [
+          "name",
+          "value"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Packet size (bytes)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Gap size (microseconds)",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Packet Testing",
+  "uid": "d341c044-4e2c-4904-b05f-98e8bf1bbf32",
+  "version": 13,
+  "weekStart": ""
+}

--- a/config/federation/grafana/dashboards/Packet_Testing.json
+++ b/config/federation/grafana/dashboards/Packet_Testing.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 465,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -106,7 +105,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT m.Bandwidth \nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND m.Packets[SAFE_OFFSET(0)].Gap = 0",
+          "rawSql": "SELECT m.Bandwidth \nFROM `raw_pt.pair1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND m.Packets[SAFE_OFFSET(0)].Gap = 0",
           "refId": "A",
           "sql": {
             "columns": [
@@ -197,7 +196,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
+          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
           "refId": "A",
           "sql": {
             "columns": [
@@ -306,7 +305,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Size AS string) As size_bytes\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size_bytes",
+          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Size AS string) As size_bytes\nFROM `raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size_bytes",
           "refId": "A",
           "sql": {
             "columns": [
@@ -402,7 +401,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
+          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
           "refId": "A",
           "sql": {
             "columns": [
@@ -510,7 +509,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Gap AS string) As gap_usecs\nFROM `mlab-sandbox.raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY gap_usecs",
+          "rawSql": "SELECT AVG(m.Bandwidth) AS avg_bandwidth, CAST(p.Gap AS string) As gap_usecs\nFROM `raw_pt.pair1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY gap_usecs",
           "refId": "A",
           "sql": {
             "columns": [
@@ -614,7 +613,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT m.Bandwidth \nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"",
+          "rawSql": "SELECT m.Bandwidth \nFROM `raw_pt.train1`, UNNEST(raw.Measurements) AS m\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"",
           "refId": "A",
           "sql": {
             "columns": [
@@ -705,7 +704,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
+          "rawSql": "SELECT CAST(p.Size AS string) As size, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nGROUP BY size\nORDER BY Percent",
           "refId": "A",
           "sql": {
             "columns": [
@@ -796,7 +795,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `mlab-sandbox.raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
+          "rawSql": "SELECT p.Gap AS Gap, (COUNT(*)/(SUM(COUNT(*)) OVER())) * 100 AS Percent\nFROM `raw_pt.train1`, UNNEST(raw.Measurements) AS m, UNNEST(m.Packets) AS p\nWHERE date between \"${__from:date:YYYY-MM-DD}\" and \"${__to:date:YYYY-MM-DD}\"\nAND gap IS NOT NULL\nGROUP BY Gap",
           "refId": "A",
           "sql": {
             "columns": [
@@ -835,6 +834,6 @@
   "timezone": "",
   "title": "Packet Testing",
   "uid": "d341c044-4e2c-4904-b05f-98e8bf1bbf32",
-  "version": 13,
+  "version": 14,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a new [dashboard](https://grafana.mlab-sandbox.measurementlab.net/d/d341c044-4e2c-4904-b05f-98e8bf1bbf32/packet-testing?orgId=1) to visualize packet testing results. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1042)
<!-- Reviewable:end -->
