### PR TITLE
Updates script-exporter container image version to v0.2.12

### DIFF
--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -7,7 +7,7 @@ scripts:
       EXPERIMENT=wehe cache_exit_code.sh 600
       monitoring-token -machine=${TARGET} -service=wehe/replay --
       wehe-client.sh -n applemusic -t wehe-cmdline/res/ -c
-    timeout: 50
+    timeout: 55
   - name: 'ndt7_client'
     script: >
       EXPERIMENT=ndt7 cache_exit_code.sh 3600

--- a/k8s/prometheus-federation/deployments/script-exporter.yml
+++ b/k8s/prometheus-federation/deployments/script-exporter.yml
@@ -32,7 +32,7 @@ spec:
 
       containers:
       - name: script-exporter
-        image: measurementlab/script-exporter-support:v0.2.11
+        image: measurementlab/script-exporter-support:v0.2.12
         args:
         - -config.file=/etc/script_exporter/script_exporter.yml
         env:


### PR DESCRIPTION
This resolves an issue where the version of java the Wehe client is build with is different and incompatible with the version of java installed in the container image.

This PR also increases the script-exporter timeout for the Wehe client from 50s to 55s. For some reason almost all Wehe e2e tests in sandbox are taking >50s, while in production almost all of them complete in 15 or 20s. There are still some timeouts, even at 55s, but most of them seem to be completing, which is better than where we are today. Meanwhile, I have a question about this out to Derek Ng in the #mlab-wehe-shared Slack channel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1065)
<!-- Reviewable:end -->
