### PR TITLE
feat(prometheus): enable remote write receiver

### DIFF
--- a/k8s/prometheus-federation/deployments/prometheus.yml
+++ b/k8s/prometheus-federation/deployments/prometheus.yml
@@ -52,6 +52,7 @@ spec:
                "--storage.tsdb.path=/prometheus",
                "--storage.tsdb.retention.time=120d",
                "--web.enable-lifecycle",
+               "--web.enable-remote-write-receiver",
                "--web.external-url=https://prometheus.{{GCLOUD_PROJECT}}.measurementlab.net",
                "--enable-feature=memory-snapshot-on-shutdown"]
         ports:


### PR DESCRIPTION
## Summary
- Enable the Prometheus remote write receiver by adding the `--web.enable-remote-write-receiver` flag
- This allows Prometheus to accept metrics via the remote write API

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1094)
<!-- Reviewable:end -->
