### PR TITLE
Add bqx query and alert for missing NDT/scamper1 data

### DIFF
--- a/config/federation/bigquery/bq_sidecar.sql
+++ b/config/federation/bigquery/bq_sidecar.sql
@@ -16,8 +16,8 @@ WITH scamper1 AS (
 
 SELECT
   n.server.Site AS site,
-  COUNTIF(n.id IS NOT NULL) AS value_ndt,
-  COUNTIF(n.id IS NOT NULL AND s.id IS NOT NULL) AS value_matching,
+  COUNTIF(n.id IS NOT NULL) AS value_ndt_total,
+  COUNTIF(n.id IS NOT NULL AND s.id IS NOT NULL) AS value_scamper1_matching,
 
 FROM ndt7 AS n
   FULL OUTER JOIN scamper1 AS s
@@ -30,4 +30,4 @@ GROUP BY
   n.server.Site
 
 HAVING
-  value_ndt > 1000
+  value_ndt_total > 1000

--- a/config/federation/bigquery/bq_sidecar.sql
+++ b/config/federation/bigquery/bq_sidecar.sql
@@ -27,8 +27,8 @@ WITH scamper1 AS (
 
 SELECT
   n.server.Site AS site,
-  COUNTIF(n.id IS NOT NULL) AS value_ndt_total,
-  COUNTIF(n.id IS NOT NULL AND s.id IS NOT NULL) AS value_scamper1_matching,
+  COUNT(*) AS value_ndt_total,
+  COUNTIF(s.id IS NOT NULL) AS value_scamper1_matching,
 
 FROM ndt7 AS n
   FULL OUTER JOIN scamper1 AS s

--- a/config/federation/bigquery/bq_sidecar.sql
+++ b/config/federation/bigquery/bq_sidecar.sql
@@ -1,0 +1,33 @@
+WITH scamper1 AS (
+    SELECT
+      *
+    FROM
+      `measurement-lab.ndt.scamper1`
+    WHERE
+      date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+), ndt7 AS (
+    SELECT
+      *
+    FROM
+      `measurement-lab.ndt.ndt7`
+    WHERE
+      date = DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+)
+
+SELECT
+  n.server.Site AS site,
+  COUNTIF(n.id IS NOT NULL) AS value_ndt,
+  COUNTIF(n.id IS NOT NULL AND s.id IS NOT NULL) AS value_matching,
+
+FROM ndt7 AS n
+  FULL OUTER JOIN scamper1 AS s
+  ON n.id = s.id
+
+WHERE
+  n.id IS NOT NULL
+
+GROUP BY
+  n.server.Site
+
+HAVING
+  value_ndt > 1000

--- a/config/federation/bigquery/bq_sidecar.sql
+++ b/config/federation/bigquery/bq_sidecar.sql
@@ -1,3 +1,14 @@
+#standardSQL
+-- bq_sidecar calculates the total number of ndt7 tests and how many matching
+-- scamper1 rows per site, since this type of configuration failure may affect
+-- individual sites.
+--
+-- This query exports two values:
+--   bq_sidecar_ndt_total -- number of ndt7 rows.
+--   bq_sidecar_scamper1_matching -- number of scamper1 rows matching ndt7 rows.
+--
+-- Each value above also has a "site" label.
+
 WITH scamper1 AS (
     SELECT
       *

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -774,6 +774,22 @@ groups:
         prometheus-federation cluster and bigquery-exporter configurations for errors
         or recent changes.
 
+# How many NDT measurements include matching scamper1 traceroutes?
+  - alert: DataQuality_TooFewNDTSidecarTraceroutes_MetricsMissing
+    expr: bq_sidecar_scamper1_matching / bq_sidecar_ndt_total < 0.90 OR absent(bq_sidecar_ndt_total)
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: Too few NDT tests have matching scamper1 traceroute data.
+      description: Most NDT tests should have matching sidecar data including
+        traceroutes. Are the metrics present or missing? If present, check recent
+        deployments for configuration changes or check container logs for errors
+        writing or starting tests. If not, check the prometheus-federation cluster
+        and bigquery-exporter configurations for errors or recent changes.
+
 # The node_exporter running on eb.measurementlab.net is down.
   - alert: NodeExporterOnEbDownOrMissing
     expr: |

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-24h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-24h.yml
@@ -22,6 +22,7 @@ spec:
                 "-gauge-query=/queries/bq_gardener_parse_time.sql",
                 "-gauge-query=/queries/bq_gardener.sql",
                 "-gauge-query=/queries/bq_gardener_historical.sql",
+                "-gauge-query=/queries/bq_sidecar.sql",
               ]
         ports:
         - containerPort: 9348

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -24,6 +24,7 @@ spec:
                 "-gauge-query=/queries/bq_daily_tests.sql",
                 "-gauge-query=/queries/bq_server.sql",
                 "-gauge-query=/queries/bq_billing.sql",
+                "-gauge-query=/queries/bq_sidecar.sql",
               ]
         ports:
         - containerPort: 9348

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -24,7 +24,6 @@ spec:
                 "-gauge-query=/queries/bq_daily_tests.sql",
                 "-gauge-query=/queries/bq_server.sql",
                 "-gauge-query=/queries/bq_billing.sql",
-                "-gauge-query=/queries/bq_sidecar.sql",
               ]
         ports:
         - containerPort: 9348


### PR DESCRIPTION
On 2024-07-22, [we discovered](https://docs.google.com/document/d/1PBht5HR3fu4-vyjavEiwJVrsLEJvtA713vZwY91Dt2A/edit) that MIG deployments were failing to start scamper1 traces from traceroute-caller due to the unknown MIG IP address. We did not detect this because we have no monitoring tracking whether sidecar data is collected for a primary measurement service. By adding monitoring, this type of error will not go unnoticed again. And this creates a framework for adding additional sidecar types if desired.

See: https://prometheus.mlab-sandbox.measurementlab.net/graph?g0.expr=bq_sidecar_scamper1_matching%20%2F%20bq_sidecar_ndt_total%20%3C%200.90&g0.tab=1&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1046)
<!-- Reviewable:end -->
