### PR TITLE
Adds "fqdn" label to script_success metrics

### DIFF
--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -741,6 +741,14 @@ scrape_configs:
         target_label: __address__
         replacement: script-exporter.default.svc.cluster.local:9172
 
+      # The Locate Service filters on the "fqdn" label when looking for failing
+      # e2e tests. Set the "fqdn" label to be equal to the "machine" label,
+      # which is actually the FQDN of the machine.
+      - source_labels: [machine]
+        regex: (.*)
+        target_label: fqdn
+        replacement: ${1}
+
   # Scrape config for App Engine Flex VMs.
   #
   # In order to scrape Prometheus metrics directly from Flex VMs, the app.yaml


### PR DESCRIPTION
Locate filters on this label, and without it will fail to notice BYOS nodes where e2e tests are failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1074)
<!-- Reviewable:end -->
