### PR TITLE
Fixes scraping of the production Autojoin Prom instances

### DIFF
--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -52,6 +52,7 @@ kubectl create secret generic discuss-credentials \
 
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
+    -e 's|{{AUTOJOIN_PROJECT}}|'${AUTOJOIN_PROJECT}'|g' \
     -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH}}|'${!REBOOTAPI_BASIC_AUTH_USER}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH_PASS}}|'${!REBOOTAPI_BASIC_AUTH_PASS}'|g' \

--- a/config.sh
+++ b/config.sh
@@ -5,6 +5,13 @@ set -x
 USAGE="PROJECT=<projectid> CLUSTER=<cluster> $0"
 PROJECT=${PROJECT:?Please provide project id: $USAGE}
 CLUSTER=${CLUSTER:?Please provide cluster name: $USAGE}
+AUTOJOIN_PROJECT=$PROJECT
+
+# The production Autojoin GCP project is different from the usual mlab-oti
+# production project.
+if [[ $PROJECT == "mlab-oti" ]]; then
+  AUTOJOIN_PROJECT="mlab-autojoin"
+fi
 
 K8S_INGRESS_NGINX_VERSION="4.2.1"
 

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -425,7 +425,7 @@ scrape_configs:
       'match[]':
         - 'script_success'
     static_configs:
-      - targets: ['prometheus-autojoin-basic.{{PROJECT}}.measurementlab.net']
+      - targets: ['prometheus-autojoin-basic.{{AUTOJOIN_PROJECT}}.measurementlab.net']
         labels:
           cluster: "autojoin"
 


### PR DESCRIPTION
Previously, it was trying to scrape a hostname that didn't exist. The production Autojoin Prom instances runs in the mlab-autojoin project, not mlab-oti.