### PR TITLE
Make IPv6 blackbox_exporter probes against a GCE instances instead of Linode

### DIFF
--- a/IPV6_MONITORING.md
+++ b/IPV6_MONITORING.md
@@ -1,82 +1,22 @@
 # IPv6 Monitoring
 
-Google Cloud Platform does not currently support IPv6 for most applications.
-Since Prometheus and the Prometheus blackbox\_exporter both run in GCP, we need
-another solution for IPv6 monitoring. The solution we decided to use is to run
-the blackbox\_exporter on a separate VM through a provider that does support
-IPv6. Since we are already using Linode.com for a few other things, we deployed
-the VM on Linode.
+Google Cloud Platform fully supports IPv6, however, the prometheus-federation
+GKE cluster is deployed into the default, auto-mode VPC network, which doesn't
+support IPv6. It would be a pretty big and possibly disruptive operation to
+redeploy the entire cluster in a new custom, dual stack subnet. An easier and
+faster way to get around this constraint is to simply deploy a dual stack GCE
+instance in each project that runs blackbox_exporter, which Prometheus will
+query over IPv4 in order to probe IPv6 targets.
 
-Any base Linux distribution would probably be just fine, but this deployment is
-using Debian 10.
+Prior to around May of 2026, this was the same basic configuration that was in
+use, but instead of running blackbox_exporter on a GCE instance, it was run on
+a Linode VM. This new configuration keeps that same basic pattern, but gets rid
+of the Linode VM in favor of a GCE instance in each project.
 
-Below are first-time setup instructions and requirements for the VM:
+The blackbox_exporter instances get automatically deployed to the GCE instances
+via builds of this repository (the deploy_bbe_config.sh script).
 
-* Request a `/64` IPv6 pool from Linode by opening a support ticket. In our
-  case, we were given this prefix `2600:3c02:e000:0185::/64`.
-* [Install Docker](https://docs.docker.com/install/linux/docker-ce/debian/),
-  since the blackbox\_exporter will be running in a Docker container.
-* Create a new user named "mlab" (`# adduser mlab`) and it to the group `docker`
-  (`# adduser mlab docker`).
-* Add the public SSH key for the Travis deployer to mlab's
-  *~/.ssh/authorized_keys* file. The public key, and the private one, can be
-  found in the M-Lab *shared_data* repository in the *ssh-keys/* directory.
-* Create the file _/etc/docker/daemon.json_ with the following content, and then
-  restart Docker (`# systemctl restart docker`):
+When resources and time permit, we should probably consider redeploying the
+prometheus-federation cluster in VPC subnet that supports IPv6 so that all
+blackbox_exporter instances live in the prometheus-federation cluster.
 
-```json
-{
-    "ipv6": true,
-    "fixed-cidr-v6": "2600:3c02:e000:0185::/64"
-}
-```
-
-* Pull the blackbox\_exporter Docker image: `$ docker pull
-  prom/blackbox-exporter:v0.12.0`.
-
-* Manually upload [the blackbox\_exporter config
-  file](https://github.com/m-lab/prometheus-support/blob/main/config/federation/blackbox/config.yml.template)
-  to mlab's home directory, then make three copies of it with the following
-  names. If you don't do this, instantiating the Docker instances will fail
-  because the blackbox\_exporter will not be able to find its config file.
-  Later, these files will be [pushed to the VM automatically on
-  builds](https://github.com/m-lab/prometheus-support/blob/main/deploy_bbe_config.sh)
-  of m-lab/prometheus-support repo.
-
-```text
-blackbox-exporter-config-mlab-sandbox.yml
-blackbox-exporter-config-mlab-staging.yml
-blackbox-exporter-config-mlab-oti.yml
-```
-
-* Instantiate the Docker containers (as the user mlab, `pwd` must be /home/mlab).
-  **NOTE**: it is very important to include the `--restart always` flag and argument.
-  Without it, if the machine is rebooted or the container crashes, then it won't
-  start again automatically.
-
-```shell
-$ docker run --detach --publish 7115:9115 --volume `pwd`:/config \
-    --restart always --name mlab-sandbox prom/blackbox-exporter:v0.12.0 \
-    --config.file=/config/blackbox-exporter-config-mlab-sandbox.yml
-
-$ docker run --detach --publish 8115:9115 --volume `pwd`:/config \
-    --restart always --name mlab-staging prom/blackbox-exporter:v0.12.0 \
-    --config.file=/config/blackbox-exporter-config-mlab-staging.yml
-
-$ docker run --detach --publish 9115:9115 --volume `pwd`:/config \
-    --restart always --name mlab-oti prom/blackbox-exporter:v0.12.0 \
-    --config.file=/config/blackbox-exporter-config-mlab-oti.yml
-```
-
-* Install node\_exporter so that we can scrape metrics from this machine.
-
-$ sudo apt install prometheus-node-exporter
-
-Then edit /etc/default/prometheus-node-exporter, comment out the existing ARGS
-definition, and add this one:
-
-ARGS="-collectors.enabled=filesystem,loadavg,meminfo,netdev"
-
-Restart node-exporter:
-
-$ sudo systemctl restart prometheus-node-exporter

--- a/apply-global-prometheus.sh
+++ b/apply-global-prometheus.sh
@@ -18,17 +18,6 @@ set -u
 
 source config.sh
 
-# GCP doesn't support IPv6, so we have a Linode VM running three instances of
-# the blackbox_exporter, on three separate ports... one port/instance for each
-# project. These variables map projects to ports.
-BBE_IPV6_PORT_mlab_oti="9115"
-BBE_IPV6_PORT_mlab_staging="8115"
-BBE_IPV6_PORT_mlab_sandbox="7115"
-
-# Construct the per-project blackbox_exporter port using the passed $PROJECT
-# argument.
-bbe_port=BBE_IPV6_PORT_${PROJECT/-/_}
-
 # Construct the per-project HTTP basic auth credentials for the Reboot API.
 export REBOOTAPI_BASIC_AUTH_USER=REBOOTAPI_BASIC_AUTH_${PROJECT/-/_}
 export REBOOTAPI_BASIC_AUTH_PASS=REBOOTAPI_BASIC_AUTH_PASS_${PROJECT/-/_}
@@ -53,7 +42,6 @@ kubectl create secret generic discuss-credentials \
 # Evaluate the Prometheus configuration template.
 sed -e 's|{{PROJECT}}|'${PROJECT}'|g' \
     -e 's|{{AUTOJOIN_PROJECT}}|'${AUTOJOIN_PROJECT}'|g' \
-    -e 's|{{BBE_IPV6_PORT}}|'${!bbe_port}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH}}|'${!REBOOTAPI_BASIC_AUTH_USER}'|g' \
     -e 's|{{REBOOTAPI_BASIC_AUTH_PASS}}|'${!REBOOTAPI_BASIC_AUTH_PASS}'|g' \
     -e 's|{{PLATFORM_PROM_AUTH_USER}}|'${!PLATFORM_PROM_AUTH_USER}'|g' \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,8 +20,6 @@ availableSecrets:
     env: GITHUB_RECEIVER_AUTH_TOKEN
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-gmx-github-webhook-secret/versions/latest
     env: GMX_GITHUB_WEBHOOK_SECRET
-  - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-linode-private-key-ipv6-monitoring/versions/latest
-    env: LINODE_PRIVATE_KEY_ipv6_monitoring
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-script-exporter-monitoring-signer-key/versions/latest
     env: MONITORING_SIGNER_KEY
   - versionName: projects/${PROJECT_NUMBER}/secrets/prometheus-support-build-oauth-proxy-client-id/versions/latest
@@ -67,7 +65,6 @@ steps:
   - GF_AUTH_GOOGLE_CLIENT_ID
   - GITHUB_RECEIVER_AUTH_TOKEN
   - GMX_GITHUB_WEBHOOK_SECRET
-  - LINODE_PRIVATE_KEY_ipv6_monitoring
   - MONITORING_SIGNER_KEY
   - OAUTH_PROXY_CLIENT_ID
   - OAUTH_PROXY_CLIENT_SECRET
@@ -173,8 +170,8 @@ steps:
       gcloud container clusters get-credentials $$CLUSTER --project $$PROJECT --zone $$(get_cluster_zone $$CLUSTER)
       ./apply-cluster.sh
 
-      # Deploy the IPv6 monitoring BBE configs to the IPv6 Linode.
-      ./deploy_bbe_config.sh $$PROJECT LINODE_PRIVATE_KEY_ipv6_monitoring
+      # Deploy the IPv6 monitoring BBE configs to the GCE monitoring VM.
+      ./deploy_bbe_config.sh $$PROJECT
     fi
 
     # TODO(soltesz): Separate configuration steps so we can use cbif conditions.

--- a/config/federation/prometheus/prometheus.yml.template
+++ b/config/federation/prometheus/prometheus.yml.template
@@ -549,12 +549,12 @@ scrape_configs:
 
   # Blackbox configurations for IPv6 probes.
   #
-  # There are three blackbox_exporter instances running on a Linode VM, one for
-  # each M-Lab GCP project. They each run on different ports.
+  # Each M-Lab GCP project has a dedicated GCE monitoring VM running
+  # blackbox_exporter on port 9115.
   - job_name: 'blackbox-exporter-ipv6'
     static_configs:
       - targets:
-        - blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:{{BBE_IPV6_PORT}}
+        - blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:9115
 
 
   # Each blackbox configuration uses a different probe (tcp, icmp, http, etc).
@@ -607,10 +607,8 @@ scrape_configs:
       # Since __address__ is the target that prometheus will contact,
       # unconditionally reset the __address__ label to the blackbox exporter
       # address.
-      - source_labels: [__blackbox_port]
-        regex: (.*)
-        target_label: __address__
-        replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:${1}
+      - target_label: __address__
+        replacement: blackbox-exporter-ipv6.{{PROJECT}}.measurementlab.net:9115
 
 
   # Probes the backend services being proxied by nginx.

--- a/deploy_bbe_config.sh
+++ b/deploy_bbe_config.sh
@@ -1,36 +1,50 @@
 #!/bin/bash
 #
-# Deploys the blackbox_exporter config to an external (e.g., Linode) VM which
-# will perform IPv6 probes, since GCP doesn't currently support IPv6.
+# Deploys the blackbox_exporter config to the GCE monitoring VM which performs
+# IPv6 probes for the given project.
 #
 #  Example usage:
-#    ./deploy_bbe_config.sh mlab-sandbox LINODE_PRIVATE_KEY_ipv6_monitoring
+#    ./deploy_bbe_config.sh mlab-sandbox
 
 set -e
 set -u
 set -x
 
 BASE_DIR=$( dirname ${BASH_SOURCE[0]} )
-USAGE="Usage: $0 <project> <keyname>"
+USAGE="Usage: $0 <project>"
 PROJECT=${1:?Please provide project name: $USAGE}
-KEYNAME=${2:?Please provide an authentication key name: $USAGE}
 BBE_CONFIG="${BASE_DIR}/config/federation/blackbox/config.yml"
-LINODE_DOMAIN="blackbox-exporter-ipv6.${PROJECT}.measurementlab.net"
-LINODE_USER="mlab"
-LOCAL_KEY_FILE="id_rsa_linode"
-SSH_OPTS="-i $LOCAL_KEY_FILE -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+VM_NAME="ipv6-monitoring"
+VM_CONFIG_DIR="/etc/blackbox-exporter"
+VM_CONFIG_FILE="${VM_CONFIG_DIR}/config.yml"
+BBE_IMAGE="prom/blackbox-exporter:v0.20.0"
+CONTAINER_NAME="blackbox-exporter"
 
-# Extract the SSH key from the configured Travis environment variable. The key
-# is base64 encoded to avoid the need for shell escaping and newlines. Set the
-# mode of the file appropriately, as SSH will refuse to use it if the
-# permissions are not strict enough.
-set +x
-echo "${!KEYNAME}" | base64 -d > $LOCAL_KEY_FILE
-set -x
-chmod 600 $LOCAL_KEY_FILE
+# Map projects to zones where the monitoring VM is deployed.
+ZONE_mlab_sandbox="us-central1-c"
+ZONE_mlab_staging="us-east1-c"
+ZONE_mlab_oti="us-central1-a"
 
-# Copy blackbox_exporter config file to the Linode VM.
-scp $SSH_OPTS $BBE_CONFIG $LINODE_USER@$LINODE_DOMAIN:blackbox-exporter-config-$PROJECT.yml
+zone_var=ZONE_${PROJECT/-/_}
+ZONE="${!zone_var}"
 
-# HUP the blackbox_exporter so it reads the new config.
-ssh $SSH_OPTS $LINODE_USER@$LINODE_DOMAIN "docker exec ${PROJECT} kill -HUP 1"
+GCE_OPTS="--tunnel-through-iap --project=${PROJECT} --zone=${ZONE}"
+
+# Copy blackbox_exporter config to the VM.
+gcloud compute scp ${GCE_OPTS} \
+    "${BBE_CONFIG}" "${VM_NAME}:/tmp/blackbox-exporter-config.yml"
+
+# Ensure config directory exists, install config, then start or reload the container.
+gcloud compute ssh ${GCE_OPTS} "${VM_NAME}" --command=" \
+    sudo mkdir -p ${VM_CONFIG_DIR} && \
+    sudo mv /tmp/blackbox-exporter-config.yml ${VM_CONFIG_FILE} && \
+    sudo chmod 644 ${VM_CONFIG_FILE} && \
+    if sudo docker inspect ${CONTAINER_NAME} > /dev/null 2>&1; then \
+        sudo docker kill --signal=HUP ${CONTAINER_NAME}; \
+    else \
+        sudo docker run --detach --network=host \
+            --volume ${VM_CONFIG_DIR}:${VM_CONFIG_DIR}:ro \
+            --restart always --name ${CONTAINER_NAME} ${BBE_IMAGE} \
+            --config.file=${VM_CONFIG_FILE}; \
+    fi \
+"

--- a/generate-prometheus-targets.sh
+++ b/generate-prometheus-targets.sh
@@ -10,14 +10,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
   mkdir -p ${BASEDIR}/gen/${project}/prometheus/{legacy-targets,blackbox-targets,blackbox-targets-ipv6,script-targets,bmc-targets,switch-monitoring-targets}
 done
 
-# GCP doesn't support IPv6, so we have a Linode VM running three instances of
-# the blackbox_exporter, on three separate ports... one port/instance for each
-# project. These variables map projects to ports, and will be transmitted to
-# Prometheus in the form of a new label that will be rewritten.
-BBE_IPV6_PORT_mlab_oti="9115"
-BBE_IPV6_PORT_mlab_staging="8115"
-BBE_IPV6_PORT_mlab_sandbox="7115"
-
 # Switches are not project-specific in siteinfo. To avoid monitoring every
 # switch from every Prometheus instance needlessly, we filter the targets list
 # with these regexes.
@@ -37,10 +29,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
 
   output=${BASEDIR}/gen/${project}/prometheus
 
-  # Construct the per-project blackbox_exporter port variable to use below.
-  # blackbox_exporter on for IPv6 targets.
-  bbe_port=BBE_IPV6_PORT_${project/-/_}
-
   switch_regex=SWITCH_REGEX_${project/-/_}
 
   # ndt7 SSL on port 443 over IPv4
@@ -59,7 +47,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:443 \
       --label service=ndt7_ipv6 \
       --label module=tcp_v6_tls_online \
-      --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
       --select "ndt.iupui" \
       --decoration "v6" > \
@@ -81,7 +68,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:3001 \
       --label service=ndt_raw_ipv6 \
       --label module=tcp_v6_online \
-      --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
       --select "ndt.iupui" \
       --decoration "v6" > \
@@ -103,7 +89,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:3010 \
       --label service=ndt_ssl_ipv6 \
       --label module=tcp_v6_tls_online \
-      --label __blackbox_port=${!bbe_port} \
       --project "${project}" \
       --select "ndt.iupui" \
       --decoration "v6" > \
@@ -143,7 +128,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:80 \
       --label service=neubot_ipv6 \
       --label module=tcp_v6_online \
-      --label __blackbox_port=${!bbe_port} \
       --decoration "v6" \
       --project "${project}" \
       --select "neubot.mlab" > \
@@ -165,7 +149,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:443 \
       --label service=neubot_tls_ipv6 \
       --label module=tcp_v6_tls_online \
-      --label __blackbox_port=${!bbe_port} \
       --decoration "v6" \
       --project "${project}" \
       --select "neubot.mlab" > \
@@ -195,7 +178,6 @@ for project in mlab-sandbox mlab-staging mlab-oti ; do
       --template_target={{hostname}}:22 \
       --label service=ssh \
       --label module=ssh_v6_online \
-      --label __blackbox_port=${!bbe_port} \
       --physical \
       --project "${project}" \
       --decoration "v6" > ${output}/blackbox-targets-ipv6/ssh_ipv6.json


### PR DESCRIPTION
The changes to the file IPV6_MONITORING.md in this PR pretty much explain what is happening here.  The basic idea is that instead of making IPv6 blackbox_exporter probes through a VM running in Linode, we're doing it through VMs that exist in GCE.

@robertodauria: you are already familiar with most all these changes, as you worked with me to create this change set with Claude Code (thanks!). Moving the probes to GCE VMs removes a fairly substantial amount of back-bending and complexity to make the Linode method work. That said, one small downside is that we'll now be running 3 GCE instances (one in each project) instead of a single VM in Linode. Then again, these GCE instances are of type e2-micro, which is not expensive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1096)
<!-- Reviewable:end -->
