### PR TITLE
Adds Compute Engine costs to the bq_billing query results

### DIFF
--- a/config/federation/bigquery/bq_billing.sql
+++ b/config/federation/bigquery/bq_billing.sql
@@ -50,8 +50,8 @@ SELECT
   SUM(IF(period = "month" AND service = "BigQuery", cost, 0))/30 AS value_average_daily_bigquery,
   SUM(IF(period = "today" AND service = "BigQuery", cost, 0)) AS value_today_bigquery,
   SUM(IF(period = "yesterday" AND service = "BigQuery", cost, 0)) AS value_yesterday_bigquery,
-  SUM(IF(period = "before_yesterday" AND service = "BigQuery", cost, 0)) AS value_before_yesterday_bigquery
-  -- Compute Engine metrics
+  SUM(IF(period = "before_yesterday" AND service = "BigQuery", cost, 0)) AS value_before_yesterday_bigquery,
+  -- Compute Engine metrics.
   SUM(IF(period = "month" AND service = "Compute Engine", cost, 0))/30 AS value_average_daily_gce,
   SUM(IF(period = "today" AND service = "Compute Engine", cost, 0)) AS value_today_gce,
   SUM(IF(period = "yesterday" AND service = "Compute Engine", cost, 0)) AS value_yesterday_gce,

--- a/config/federation/bigquery/bq_billing.sql
+++ b/config/federation/bigquery/bq_billing.sql
@@ -51,5 +51,11 @@ SELECT
   SUM(IF(period = "today" AND service = "BigQuery", cost, 0)) AS value_today_bigquery,
   SUM(IF(period = "yesterday" AND service = "BigQuery", cost, 0)) AS value_yesterday_bigquery,
   SUM(IF(period = "before_yesterday" AND service = "BigQuery", cost, 0)) AS value_before_yesterday_bigquery
+  -- Compute Engine metrics
+  SUM(IF(period = "month" AND service = "Compute Engine", cost, 0))/30 AS value_average_daily_gce,
+  SUM(IF(period = "today" AND service = "Compute Engine", cost, 0)) AS value_today_gce,
+  SUM(IF(period = "yesterday" AND service = "Compute Engine", cost, 0)) AS value_yesterday_gce,
+  SUM(IF(period = "before_yesterday" AND service = "Compute Engine", cost, 0)) AS value_before_yesterday_gce
 FROM
   billing
+


### PR DESCRIPTION
We want to start alerting on Compute Engines costs, and this is the first step by getting metrics about Compute Engine costs into Prometheus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1062)
<!-- Reviewable:end -->
