### PR TITLE
Add visualization of BBR-terminated test trials

### DIFF
--- a/config/federation/grafana/dashboards/Packet_Testing.json
+++ b/config/federation/grafana/dashboards/Packet_Testing.json
@@ -56,9 +56,6 @@
           "font": {
             "color": "grey"
           },
-          "legend": {
-            "orientation": "h"
-          },
           "margin": {
             "b": 50,
             "l": 50,
@@ -74,20 +71,26 @@
               -0.013228265733755159,
               3.469998642218747
             ],
+            "title": {
+              "text": "Mbps"
+            },
             "type": "log"
           },
           "yaxis": {
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.02477829942618675,
-              0.47078768909754826
+              -0.0031193399074260423,
+              0.05926745824109479
             ],
+            "title": {
+              "text": "Frequency"
+            },
             "type": "linear"
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
       },
       "targets": [
         {
@@ -100,8 +103,39 @@
           "location": "US",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), ndt7_and_offset AS (\n  SELECT *, ARRAY_LENGTH(raw.Download.ServerMeasurements) AS dlm_length, ARRAY_REVERSE(raw.Download.ServerMeasurements)[OFFSET(0)] AS m,\n  CASE\n    WHEN (\"bbr_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) AND (\"early_exit\" NOT IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) THEN \"bbr_exit\"\n    WHEN (\"bbr_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) AND (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) AND (\"100\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) THEN \"bbr_exit&early_exit100\"\n    WHEN (\"bbr_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) AND (\"early_exit\" IN (SELECT metadata.Name FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) AND (\"200\" IN (SELECT metadata.Value FROM UNNEST(raw.Download.ClientMetadata) AS metadata)) THEN \"bbr_exit&early_exit200\"\n    ELSE \"full_test\"\n    END\n    AS test_type,\n  FROM raw_pt.ndt7\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n   AND raw.Download is not NULL \n   AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n), pdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((m.TCPInfo.BytesAcked/m.TCPInfo.ElapsedTime) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM ndt7_and_offset, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the pt data.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only ndt7 tests with matching pt tests.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM pt)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM ndt7, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
           "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "hide": false,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "refId": "B",
           "sql": {
             "columns": [
               {
@@ -121,7 +155,131 @@
           }
         }
       ],
-      "title": "Scatter Chart (Download Mbps PDF, normalized)",
+      "title": "Full length test (Download Mbps PDF, normalized)",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "PB00E94094811FA13"
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 13,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.013228265733755159,
+              3.469998642218747
+            ],
+            "title": {
+              "text": "Mbps"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0008339019028125238,
+              0.015844136153437948
+            ],
+            "title": {
+              "text": "Frequency"
+            },
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "US",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "PB00E94094811FA13"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "hide": false,
+          "location": "",
+          "project": "mlab-sandbox",
+          "rawQuery": true,
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "refId": "B",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "BBR-terminated test (Download Mbps PDF, normalized)",
       "type": "ae3e-plotly-panel"
     },
     {
@@ -130,7 +288,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 31
       },
       "id": 3,
       "panels": [],
@@ -155,7 +313,11 @@
               "tooltip": false,
               "viz": false
             },
-            "lineWidth": 1
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -179,7 +341,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 32
       },
       "id": 4,
       "options": {
@@ -258,7 +420,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 44
       },
       "id": 5,
       "options": {
@@ -360,8 +522,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -372,7 +533,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 44
       },
       "id": 9,
       "options": {
@@ -454,8 +615,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -471,7 +631,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 55
       },
       "id": 7,
       "options": {
@@ -564,8 +724,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -576,7 +735,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 55
       },
       "id": 10,
       "options": {
@@ -642,7 +801,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 66
       },
       "id": 2,
       "panels": [],
@@ -674,8 +833,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -687,7 +845,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 67
       },
       "id": 1,
       "options": {
@@ -766,7 +924,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 81
       },
       "id": 6,
       "options": {
@@ -853,8 +1011,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -870,7 +1027,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 81
       },
       "id": 8,
       "options": {
@@ -924,7 +1081,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 38,
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
@@ -937,6 +1094,6 @@
   "timezone": "",
   "title": "Packet Testing",
   "uid": "d341c044-4e2c-4904-b05f-98e8bf1bbf32",
-  "version": 15,
+  "version": 16,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Packet_Testing.json
+++ b/config/federation/grafana/dashboards/Packet_Testing.json
@@ -90,7 +90,7 @@
           }
         },
         "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
+        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values.concat(data.series[1].fields[0].values);\nvar y = data.series[0].fields[1].values.concat(data.series[1].fields[1].values);\nvar names = data.series[0].fields[2].values.concat(data.series[1].fields[2].values);\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
       },
       "targets": [
         {
@@ -103,7 +103,7 @@
           "location": "US",
           "project": "mlab-oti",
           "rawQuery": true,
-          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the pt data.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only ndt7 tests with matching pt tests.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM pt)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM ndt7, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the pt data.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only ndt7 tests with matching pt tests.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    \"Full length\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM pt)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM ndt7, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), pdf_normalized AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM pdf_normalized",
           "refId": "A",
           "sql": {
             "columns": [
@@ -134,7 +134,7 @@
           "location": "",
           "project": "mlab-sandbox",
           "rawQuery": true,
-          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
+          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"BBR-terminated\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), pdf_normalized AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM pdf_normalized",
           "refId": "B",
           "sql": {
             "columns": [
@@ -155,131 +155,7 @@
           }
         }
       ],
-      "title": "Full length test (Download Mbps PDF, normalized)",
-      "type": "ae3e-plotly-panel"
-    },
-    {
-      "datasource": {
-        "type": "grafana-bigquery-datasource",
-        "uid": "PB00E94094811FA13"
-      },
-      "gridPos": {
-        "h": 15,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 13,
-      "maxDataPoints": 80000,
-      "options": {
-        "config": {
-          "displayModeBar": false
-        },
-        "data": [],
-        "layout": {
-          "font": {
-            "color": "grey"
-          },
-          "margin": {
-            "b": 50,
-            "l": 50,
-            "r": 50,
-            "t": 10
-          },
-          "paper_bgcolor": "rgba(0, 0, 0, 0)",
-          "plot_bgcolor": "rgba(0, 0, 0, 0)",
-          "xaxis": {
-            "autorange": true,
-            "gridcolor": "#333",
-            "range": [
-              -0.013228265733755159,
-              3.469998642218747
-            ],
-            "title": {
-              "text": "Mbps"
-            },
-            "type": "log"
-          },
-          "yaxis": {
-            "autorange": true,
-            "gridcolor": "#333",
-            "range": [
-              -0.0008339019028125238,
-              0.015844136153437948
-            ],
-            "title": {
-              "text": "Frequency"
-            },
-            "type": "linear"
-          }
-        },
-        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
-        "script": "console.log(data);\nvar types = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(type => {\n  types[type] = {\n    x: [],\n    y: [],\n    name: type,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  types[names[i]].x.push(x[i]);\n  types[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(types).sort().forEach(type => {\n  data.push(types[type]);\n});\nconsole.log(data);\nvar trace = {\n  x: x,\n  y: y,\n  name: names\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\nreturn {data:data};"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-bigquery-datasource",
-            "uid": "PB00E94094811FA13"
-          },
-          "editorMode": "code",
-          "format": 1,
-          "location": "US",
-          "project": "mlab-oti",
-          "rawQuery": true,
-          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        },
-        {
-          "datasource": {
-            "type": "grafana-bigquery-datasource",
-            "uid": "PB00E94094811FA13"
-          },
-          "editorMode": "code",
-          "format": 1,
-          "hide": false,
-          "location": "",
-          "project": "mlab-sandbox",
-          "rawQuery": true,
-          "rawSql": "WITH steps AS (\n  SELECT x, POW(10, x-.01) AS bucket_left, POW(10, x+.01) AS bucket_right\n  FROM UNNEST(GENERATE_ARRAY(0, 3.5, .02)) AS x\n), \n\n-- Get all the ndt7 data.\nndt7 AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"full\" AS test_type,\n  FROM `mlab-oti.ndt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n),\n\n-- Select only pt tests with matching ndt7 tests.\npt AS (\n  SELECT ARRAY_REVERSE(raw.Download.ServerMeasurements)[SAFE_OFFSET(0)].TCPInfo AS tcpinfo, \n    metadata.Value AS session_id, \n    \"bbr\" AS test_type\n  FROM `mlab-oti.raw_pt.ndt7`, UNNEST (raw.Download.ClientMetadata) AS metadata\n  WHERE date BETWEEN \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\"\n  AND raw.Download is not NULL \n  AND ARRAY_LENGTH(raw.Download.ServerMeasurements) > 0\n  AND metadata.Name = \"client_session_id\"\n  AND metadata.Value IN (SELECT session_id FROM ndt7)\n),\n\npdf_sort AS (\n  SELECT bucket_left, bucket_right, test_type, IF((SAFE_DIVIDE(tcpinfo.BytesAcked*8,tcpinfo.ElapsedTime)) BETWEEN bucket_left AND bucket_right, 1, 0) AS present_true\n  FROM pt, steps\n), pdf_totals AS (  \n  SELECT bucket_left AS buckets, test_type, sum(present_true) AS total_true\n  FROM   pdf_sort\n  GROUP BY bucket_left, test_type\n  ORDER BY bucket_left\n), pdf_product  AS (\n  SELECT\n    total_true,\n    test_type,\n    trunc(buckets,2) as buckets,\n    total_true AS product_true,\n  FROM pdf_totals\n  ORDER BY buckets\n), cdf_tests_and_bytes AS (\n  SELECT  \n    buckets,\n    test_type,\n    product_true / SUM(product_true) OVER (partition BY test_type) AS normalized,\n    \n  FROM pdf_product\n  ORDER BY buckets\n)\nSELECT\n  buckets,\n  normalized,\n  test_type,\n\nFROM cdf_tests_and_bytes",
-          "refId": "B",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "BBR-terminated test (Download Mbps PDF, normalized)",
+      "title": "BBR-terminated vs. full length test (Download Mbps PDF, normalized)",
       "type": "ae3e-plotly-panel"
     },
     {
@@ -288,7 +164,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 16
       },
       "id": 3,
       "panels": [],
@@ -341,7 +217,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 17
       },
       "id": 4,
       "options": {
@@ -420,7 +296,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 29
       },
       "id": 5,
       "options": {
@@ -522,7 +398,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           }
@@ -533,7 +410,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 29
       },
       "id": 9,
       "options": {
@@ -631,7 +508,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 40
       },
       "id": 7,
       "options": {
@@ -735,7 +612,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 40
       },
       "id": 10,
       "options": {
@@ -801,7 +678,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 51
       },
       "id": 2,
       "panels": [],
@@ -845,7 +722,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 52
       },
       "id": 1,
       "options": {
@@ -924,7 +801,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 81
+        "y": 66
       },
       "id": 6,
       "options": {
@@ -1027,7 +904,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 81
+        "y": 66
       },
       "id": 8,
       "options": {
@@ -1094,6 +971,6 @@
   "timezone": "",
   "title": "Packet Testing",
   "uid": "d341c044-4e2c-4904-b05f-98e8bf1bbf32",
-  "version": 16,
+  "version": 17,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds a PDF visualization of the throughput distribution of BBR-terminated tests compared to full-length ndt7 tests.

[Panel](https://grafana.mlab-sandbox.measurementlab.net/d/d341c044-4e2c-4904-b05f-98e8bf1bbf32/packet-testing?orgId=1&viewPanel=11).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1055)
<!-- Reviewable:end -->
