### PR TITLE
Adds new alert for when Jostler data volume is too low in autojoin

### DIFF
--- a/config/autojoin/prometheus/alerts.yml
+++ b/config/autojoin/prometheus/alerts.yml
@@ -76,10 +76,10 @@ groups:
     expr: |
       datatype:jostler_bytes_per_bundle:increase24h
         < (0.7 * quantile by(datatype)(0.5,
-          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1d)), "delay", "1d", "", ".*") or
-          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 3d)), "delay", "3d", "", ".*") or
-          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 5d)), "delay", "5d", "", ".*") or
-          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1w)), "delay", "7d", "", ".*")))
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1d, "delay", "1d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 3d, "delay", "3d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 5d, "delay", "5d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1w, "delay", "7d", "", ".*")))
     for: 2h
     labels:
       repo: ops-tracker
@@ -89,4 +89,3 @@ groups:
       summary: Autojoin test data volume for one or more datatypes is too low.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#autojoincluster_jostlerdailydatavolumetoolow
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/deeyimsfzkwe8c/autojoin3a-site-overview
-

--- a/config/autojoin/prometheus/alerts.yml
+++ b/config/autojoin/prometheus/alerts.yml
@@ -70,3 +70,23 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#autojoincluster_toofewbigqueryrows
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/abcdef37wdji8d/autojoin?orgId=1
 
+  # Fires when Autojoin data volume pushed to GCS is much lower than on
+  # previous days.
+  - alert: PlatformCluster_JostlerDailyDataVolumeTooLow
+    expr: |
+      datatype:jostler_bytes_per_bundle:increase24h
+        < (0.7 * quantile by(datatype)(0.5,
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1d)), "delay", "1d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 3d)), "delay", "3d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 5d)), "delay", "5d", "", ".*") or
+          label_replace(datatype:jostler_bytes_per_bundle:increase24h offset 1w)), "delay", "7d", "", ".*")))
+    for: 2h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: autojoin
+    annotations:
+      summary: Autojoin test data volume for one or more datatypes is too low.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#autojoincluster_jostlerdailydatavolumetoolow
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/deeyimsfzkwe8c/autojoin3a-site-overview
+

--- a/config/autojoin/prometheus/prometheus.yml.template
+++ b/config/autojoin/prometheus/prometheus.yml.template
@@ -16,7 +16,7 @@ global:
 # 'evaluation_interval'.
 rule_files:
   - /etc/prometheus/alerts.yml
-  # - /etc/prometheus/rules.yml
+  - /etc/prometheus/rules.yml
 
 alerting:
   alertmanagers:

--- a/config/autojoin/prometheus/rules.yml
+++ b/config/autojoin/prometheus/rules.yml
@@ -1,0 +1,8 @@
+groups:
+- name rules.yml
+  rules:
+
+  # This rule optimizes the alert query used for JostlerDailyDataVolumeTooLow.
+  - record: datatype:jostler_bytes_per_bundle:increase24h
+    expr: sum by(datatype) (increase(jostler_bytes_per_bundle_sum[1d]))
+

--- a/config/autojoin/prometheus/rules.yml
+++ b/config/autojoin/prometheus/rules.yml
@@ -1,5 +1,5 @@
 groups:
-- name rules.yml
+- name: rules.yml
   rules:
 
   # This rule optimizes the alert query used for JostlerDailyDataVolumeTooLow.


### PR DESCRIPTION
This is almost identical to a simlar alert we have in k8s-support to monitor Pusher data volume:

https://github.com/m-lab/k8s-support/blob/main/config/prometheus/alerts.yml#L582

I don't know if 70% is the right threshold here, but it can serve as a start. When I ran the query manually in production, it did correctly show that the alert would have fired right after the incident began. What I don't know yet is whether 70% is too sensitive for the byos platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1078)
<!-- Reviewable:end -->
