### PR TITLE
Add dashboard for Autojoin status

### DIFF
--- a/config/federation/grafana/dashboards/Autojoin.json
+++ b/config/federation/grafana/dashboards/Autojoin.json
@@ -1,83 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)",
-      "label": "Autojoin Platform (mlab-autojoin)",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
-      "name": "DS_PLATFORM_CLUSTER (MLAB-OTI)",
-      "label": "Platform Cluster (mlab-oti)",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
-      "name": "DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)",
-      "label": "Google BigQuery (measurement-lab)",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-bigquery-datasource",
-      "pluginName": "Google BigQuery"
-    },
-    {
-      "name": "DS_GOOGLE_BIGQUERY (MLAB-OTI)",
-      "label": "Google BigQuery (mlab-oti)",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-bigquery-datasource",
-      "pluginName": "Google BigQuery"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "ae3e-plotly-panel",
-      "name": "Plotly panel",
-      "version": "0.5.0"
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.1.3"
-    },
-    {
-      "type": "datasource",
-      "id": "grafana-bigquery-datasource",
-      "name": "Google BigQuery",
-      "version": "1.9.3"
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -97,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
+  "id": 466,
   "links": [],
   "panels": [
     {
@@ -179,7 +100,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+            "uid": "${datasourceAutojoin}"
           },
           "editorMode": "code",
           "expr": "count(sum(ndt7_measurer_bbr_enabled_total{status=\"true\", machine=~\".*${metro:regex}.*\"}) > 0)",
@@ -205,7 +126,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+            "uid": "${datasourceAutojoin}"
           },
           "editorMode": "code",
           "expr": "count(heartbeat_health_endpoint_checks_total{status=\"OK\", machine=~\".*${metro:regex}.*\"} > 0)",
@@ -231,7 +152,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+            "uid": "${datasourceAutojoin}"
           },
           "editorMode": "code",
           "expr": "count(traces_performed_total{exported_type=\"scamper\", machine=~\".*${metro:regex}.*\"} > 0)",
@@ -345,7 +266,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PLATFORM_CLUSTER (MLAB-OTI)}"
+            "uid": "${datasourcePlatform}"
           },
           "editorMode": "code",
           "expr": "sum by(site) (rate(controller_access_txcontroller_requests_total{request=\"rejected\", machine=~\".*${metro:regex}.*\"}[15m])) / \n  sum by(site) (rate(controller_access_txcontroller_requests_total{machine=~\".*${metro:regex}.*\"}[15m]) )",
@@ -452,7 +373,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+            "uid": "${datasourceAutojoin}"
           },
           "editorMode": "code",
           "expr": "60 * sum by(direction, org, site) (label_replace(rate(ndt_test_rate_mbps_count{deployment=\"byos\", direction=\"download\",  machine=~\".*(${metro:regex}).*\"}[5m]), \"site\", \"$1\", \"machine\", \"ndt-([a-z]{3}[^-]+)-.*\"))\n",
@@ -557,7 +478,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+            "uid": "${datasourceAutojoin}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -590,7 +511,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "${DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)}"
+        "uid": "f126f149-75bd-4e5a-9883-fcd7e62bc80a"
       },
       "fieldConfig": {
         "defaults": {
@@ -669,7 +590,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "${DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)}"
+            "uid": "f126f149-75bd-4e5a-9883-fcd7e62bc80a"
           },
           "editorMode": "code",
           "format": 0,
@@ -703,7 +624,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+        "uid": "PE8D1C7E267159A85"
       },
       "gridPos": {
         "h": 16,
@@ -749,8 +670,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0016346331303224446,
-              0.031058029476126445
+              -0.0016114953333780972,
+              0.030618411334183845
             ],
             "type": "linear"
           }
@@ -762,7 +683,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+            "uid": "PE8D1C7E267159A85"
           },
           "editorMode": "code",
           "format": 1,
@@ -796,7 +717,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+        "uid": "PE8D1C7E267159A85"
       },
       "gridPos": {
         "h": 16,
@@ -842,8 +763,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0016970240528979103,
-              0.032243457005060296
+              -0.0016684022529029079,
+              0.03169964280515525
             ],
             "type": "linear"
           }
@@ -855,7 +776,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+            "uid": "PE8D1C7E267159A85"
           },
           "editorMode": "code",
           "format": 1,
@@ -889,7 +810,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+        "uid": "PE8D1C7E267159A85"
       },
       "gridPos": {
         "h": 16,
@@ -948,7 +869,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+            "uid": "PE8D1C7E267159A85"
           },
           "editorMode": "code",
           "format": 1,
@@ -985,7 +906,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "Autojoin Platform (mlab-autojoin)",
+          "value": "P9963F0EC00120018"
+        },
         "hide": 1,
         "includeAll": false,
         "multi": false,
@@ -999,7 +924,11 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "Platform Cluster (mlab-oti)",
+          "value": "WW1Jk2sGk"
+        },
         "hide": 1,
         "includeAll": false,
         "multi": false,
@@ -1013,7 +942,11 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "Google BigQuery (measurement-lab)",
+          "value": "f126f149-75bd-4e5a-9883-fcd7e62bc80a"
+        },
         "hide": 0,
         "includeAll": false,
         "multi": false,
@@ -1026,7 +959,11 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "equinix",
+          "value": "equinix"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasourceAutojoin}"
@@ -1049,10 +986,14 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "dfw",
+          "value": "dfw"
+        },
         "datasource": {
           "type": "grafana-bigquery-datasource",
-          "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+          "uid": "${bigquery}"
         },
         "definition": "",
         "hide": 0,
@@ -1102,6 +1043,6 @@
   "timezone": "",
   "title": "Autojoin",
   "uid": "abcdef37wdji8d",
-  "version": 80,
+  "version": 81,
   "weekStart": ""
 }

--- a/config/federation/grafana/dashboards/Autojoin.json
+++ b/config/federation/grafana/dashboards/Autojoin.json
@@ -1,0 +1,1107 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)",
+      "label": "Autojoin Platform (mlab-autojoin)",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_PLATFORM_CLUSTER (MLAB-OTI)",
+      "label": "Platform Cluster (mlab-oti)",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)",
+      "label": "Google BigQuery (measurement-lab)",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-bigquery-datasource",
+      "pluginName": "Google BigQuery"
+    },
+    {
+      "name": "DS_GOOGLE_BIGQUERY (MLAB-OTI)",
+      "label": "Google BigQuery (mlab-oti)",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-bigquery-datasource",
+      "pluginName": "Google BigQuery"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "ae3e-plotly-panel",
+      "name": "Plotly panel",
+      "version": "0.5.0"
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.1.3"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-bigquery-datasource",
+      "name": "Google BigQuery",
+      "version": "1.9.3"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasourceAutojoin}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "✓"
+                },
+                "to": 100
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "☓"
+                },
+                "to": 1
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+          },
+          "editorMode": "code",
+          "expr": "count(sum(ndt7_measurer_bbr_enabled_total{status=\"true\", machine=~\".*${metro:regex}.*\"}) > 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "ndt7",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasourceAutojoin}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "count(jostler_bytes_per_bundle_count{datatype=\"ndt7\", machine=~\".*${metro:regex}.*\"} > 0)",
+          "interval": "",
+          "legendFormat": "jostler",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+          },
+          "editorMode": "code",
+          "expr": "count(heartbeat_health_endpoint_checks_total{status=\"OK\", machine=~\".*${metro:regex}.*\"} > 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "heartbeat",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasourceAutojoin}"
+          },
+          "editorMode": "code",
+          "expr": "count(uuid_annotator_annotation_errors_total{machine=~\".*${metro:regex}.*\"} == 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "uuid-annotator",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+          },
+          "editorMode": "code",
+          "expr": "count(traces_performed_total{exported_type=\"scamper\", machine=~\".*${metro:regex}.*\"} > 0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "traceroute",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Status ${metro}",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 3,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasourceAutojoin}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(site) (label_replace(rate(controller_access_txcontroller_requests_total{request=\"rejected\", machine=~\".*${metro:regex}.*\"}[15m]), \"site\", \"$1\", \"machine\", \"ndt-([a-z]{3}[^-]+)-.*\")) / \n  sum by(site) (label_replace(rate(controller_access_txcontroller_requests_total{machine=~\".*${metro:regex}.*\"}[15m]), \"site\", \"$1\", \"machine\", \"ndt-([a-z]{3}[^-]+)-.*\"))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PLATFORM_CLUSTER (MLAB-OTI)}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(site) (rate(controller_access_txcontroller_requests_total{request=\"rejected\", machine=~\".*${metro:regex}.*\"}[15m])) / \n  sum by(site) (rate(controller_access_txcontroller_requests_total{machine=~\".*${metro:regex}.*\"}[15m]) )",
+          "hide": false,
+          "legendFormat": "{{site}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Prometheus: Percent of NDT TX Rejections ($metro)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Tests/min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasourcePlatform}"
+          },
+          "editorMode": "code",
+          "expr": "60 * sum by(direction, site) (rate(ndt_test_rate_mbps_count{direction=\"download\", machine=~\".*(${metro:regex}).*\"}[5m]))\n",
+          "hide": false,
+          "legendFormat": "{{site}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+          },
+          "editorMode": "code",
+          "expr": "60 * sum by(direction, org, site) (label_replace(rate(ndt_test_rate_mbps_count{deployment=\"byos\", direction=\"download\",  machine=~\".*(${metro:regex}).*\"}[5m]), \"site\", \"$1\", \"machine\", \"ndt-([a-z]{3}[^-]+)-.*\"))\n",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prometheus: NDT Download Counts ($metro)",
+      "type": "timeseries"
+    },
+    {
+      "cards": {
+        "cardPadding": 0,
+        "cardRound": 0
+      },
+      "color": {
+        "cardColor": "#cffaff",
+        "colorScale": "linear",
+        "colorScheme": "interpolateSpectral",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasourceAutojoin}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 6,
+      "interval": "5m",
+      "legend": {
+        "show": true
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 1,
+        "cellRadius": 0,
+        "cellValues": {
+          "decimals": 0
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "#cffaff",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "ge"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "Mbits"
+        }
+      },
+      "pluginVersion": "11.1.3",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_AUTOJOIN_PLATFORM (MLAB-AUTOJOIN)}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(le) (increase(ndt_test_rate_mbps_bucket{direction=~\"download\", monitoring=\"false\", machine=~\".*${metro:regex}.*\"}[5m]))",
+          "format": "heatmap",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prometheus: Aggregate Download Rate Heatmap ($metro)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 0,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "Mbits",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "upper"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "${DS_GOOGLE_BIGQUERY (MEASUREMENT-LAB)}"
+          },
+          "editorMode": "code",
+          "format": 0,
+          "location": "",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "/* TODO: figure out per-org labels */\nSELECT time, org as metric, count(*) as total FROM (\nSELECT TIMESTAMP_TRUNC(raw.StartTime, HOUR) as time, server.Site as org,\nFROM `mlab-autojoin.autoload_v2_ndt.ndt7_union`\nWHERE date BETWEEN  \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\" AND server.Site is not NULL\n AND REGEXP_CONTAINS(server.Site, \"${metro:regex}\")\nUNION ALL\nSELECT TIMESTAMP_TRUNC(raw.StartTime, HOUR) as time, server.Site as org\nFROM `mlab-oti.ndt.ndt7`\nWHERE date BETWEEN  \"${__from:date:YYYY-MM-DD}\" AND \"${__to:date:YYYY-MM-DD}\" AND server.Site is not NULL\n AND REGEXP_CONTAINS(server.Site, \".*${metro:regex}.*\")\n)\ngroup by time, org\norder by time,org",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "BigQuery: Row Counts per hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.9899999999999997,
+              3.5500000000000025
+            ],
+            "title": {
+              "text": "Mbps"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0016346331303224446,
+              0.031058029476126445
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(data)",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM (\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf_byosraw`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\nUNION ALL\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf`(0.1, 3500, \"MeanThroughputMbps\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\n)\nORDER BY xright, site",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "BigQuery: Download Mbps",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 4,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.9899999999999997,
+              2.6900000000000026
+            ],
+            "title": {
+              "text": "RTT"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.0016970240528979103,
+              0.032243457005060296
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM (\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf_byosraw`(0.1, 500, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\nUNION ALL\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf`(0.1, 500, \"MinRTT\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\n)\nORDER BY xright, site",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "BigQuery: Download MinRTT",
+      "type": "ae3e-plotly-panel"
+    },
+    {
+      "datasource": {
+        "type": "grafana-bigquery-datasource",
+        "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 5,
+      "maxDataPoints": 80000,
+      "options": {
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [],
+        "layout": {
+          "font": {
+            "color": "grey"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "margin": {
+            "b": 50,
+            "l": 50,
+            "r": 50,
+            "t": 10
+          },
+          "paper_bgcolor": "rgba(0, 0, 0, 0)",
+          "plot_bgcolor": "rgba(0, 0, 0, 0)",
+          "xaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -5.989999999999998,
+              0.009999999999961536
+            ],
+            "title": {
+              "text": "Loss"
+            },
+            "type": "log"
+          },
+          "yaxis": {
+            "autorange": true,
+            "gridcolor": "#333",
+            "range": [
+              -0.000544817130945613,
+              0.010351525487966648
+            ],
+            "type": "linear"
+          }
+        },
+        "onclick": "console.log(\"okay\");\nconsole.log(data)\n// window.updateVariables({query:{'var-project':'test'}, partial: true})",
+        "script": "console.log(data);\nvar sites = {};\n\nvar x = data.series[0].fields[0].values;\nvar y = data.series[0].fields[1].values;\nvar names = data.series[0].fields[2].values;\n\nnames.forEach(site => {\n  sites[site] = {\n    x: [],\n    y: [],\n    name: site,\n    line: {\n      width: 1\n    }\n  }\n}); \nx.forEach((xv, i) => {\n  sites[names[i]].x.push(x[i]);\n  sites[names[i]].y.push(y[i]);\n})\nvar data = [];\nObject.keys(sites).sort().forEach(site => {\n  data.push(sites[site]);\n});\nconsole.log(data);\nvar site = \"atl03\";\nvar trace = {\n  x: x, //.filter((element, i) => names[i] === site),\n  y: y, //.filter((element, i) => names[i] === site),\n  name: names //.filter((element, i) => names[i] === site)\n};\nconsole.log(\"okay2\");\nconsole.log(trace);\n//return {data:[trace]};\nreturn {data:data};"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-bigquery-datasource",
+            "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+          },
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "mlab-oti",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM (\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf_byosraw`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\nUNION ALL\nSELECT\n  xright,\n  CASE \"pdf\"\n    WHEN \"pdf\" THEN site_pdf\n    ELSE site_cdf\n  END AS data,\n  site,\nFROM `ops.ndt7_download_pdf`(1e-6, 1, \"LossRate\", \"${__from:date:YYYY-MM-DD}\", \"${__to:date:YYYY-MM-DD}\", \"${metro:regex}.*\")\n)\nORDER BY xright, site",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "BigQuery: Download LossRates",
+      "type": "ae3e-plotly-panel"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 1,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasourceAutojoin",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/Autojoin/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "hide": 1,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasourcePlatform",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/Platform Cluster/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "bigquery",
+        "options": [],
+        "query": "grafana-bigquery-datasource",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasourceAutojoin}"
+        },
+        "definition": "label_values(ndt_test_rate_mbps_count,org)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "org",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(ndt_test_rate_mbps_count,org)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-bigquery-datasource",
+          "uid": "${DS_GOOGLE_BIGQUERY (MLAB-OTI)}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "metro",
+        "options": [],
+        "query": {
+          "editorMode": "code",
+          "format": 1,
+          "location": "",
+          "project": "measurement-lab",
+          "rawQuery": true,
+          "rawSql": "SELECT SUBSTR(server.Site, 0, 3) as metro FROM `measurement-lab.ndt.ndt7`\nWHERE date BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AND CURRENT_DATE()\n  AND server.Site is not null\n  AND \"mlab\" = \"$org\"\nGROUP BY server.Site \nUNION ALL\nSELECT SUBSTR(server.Site, 0, 3) as metro FROM `mlab-autojoin.autoload_v2_ndt.ndt7_union`\nWHERE date BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AND CURRENT_DATE()\n  AND server.Site is not null\n  AND archiver.ArchiveURL LIKE \"%${org}%\"\nGROUP BY server.Site\nORDER BY metro",
+          "refId": "tempvar",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Autojoin",
+  "uid": "abcdef37wdji8d",
+  "version": 80,
+  "weekStart": ""
+}


### PR DESCRIPTION
This change adds a new dashboard for viewing the operating status and data for an autonode.

NOTE: a new autonode site will not be available to this dashboard until the etl-schema repo has been re-deployed because the `autoload_v2_ndt.ndt7_union` view is not updated automatically. See:

* https://github.com/m-lab/autoloader/issues/38

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1070)
<!-- Reviewable:end -->
