### PR TITLE
Changes the GCP zone for the staging IPv6 monitoring VM

### DIFF
--- a/deploy_bbe_config.sh
+++ b/deploy_bbe_config.sh
@@ -22,7 +22,7 @@ CONTAINER_NAME="blackbox-exporter"
 
 # Map projects to zones where the monitoring VM is deployed.
 ZONE_mlab_sandbox="us-central1-c"
-ZONE_mlab_staging="us-east1-c"
+ZONE_mlab_staging="us-central1-b"
 ZONE_mlab_oti="us-central1-a"
 
 zone_var=ZONE_${PROJECT/-/_}


### PR DESCRIPTION
Forgetting about these statically assigned zones in the script, I told terraform-support to create the IPv6 monitoring VM for staging in the us-central1-b zone. I could either update terraform-support to match this file, or modify this file to match terraform-support. I decided on the latter, since it seemed cleaner to have all the IPv6 monitoring VMs for each project in the us-central1 region, but just in different zones.

This should resolve the following failed build:

https://console.cloud.google.com/cloud-build/builds;region=global/c41af3e3-d272-46e3-a87a-eb9c57b56e45?project=mlab-staging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-support/1097)
<!-- Reviewable:end -->
