### PR TITLE
Move webhook_config to the slack-alerts-ticket receiver for Alertmanager

### DIFF
--- a/config/federation/alertmanager/config.yml.template
+++ b/config/federation/alertmanager/config.yml.template
@@ -142,6 +142,10 @@ receivers:
           {{- printf "}" | urlquery }}
         {{- end -}}
 
+  # All alerts sent to slack are also sent to the github webhook receiver.
+  webhook_configs:
+  - url: '{{GITHUB_RECEIVER_URL}}'
+
 - name: 'slack-fyis'
   slack_configs:
   - send_resolved: false
@@ -186,10 +190,6 @@ receivers:
           {{- end -}}
           {{- printf "}" | urlquery }}
         {{- end -}}
-
-  # All alerts sent to slack are also sent to the github webhook receiver.
-  webhook_configs:
-  - url: '{{GITHUB_RECEIVER_URL}}'
 
 - name: 'pagerduty-pages'
   pagerduty_configs:

--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -58,7 +58,7 @@ spec:
 
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
-      - image: jimmidyson/configmap-reload:v0.7.1
+      - image: jimmidyson/configmap-reload:v0.9.0
         name: configmap-reload
         args: ["-webhook-url", "$(ALERTMGR_RELOAD_URL)", "-volume-dir", "/alertmanager-config"]
         env:

--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -58,7 +58,7 @@ spec:
 
       # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
-      - image: jimmidyson/configmap-reload:v0.9.0
+      - image: ghcr.io/jimmidyson/configmap-reload:v0.15.0
         name: configmap-reload
         args: ["-webhook-url", "$(ALERTMGR_RELOAD_URL)", "-volume-dir", "/alertmanager-config"]
         env:

--- a/k8s/prometheus-federation/deployments/alertmanager.yml
+++ b/k8s/prometheus-federation/deployments/alertmanager.yml
@@ -56,7 +56,7 @@ spec:
         - mountPath: /etc/alertmanager
           name: alertmanager-config
 
-      # Check https://hub.docker.com/r/jimmidyson/configmap-reload/tags/ for the current
+      # Check https://ghcr.io/jimmidyson/configmap-reload/tags/ for the current
       # stable version.
       - image: ghcr.io/jimmidyson/configmap-reload:v0.15.0
         name: configmap-reload


### PR DESCRIPTION
I noticed that lately when a production alert fires in the Slack #oti-alerts channel that a corresponding Github issue is not being created in the ops-tracker Github repository.

When I looked back at the last time that the metric `githubreceiver_created_issues_total` had a non-zero value, it was around January 17. Then looking at the latest release of this repository on January 28 (v2.65.0) that there were some changes I had made to the Alertmanager config. Upon closer inspection, I noticed that I had inadvertently moved the `webhook_config` section from the "slack-alerts-ticket" receiver to the newer "slack-fyis" receiver, which would explain why issues were no longer being created, since the `webhook_config` section is what configures Alertmanger to send a message to the alertmanager-github-receiver service.

This PR corrects that error, moving the `webhook_config` back to the right location.

Additionally, while testing the changes I noticed that the configmap-reload container in the Alertmanager pod was failing with:

```
error: Post "https://<user>:***@alertmanager.mlab-sandbox.measurementlab.net/-/reload": x509: certificate signed by unknown authority
```

So I also updated configmap-reload to the latest version with the hope that the updated container image might have an updated list of trusted CA certificates, which it appear to. I tested modifying the configmap manually, and configmap-reload noticed and successfully reloaded Alertamanager.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1095)
<!-- Reviewable:end -->
