### PR TITLE
Adds "fqdn" label to script_exporter e2e metrics + new alert

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1381,11 +1381,16 @@ groups:
 # Autojoin system will delete a DNS record for an autojoin client if it hasn't
 # heard from that client more than 14d. Autojoin clients are supposed to
 # checkin every hour. This alert conservatively allows an M-Lab autojoined
-# machine to not checkin for 4 days before firing.
+# machine to not checkin for 4 days before firing. Since this alert is only
+# meant to uncover issues with the Autojoin client successfully registering, or
+# some bug in the Autojoin API where client registrations are not properly
+# updated in Memorystore, we only trigger this alert when script_exporter E2E
+# tests are succeeding. If E2E test are failing, then there is some other issue
+# and k8s alerts should cover them.
   - alert: AutojoinDNSRecordTooCloseToExpiring
     expr: |
       ((autojoin_dns_expiration - time()) / 86400) < 10
-        unless on(machine) gmx_machine_maintenance == 1
+        unless on(fqdn) script_success == 0
     for: 10m
     labels:
       repo: ops-tracker

--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -1377,3 +1377,22 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#billing_dailygceincrease
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/a5mC51ZMk/gcp-billing?orgId=1&refresh=5m
 
+# A DNS record for an M-Lab autojoined machine is too close to expiring. The
+# Autojoin system will delete a DNS record for an autojoin client if it hasn't
+# heard from that client more than 14d. Autojoin clients are supposed to
+# checkin every hour. This alert conservatively allows an M-Lab autojoined
+# machine to not checkin for 4 days before firing.
+  - alert: AutojoinDNSRecordTooCloseToExpiring
+    expr: |
+      ((autojoin_dns_expiration - time()) / 86400) < 10
+        unless on(machine) gmx_machine_maintenance == 1
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: prometheus-federation
+    annotations:
+      summary: A DNS record for an Autojoin machine is too close to expiring
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#autojoindnsrecordtooclosetoexpiring
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/abcdef37wdji8d/autojoin?orgId=1
+

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -741,6 +741,14 @@ scrape_configs:
         target_label: __address__
         replacement: script-exporter.default.svc.cluster.local:9172
 
+      # The Locate Service filters on the "fqdn" label when looking for failing
+      # e2e tests. Set the "fqdn" label to be equal to the "machine" label,
+      # which is actually the FQDN of the machine.
+      - source_labels: [machine]
+        regex: (.*)
+        target_label: fqdn
+        replacement: ${1}
+
   # Scrape config for App Engine Flex VMs.
   #
   # In order to scrape Prometheus metrics directly from Flex VMs, the app.yaml


### PR DESCRIPTION
The Locate Service filters on label "fqdn" when looking to see whether e2e testing to a machine is failing. This PR adds that label Autojoin e2e testing so that Locate can effectively stop serving a machine where e2e testing is not working.

Additionally, in anticipation of moving M-Lab-managed VMs to leveraging the Autojoin system, this PR adds a new alert that will fire when Autojoin is less than 10d away from removing a DNS entry for an M-Lab-managed VM. This should give operators plenty of lead time to resolve the issue. In any case, by the time this alert may fire, other k8s alerts for the node should have already fired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1075)
<!-- Reviewable:end -->
