### PR TITLE
Select datasource variable in all panels

### DIFF
--- a/config/federation/grafana/dashboards/Autojoin.json
+++ b/config/federation/grafana/dashboards/Autojoin.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 466,
   "links": [],
   "panels": [
     {
@@ -511,7 +510,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "f126f149-75bd-4e5a-9883-fcd7e62bc80a"
+        "uid": "${bigquery}"
       },
       "fieldConfig": {
         "defaults": {
@@ -590,7 +589,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "f126f149-75bd-4e5a-9883-fcd7e62bc80a"
+            "uid": "${bigquery}"
           },
           "editorMode": "code",
           "format": 0,
@@ -624,7 +623,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${bigquery}"
       },
       "gridPos": {
         "h": 16,
@@ -670,8 +669,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0016114953333780972,
-              0.030618411334183845
+              -0.001584035211530809,
+              0.030096669019085368
             ],
             "type": "linear"
           }
@@ -683,7 +682,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${bigquery}"
           },
           "editorMode": "code",
           "format": 1,
@@ -717,7 +716,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${bigquery}"
       },
       "gridPos": {
         "h": 16,
@@ -763,8 +762,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.0016684022529029079,
-              0.03169964280515525
+              -0.0016112144927918773,
+              0.030613075363045666
             ],
             "type": "linear"
           }
@@ -776,7 +775,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${bigquery}"
           },
           "editorMode": "code",
           "format": 1,
@@ -810,7 +809,7 @@
     {
       "datasource": {
         "type": "grafana-bigquery-datasource",
-        "uid": "PE8D1C7E267159A85"
+        "uid": "${bigquery}"
       },
       "gridPos": {
         "h": 16,
@@ -856,8 +855,8 @@
             "autorange": true,
             "gridcolor": "#333",
             "range": [
-              -0.000544817130945613,
-              0.010351525487966648
+              -0.0005475975514788236,
+              0.010404353478097648
             ],
             "type": "linear"
           }
@@ -869,7 +868,7 @@
         {
           "datasource": {
             "type": "grafana-bigquery-datasource",
-            "uid": "PE8D1C7E267159A85"
+            "uid": "${bigquery}"
           },
           "editorMode": "code",
           "format": 1,
@@ -1043,6 +1042,6 @@
   "timezone": "",
   "title": "Autojoin",
   "uid": "abcdef37wdji8d",
-  "version": 81,
+  "version": 82,
   "weekStart": ""
 }


### PR DESCRIPTION
The original dashboard included BigQuery datasource variables but individual panels were not referencing this variable. As a result, panels did not work correctly across projects. This fix updates all panels to refer to the datasource variable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1072)
<!-- Reviewable:end -->
