### PR TITLE
Add new datasource for mlab-collaboration

### DIFF
--- a/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-collaboration.yml.template
+++ b/config/federation/grafana/provisioning/datasources/grafana_bigquery_mlab-collaboration.yml.template
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Google BigQuery (mlab-collaboration)
+    type: grafana-bigquery-datasource
+    access: proxy
+    isDefault: {{IS_DEFAULT}}
+    editable: false
+    enabled: true
+    jsonData:
+      authenticationType: gce
+      defaultProject: mlab-collaboration


### PR DESCRIPTION
This change adds a new datasource for mlab-collaboration. While the Grafana instance runs in mlab-sandbox, it is helpful to localize all billing for mlab-collaboration to that project by allowing queries to be run in this project also.

This is in service of estimating total costs for https://github.com/m-lab/hermes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1067)
<!-- Reviewable:end -->
