### PR TITLE
Updates bigquery-exporter container image to v1.2.0

### DIFF
--- a/k8s/autojoin/deployments/bigquery-exporter-3h.yml
+++ b/k8s/autojoin/deployments/bigquery-exporter-3h.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
+        image: measurementlab/prometheus-bigquery-exporter:v1.2.0
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=3h",
                 "-gauge-query=/queries/bq_ndt7_test.sql",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-24h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-24h.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
+        image: measurementlab/prometheus-bigquery-exporter:v1.2.0
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=24h",
                 "-gauge-query=/queries/bq_gardener_parse_time.sql",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-3h.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
+        image: measurementlab/prometheus-bigquery-exporter:v1.2.0
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=3h",
                 "-gauge-query=/queries/bq_annotation.sql",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-5m.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
+        image: measurementlab/prometheus-bigquery-exporter:v1.2.0
         args: [ "-project={{GCLOUD_PROJECT}}",
                 "-refresh=5m",
                 "-gauge-query=/queries/bq_mlabns_ratelimit.sql",

--- a/k8s/prometheus-federation/deployments/bigquery-exporter-discuss.yml
+++ b/k8s/prometheus-federation/deployments/bigquery-exporter-discuss.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: bigquery-exporter
-        image: measurementlab/prometheus-bigquery-exporter:v1.1.1
+        image: measurementlab/prometheus-bigquery-exporter:v1.2.0
         args: [ "-project=measurement-lab",
                 "-refresh=15m",
                 # TODO(github.com/m-lab/prometheus-support/issues/894): include discuss@


### PR DESCRIPTION
There were quite a few changes since the last release in 2021, but no new version was ever released.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1082)
<!-- Reviewable:end -->
