### PR TITLE
Modifies the "org" variable regexp on the AutoJoin:SiteOverview dashboard

### DIFF
--- a/config/federation/grafana/dashboards/Autojoin_SiteOverview.json
+++ b/config/federation/grafana/dashboards/Autojoin_SiteOverview.json
@@ -1242,4 +1242,4 @@
   "uid": "deeyimsfzkwe8c",
   "version": 18,
   "weekStart": ""
-}d
+}

--- a/config/federation/grafana/dashboards/Autojoin_SiteOverview.json
+++ b/config/federation/grafana/dashboards/Autojoin_SiteOverview.json
@@ -1147,7 +1147,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "mlab",
           "value": "mlab"
         },
@@ -1169,7 +1169,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/ndt-[a-z0-9]+-[a-z0-9]+\\.([a-z]+)\\..+/",
+        "regex": "/ndt-[a-z0-9]+-[a-z0-9]+\\.([a-z-]+)\\..+/",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
@@ -1177,7 +1177,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1240,6 +1240,6 @@
   "timezone": "",
   "title": "Autojoin: Site Overview",
   "uid": "deeyimsfzkwe8c",
-  "version": 17,
+  "version": 18,
   "weekStart": ""
-}
+}d


### PR DESCRIPTION
Matching on the org now allows for dashes in the name, which will catch names like "google-oim".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1085)
<!-- Reviewable:end -->
