### PR TITLE
Change wehe e2e tests to use the amazon replay instead of applemusic

### DIFF
--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -6,7 +6,7 @@ scripts:
     script: >
       EXPERIMENT=wehe cache_exit_code.sh 600
       monitoring-token -machine=${TARGET} -service=wehe/replay --
-      wehe-client.sh -n applemusic -t wehe-cmdline/res/ -c
+      wehe-client.sh -n amazon -t wehe-cmdline/res/ -c
     timeout: 55
   - name: 'ndt7_client'
     script: >

--- a/config/federation/script-exporter/script_exporter.yml
+++ b/config/federation/script-exporter/script_exporter.yml
@@ -7,7 +7,7 @@ scripts:
       EXPERIMENT=wehe cache_exit_code.sh 600
       monitoring-token -machine=${TARGET} -service=wehe/replay --
       wehe-client.sh -n amazon -t wehe-cmdline/res/ -c
-    timeout: 55
+    timeout: 50
   - name: 'ndt7_client'
     script: >
       EXPERIMENT=ndt7 cache_exit_code.sh 3600


### PR DESCRIPTION
Changes wehe e2e test from using applemusic to amazon I noticed that many e2e tests in sandbox were timing out at 50s from the timeout setting configured for the wehe_client script. But in production the tests were completing in around 10 or 15 seconds.

I turned on debug logging for wehe-cmdline.jar and noticed that for some odd reason there was a 20s delay when sending packet number 13 our of 15. And this happens twice during the test, making the test very long.

Looking at the wehe-cmdline repository, I noticed that a new version was released just a couple months ago which updated all the replay files. Inspecting the applemusic replay file (which is JSON), I noticed that the timestamp field of the 13th packet in the array has a value of ~20s, which I think explain why there is always a 20s delay when sending the 13th packet.

I looked through the available replay files looking for one where the final packet's timestamp value was low, and it turns out that the amazon test fit that bill. This should cause wehe e2e tests to complete much more quickly.

In sandbox this looks much better now, with tests completing in ~30s:

```
2024/10/24 22:06:32 OK: wehe_client to mlab4-lga0t.mlab-sandbox.measurement-lab.org (after 30.994064s).
2024/10/24 22:06:32 OK: wehe_client to mlab1-lga0t.mlab-sandbox.measurement-lab.org (after 30.600285s).
2024/10/24 22:06:35 OK: wehe_client to mlab4-lga1t.mlab-sandbox.measurement-lab.org (after 32.022518s).
2024/10/24 22:06:35 OK: wehe_client to mlab3-lga0t.mlab-sandbox.measurement-lab.org (after 31.062820s).
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1066)
<!-- Reviewable:end -->
