### PR TITLE
Add datasources for autojoin cluster

### DIFF
--- a/config/federation/grafana/provisioning/datasources/autojoin_mlab-autojoin.yml.template
+++ b/config/federation/grafana/provisioning/datasources/autojoin_mlab-autojoin.yml.template
@@ -1,0 +1,20 @@
+# config file version
+apiVersion: 1
+
+datasources:
+- name: Autojoin Platform (mlab-autojoin)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: https://prometheus-autojoin-basic.mlab-autojoin.measurementlab.net
+  basicAuth: true
+  basicAuthUser: {{PROM_AUTH_USER}}
+  secureJsonData:
+    basicAuthPassword: {{PROM_AUTH_PASS}}
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false
+
+  jsonData:
+    timeout: 60
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/autojoin_mlab-sandbox.yml.template
+++ b/config/federation/grafana/provisioning/datasources/autojoin_mlab-sandbox.yml.template
@@ -1,0 +1,20 @@
+# config file version
+apiVersion: 1
+
+datasources:
+- name: Autojoin Platform (mlab-sandbox)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: https://prometheus-autojoin-basic.mlab-sandbox.measurementlab.net
+  basicAuth: true
+  basicAuthUser: {{PROM_AUTH_USER}}
+  secureJsonData:
+    basicAuthPassword: {{PROM_AUTH_PASS}}
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false
+
+  jsonData:
+    timeout: 60
+    timeInterval: 60s

--- a/config/federation/grafana/provisioning/datasources/autojoin_mlab-staging.yml.template
+++ b/config/federation/grafana/provisioning/datasources/autojoin_mlab-staging.yml.template
@@ -1,0 +1,20 @@
+# config file version
+apiVersion: 1
+
+datasources:
+- name: Autojoin Platform (mlab-staging)
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: https://prometheus-autojoin-basic.mlab-staging.measurementlab.net
+  basicAuth: true
+  basicAuthUser: {{PROM_AUTH_USER}}
+  secureJsonData:
+    basicAuthPassword: {{PROM_AUTH_PASS}}
+  isDefault: {{IS_DEFAULT}}
+  version: 1
+  editable: false
+
+  jsonData:
+    timeout: 60
+    timeInterval: 60s


### PR DESCRIPTION
This change adds new datasources for the Autojoin cluster instance of Prometheus. These datasources will make it possible to create dashboards with metrics collected directly from the Autojoin platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1058)
<!-- Reviewable:end -->
