### PR TITLE
Allow mlab-autojoin to match in mlab-oti

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -90,7 +90,7 @@ for ds_tmpl in $ds_tmpls; do
   case "$PROJECT" in
     # Don't include sandbox or staging data sources in the production instance.
     mlab-oti)
-      if [[ $(basename $ds_tmpl) != *mlab-oti* ]]; then
+      if [[ $(basename $ds_tmpl) != *mlab-oti* && $(basename $ds_tmpl) != *mlab-autojoin* ]]; then
         rm $ds_tmpl
         continue
       fi


### PR DESCRIPTION
This change fixes a bug that removes the mlab-autojoin datasources from deployments to the mlab-oti project. Simply, the change removes templates only if they are not in mlab-oti and not in mlab-autojoin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1071)
<!-- Reviewable:end -->
