### PR TITLE
Reduce sensitivity of Parser alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -909,7 +909,7 @@ groups:
     expr: (sum(rate(etl_task_total{status!="OK", cluster="data-pipeline"}[1h])) by (table) /
       sum(rate(etl_task_total{cluster="data-pipeline"}[1h])) by (table)) > 0.01
       OR absent(etl_task_total{cluster="data-pipeline"})
-    for: 10m
+    for: 3h
     labels:
       repo: dev-tracker
       severity: ticket


### PR DESCRIPTION
This PR reduces the sensitivity of the `ParserFailureRateTooHighOrMissing` alert. The alert recently [fired](https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=(sum(rate(etl_task_total%7Bstatus!%3D%22OK%22%2C%20cluster%3D%22data-pipeline%22%7D%5B1h%5D))%20by%20(table)%20%2F%0A%20%20%20%20%20%20sum(rate(etl_task_total%7Bcluster%3D%22data-pipeline%22%7D%5B1h%5D))%20by%20(table))%20%3E%200.01%0A%20%20%20%20%20%20OR%20absent(etl_task_total%7Bcluster%3D%22data-pipeline%22%7D)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=12h) because of an ephemeral event that lasted ~20 mins (could be caused because of a pod restart).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1045)
<!-- Reviewable:end -->
