### PR TITLE
Changes tolerance of GeoAnnotationRatioTooLowOrMissing to < 0.95

### DIFF
--- a/config/federation/prometheus/alerts.yml
+++ b/config/federation/prometheus/alerts.yml
@@ -935,7 +935,7 @@ groups:
 # disappear.
   - alert: DataPipeline_GeoAnnotationRatioTooLowOrMissing
     expr: |
-      bq_annotation_geo_success / bq_annotation_total < 0.98
+      bq_annotation_geo_success / bq_annotation_total < 0.95
         or absent(bq_annotation_geo_success / bq_annotation_total)
     for: 3h
     labels:


### PR DESCRIPTION
0.98 seems to be a bit too sensitive. The ratio is _usually_ above 0.98, but reasons we don't understand it sometimes dips into the 0.97 range, and I observed that once in the past couple months it dipped to 0.96. Setting it to 0.95 should allow for normal fluctuations in the ratio, and only alert when there is something quite abnormal.